### PR TITLE
Don't enforce multiple sub-changes in a change

### DIFF
--- a/packages/apollo-collaboration-server/src/changes/changes.service.ts
+++ b/packages/apollo-collaboration-server/src/changes/changes.service.ts
@@ -71,9 +71,7 @@ export class ChangesService {
       // Add entry to change collection
       const changeEntry: CreateChangeDto = {
         assembly: change.assemblyId,
-        typeName: change.typeName,
-        changedIds: change.changedIds,
-        changes: change.changes,
+        ...change,
         user: 'demo user id',
       }
       const savedChangedLogDoc = await this.changeModel.create(changeEntry)

--- a/packages/apollo-collaboration-server/src/changes/dto/create-change.dto.ts
+++ b/packages/apollo-collaboration-server/src/changes/dto/create-change.dto.ts
@@ -1,7 +1,6 @@
 export class CreateChangeDto {
   readonly assembly: string
   readonly changedIds: string[]
-  readonly changes: unknown
   readonly reverts?: string
   readonly user: string
   readonly typeName: string

--- a/packages/apollo-shared/package.json
+++ b/packages/apollo-shared/package.json
@@ -22,7 +22,6 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@types/cache-manager": "^3",
     "@types/node": "^16.0.0",
     "mobx-state-tree": "3.14.1",
     "mongoose": "^6.2.10",

--- a/packages/apollo-shared/src/ChangeManager/Change.ts
+++ b/packages/apollo-shared/src/ChangeManager/Change.ts
@@ -1,5 +1,4 @@
 import { FeatureDocument } from 'apollo-schemas'
-import { Cache } from 'cache-manager'
 import { IAnyStateTreeNode, Instance, SnapshotIn } from 'mobx-state-tree'
 
 import { FeaturesForRefName } from '../BackendDrivers/AnnotationFeature'
@@ -15,7 +14,6 @@ export interface ClientDataStore extends IAnyStateTreeNode {
 }
 export interface LocalGFF3DataStore {
   typeName: 'LocalGFF3'
-  cacheManager: Cache
   gff3Handle: import('fs').promises.FileHandle
 }
 export interface ServerDataStore {

--- a/packages/apollo-shared/src/ChangeManager/Change.ts
+++ b/packages/apollo-shared/src/ChangeManager/Change.ts
@@ -27,7 +27,6 @@ export interface SerializedChange {
   changedIds: string[]
   typeName: string
   assemblyId: string
-  changes: unknown
 }
 
 export type DataStore = ServerDataStore | LocalGFF3DataStore | ClientDataStore
@@ -39,7 +38,6 @@ export interface ChangeOptions {
 export abstract class Change implements SerializedChange {
   protected logger: import('@nestjs/common').LoggerService
   abstract typeName: string
-  abstract changes: unknown[]
 
   assemblyId: string
   changedIds: string[]

--- a/packages/apollo-shared/src/ChangeManager/LocationEndChange.ts
+++ b/packages/apollo-shared/src/ChangeManager/LocationEndChange.ts
@@ -1,4 +1,4 @@
-import gff, { GFF3Feature, GFF3Item } from '@gmod/gff'
+import { GFF3Feature } from '@gmod/gff'
 import { FeatureDocument } from 'apollo-schemas'
 import { resolveIdentifier } from 'mobx-state-tree'
 
@@ -120,50 +120,8 @@ export class LocationEndChange extends FeatureChange {
     }
   }
 
-  /**
-   * Applies the required change to cache and overwrites GFF3 file on the server
-   * @param backend - parameters from backend
-   * @returns
-   */
   async applyToLocalGFF3(backend: LocalGFF3DataStore) {
-    const { changes } = this
-
-    this.logger.debug?.(`Change request: ${JSON.stringify(changes)}`)
-    let gff3ItemString: string | undefined = ''
-    const cacheKeys: string[] = await backend.cacheManager.store.keys?.()
-    cacheKeys.sort((n1: string, n2: string) => Number(n1) - Number(n2))
-    for (const change of changes) {
-      // const { featureId, oldEnd, newEnd } = change
-      // const searchApolloIdStr = `"apollo_id":["${featureId}"]`
-
-      // Loop the cache content
-      for (const lineNumber of cacheKeys) {
-        gff3ItemString = await backend.cacheManager.get(lineNumber)
-        if (!gff3ItemString) {
-          throw new Error(`No cache value found for key ${lineNumber}`)
-        }
-        const gff3Item = JSON.parse(gff3ItemString) as GFF3Item
-        if (Array.isArray(gff3Item)) {
-          const updated = this.getUpdatedCacheEntryForFeature(gff3Item, change)
-          if (updated) {
-            await backend.cacheManager.set(lineNumber, JSON.stringify(gff3Item))
-            break
-          }
-        }
-      }
-    }
-    // Loop the updated cache and write it into file
-    const gff3 = await Promise.all(
-      cacheKeys.map(async (keyInd): Promise<GFF3Item> => {
-        gff3ItemString = await backend.cacheManager.get(keyInd.toString())
-        if (!gff3ItemString) {
-          throw new Error(`No entry found for ${keyInd.toString()}`)
-        }
-        return JSON.parse(gff3ItemString)
-      }),
-    )
-    // this.logger.verbose(`Write into file =${JSON.stringify(cacheValue)}, key=${keyInd}`)
-    await backend.gff3Handle.writeFile(gff.formatSync(gff3))
+    throw new Error('applyToLocalGFF3 not implemented')
   }
 
   async applyToClient(dataStore: ClientDataStore) {

--- a/packages/apollo-shared/src/ChangeManager/LocationStartChange.ts
+++ b/packages/apollo-shared/src/ChangeManager/LocationStartChange.ts
@@ -1,4 +1,4 @@
-import gff, { GFF3Feature, GFF3Item } from '@gmod/gff'
+import { GFF3Feature } from '@gmod/gff'
 import { FeatureDocument } from 'apollo-schemas'
 import { resolveIdentifier } from 'mobx-state-tree'
 
@@ -122,47 +122,8 @@ export class LocationStartChange extends FeatureChange {
     }
   }
 
-  /**
-   * Applies the required change to cache and overwrites GFF3 file on the server
-   * @param backend - parameters from backend
-   * @returns
-   */
   async applyToLocalGFF3(backend: LocalGFF3DataStore) {
-    const { changes } = this
-
-    this.logger.debug?.(`Change request: ${JSON.stringify(changes)}`)
-    let gff3ItemString: string | undefined = ''
-    const cacheKeys: string[] = await backend.cacheManager.store.keys?.()
-    cacheKeys.sort((n1: string, n2: string) => Number(n1) - Number(n2))
-    for (const change of changes) {
-      // Loop the cache content
-      for (const lineNumber of cacheKeys) {
-        gff3ItemString = await backend.cacheManager.get(lineNumber)
-        if (!gff3ItemString) {
-          throw new Error(`No cache value found for key ${lineNumber}`)
-        }
-        const gff3Item = JSON.parse(gff3ItemString) as GFF3Item
-        if (Array.isArray(gff3Item)) {
-          const updated = this.getUpdatedCacheEntryForFeature(gff3Item, change)
-          if (updated) {
-            await backend.cacheManager.set(lineNumber, JSON.stringify(gff3Item))
-            break
-          }
-        }
-      }
-    }
-    // Loop the updated cache and write it into file
-    const gff3 = await Promise.all(
-      cacheKeys.map(async (keyInd): Promise<GFF3Item> => {
-        gff3ItemString = await backend.cacheManager.get(keyInd.toString())
-        if (!gff3ItemString) {
-          throw new Error(`No entry found for ${keyInd.toString()}`)
-        }
-        return JSON.parse(gff3ItemString)
-      }),
-    )
-    // this.logger.verbose(`Write into file =${JSON.stringify(cacheValue)}, key=${keyInd}`)
-    await backend.gff3Handle.writeFile(gff.formatSync(gff3))
+    throw new Error('applyToLocalGFF3 not implemented')
   }
 
   async applyToClient(dataStore: ClientDataStore) {

--- a/packages/apollo-shared/src/ChangeManager/TypeChange.ts
+++ b/packages/apollo-shared/src/ChangeManager/TypeChange.ts
@@ -1,4 +1,4 @@
-import gff, { GFF3Feature, GFF3Item } from '@gmod/gff'
+import { GFF3Feature } from '@gmod/gff'
 import { FeatureDocument } from 'apollo-schemas'
 import { resolveIdentifier } from 'mobx-state-tree'
 
@@ -121,50 +121,8 @@ export class TypeChange extends FeatureChange {
     }
   }
 
-  /**
-   * Applies the required change to cache and overwrites GFF3 file on the server
-   * @param backend - parameters from backend
-   * @returns
-   */
   async applyToLocalGFF3(backend: LocalGFF3DataStore) {
-    const { changes } = this
-
-    this.logger.debug?.(`Change request: ${JSON.stringify(changes)}`)
-    let gff3ItemString: string | undefined = ''
-    const cacheKeys: string[] = await backend.cacheManager.store.keys?.()
-    cacheKeys.sort((n1: string, n2: string) => Number(n1) - Number(n2))
-    for (const change of changes) {
-      // const { featureId, oldType, newType } = change
-      // const searchApolloIdStr = `"apollo_id":["${featureId}"]`
-
-      // Loop the cache content
-      for (const lineNumber of cacheKeys) {
-        gff3ItemString = await backend.cacheManager.get(lineNumber)
-        if (!gff3ItemString) {
-          throw new Error(`No cache value found for key ${lineNumber}`)
-        }
-        const gff3Item = JSON.parse(gff3ItemString) as GFF3Item
-        if (Array.isArray(gff3Item)) {
-          const updated = this.getUpdatedCacheEntryForFeature(gff3Item, change)
-          if (updated) {
-            await backend.cacheManager.set(lineNumber, JSON.stringify(gff3Item))
-            break
-          }
-        }
-      }
-    }
-    // Loop the updated cache and write it into file
-    const gff3 = await Promise.all(
-      cacheKeys.map(async (keyInd): Promise<GFF3Item> => {
-        gff3ItemString = await backend.cacheManager.get(keyInd.toString())
-        if (!gff3ItemString) {
-          throw new Error(`No entry found for ${keyInd.toString()}`)
-        }
-        return JSON.parse(gff3ItemString)
-      }),
-    )
-    // this.logger.verbose(`Write into file =${JSON.stringify(cacheValue)}, key=${keyInd}`)
-    await backend.gff3Handle.writeFile(gff.formatSync(gff3))
+    throw new Error('applyToLocalGFF3 not implemented')
   }
 
   async applyToClient(dataStore: ClientDataStore) {

--- a/packages/jbrowse-plugin-apollo/src/ApolloDetailsView/components/ApolloDetailsView.tsx
+++ b/packages/jbrowse-plugin-apollo/src/ApolloDetailsView/components/ApolloDetailsView.tsx
@@ -131,7 +131,9 @@ export const ApolloDetailsView = observer(
         change = new LocationStartChange({
           typeName: 'LocationStartChange',
           changedIds: [featureId],
-          changes: [{ featureId, oldStart, newStart: Number(newValue) }],
+          featureId,
+          oldStart,
+          newStart: Number(newValue),
           assemblyId,
         })
       } else if (field === 'end' && changedFeature.end !== Number(newValue)) {
@@ -140,7 +142,9 @@ export const ApolloDetailsView = observer(
         change = new LocationEndChange({
           typeName: 'LocationEndChange',
           changedIds: [featureId],
-          changes: [{ featureId, oldEnd, newEnd: Number(newValue) }],
+          featureId,
+          oldEnd,
+          newEnd: Number(newValue),
           assemblyId,
         })
       } else if (
@@ -155,7 +159,9 @@ export const ApolloDetailsView = observer(
         change = new TypeChange({
           typeName: 'TypeChange',
           changedIds: [featureId],
-          changes: [{ featureId, oldType, newType: String(newValue) }],
+          featureId,
+          oldType,
+          newType: String(newValue),
           assemblyId,
         })
       }

--- a/packages/jbrowse-plugin-apollo/src/ApolloRenderer/components/ApolloRendering.tsx
+++ b/packages/jbrowse-plugin-apollo/src/ApolloRenderer/components/ApolloRendering.tsx
@@ -244,7 +244,9 @@ function ApolloRendering(props: ApolloRenderingProps) {
         change = new LocationEndChange({
           typeName: 'LocationEndChange',
           changedIds: [featureId],
-          changes: [{ featureId, oldEnd, newEnd }],
+          featureId,
+          oldEnd,
+          newEnd,
           assemblyId,
         })
       } else {
@@ -254,7 +256,9 @@ function ApolloRendering(props: ApolloRenderingProps) {
         change = new LocationStartChange({
           typeName: 'LocationStartChange',
           changedIds: [featureId],
-          changes: [{ featureId, oldStart, newStart }],
+          featureId,
+          oldStart,
+          newStart,
           assemblyId,
         })
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5482,7 +5482,6 @@ __metadata:
     "@gmod/gff": ^1.2.0
     "@jbrowse/core": ^1.7.4
     "@nestjs/common": ^8.4.4
-    "@types/cache-manager": ^3
     "@types/node": ^16.0.0
     apollo-schemas: "workspace:^"
     mobx-state-tree: 3.14.1


### PR DESCRIPTION
This PR allows either of these changes to be valid:

```json
{
  "typeName": "LocationEndChange",
  "changedIds": [
    "1ccdfd84-587f-49aa-be63-8dab88a61b1b"
  ],
  "assemblyId": "624a7e97d45d7745c2532b01",
  "featureId": "1ccdfd84-587f-49aa-be63-8dab88a61b1b",
  "oldEnd": 2200,
  "newEnd": 2300
}
```

```json
{
  "typeName": "LocationEndChange",
  "changedIds": [
    "1ccdfd84-587f-49aa-be63-8dab88a61b1b"
  ],
  "assemblyId": "624a7e97d45d7745c2532b01",
  "changes": [
    {
      "featureId": "1ccdfd84-587f-49aa-be63-8dab88a61b1b",
      "oldEnd": 2200,
      "newEnd": 2300
    }
  ]
}
```

Previously only the second one was valid.
