### PR TITLE
Add glyphs for subfeatures

### DIFF
--- a/packages/apollo-shared/src/BackendDrivers/AnnotationFeature.ts
+++ b/packages/apollo-shared/src/BackendDrivers/AnnotationFeature.ts
@@ -70,6 +70,48 @@ export const AnnotationFeatureLocation = types
       })
       return max
     },
+    get featuresForRow() {
+      const features = [[self]]
+      if (self.children) {
+        self.children?.forEach((child) => {
+          features.push(...child.featuresForRow)
+        })
+      }
+      return features
+    },
+    // get featuresForRow() {
+    //   const features = [[self]]
+    //   if (self.children) {
+    //     const row: AnnotationFeatureLocationI[] = []
+    //     self.children?.forEach((child) => {
+    //       const f = child.featuresForRow
+    //       if (f.length > 1) {
+    //         features.push(row)
+    //         row.length = 0
+    //         features.push(...f)
+    //       } else if (
+    //         row.find((rowFeature) =>
+    //           f[0].find(
+    //             (childRowFeature: AnnotationFeatureLocationI) =>
+    //               rowFeature.start > childRowFeature.end &&
+    //               childRowFeature.start < rowFeature.end,
+    //           ),
+    //         )
+    //       ) {
+    //         features.push(row)
+    //         row.length = 0
+    //         row.push(...f[0])
+    //       } else {
+    //         row.push(...f[0])
+    //       }
+    //     })
+    //     features.push(row)
+    //   }
+    //   return features
+    // },
+    get rowCount() {
+      return this.featuresForRow.length
+    },
   }))
   .actions((self) => ({
     setFeatureType(featureType: string) {
@@ -123,6 +165,244 @@ export const AnnotationFeatureLocation = types
     addChild(childFeature: SnapshotOrInstance<typeof LateAnnotationFeature>) {
       self.children?.set(childFeature.id, childFeature)
     },
+    setFeatureType(featureType: string) {
+      self.featureType = featureType
+    },
+    draw(
+      ctx: CanvasRenderingContext2D,
+      x: number,
+      y: number,
+      bpPerPx: number,
+      rowHeight: number,
+    ) {
+      for (let i = 0; i < self.rowCount; i++) {
+        this.drawRow(i, ctx, x, y + i * rowHeight, bpPerPx, rowHeight)
+      }
+    },
+    drawRow(
+      rowNumber: number,
+      ctx: CanvasRenderingContext2D,
+      xOffset: number,
+      yOffset: number,
+      bpPerPx: number,
+      rowHeight: number,
+    ) {
+      const features = self.featuresForRow[rowNumber]
+
+      features.forEach((feature) => {
+        const width = feature.end - feature.start
+        const startPx = (feature.start - self.start) / bpPerPx
+        const widthPx = width / bpPerPx
+        const { rowCount } = feature as AnnotationFeatureLocationI
+        if (rowCount > 1) {
+          const featureHeight = rowCount * rowHeight
+          ctx.fillStyle = 'rgba(255,0,0,0.25)'
+          ctx.fillRect(xOffset + startPx, yOffset, widthPx, featureHeight)
+        }
+        ctx.fillStyle = 'black'
+        ctx.fillRect(xOffset + startPx, yOffset, widthPx, rowHeight)
+        if (widthPx > 2) {
+          ctx.clearRect(
+            xOffset + startPx + 1,
+            yOffset + 1,
+            widthPx - 2,
+            rowHeight - 2,
+          )
+          ctx.fillStyle = 'rgba(255,255,255,0.75)'
+          ctx.fillRect(
+            xOffset + startPx + 1,
+            yOffset + 1,
+            widthPx - 2,
+            rowHeight - 2,
+          )
+          ctx.fillStyle = 'black'
+          feature.featureType &&
+            ctx.fillText(
+              feature.featureType,
+              xOffset + startPx + 1,
+              yOffset + 11,
+              widthPx - 2,
+            )
+        }
+      })
+      if (features.length > 1) {
+        let [{ start, end }] = features
+        features.forEach((feature) => {
+          start = Math.min(start, feature.start)
+          end = Math.max(end, feature.end)
+        })
+        const width = end - start
+        const startPx = (start - self.start) / bpPerPx
+        const widthPx = width / bpPerPx
+        ctx.fillStyle = 'rgba(0,255,255,0.2)'
+        ctx.fillRect(
+          xOffset + startPx + 1,
+          yOffset + 1,
+          widthPx - 2,
+          rowHeight - 2,
+        )
+      }
+    },
+    getFeatureFromLayout(
+      x: number,
+      y: number,
+      bpPerPx: number,
+      rowHeight: number,
+    ) {
+      const bp = bpPerPx * x + self.start
+      const row = Math.floor(y / rowHeight)
+      const layoutRow = self.featuresForRow[row]
+      return layoutRow.find((f) => bp >= f.start && bp <= f.end)
+    },
+    // drawRow(
+    //   rowNumber: number,
+    //   rowHeight: number,
+    //   bpPerPx: number,
+    //   xOffset: number,
+    //   yOffset: number,
+    //   ctx: CanvasRenderingContext2D,
+    // ) {
+    //   const feature = self.featuresForRow[rowNumber]
+    //   if (self.rowCount === 1) {
+    //     const width = feature.length
+    //     const startPx = 0
+    //     const widthPx = width / bpPerPx
+    //     ctx.fillStyle = 'black'
+    //     ctx.fillRect(xOffset + startPx, yOffset, widthPx, rowHeight)
+    //     if (widthPx > 2) {
+    //       ctx.clearRect(
+    //         xOffset + startPx + 1,
+    //         yOffset + 1,
+    //         widthPx - 2,
+    //         rowHeight - 2,
+    //       )
+    //       ctx.fillStyle = 'rgba(255,255,255,0.75)'
+    //       ctx.fillRect(
+    //         xOffset + startPx + 1,
+    //         yOffset + 1,
+    //         widthPx - 2,
+    //         rowHeight - 2,
+    //       )
+    //     }
+    //     return
+    //   }
+    //   if (!feature.children) {
+    //     throw new Error('no child feature found')
+    //   }
+    //   const exons = Array.from(feature.children.values())
+    //     .flat()
+    //     .filter((f: AnnotationFeatureLocationI) => f.featureType === 'exon')
+    //     .sort((f1, f2) => {
+    //       const { start: start1 } = f1
+    //       const { start: start2 } = f2
+    //       return start1 - start2
+    //     }) as AnnotationFeatureLocationI[]
+    //   const introns = exons
+    //     .map((exon, idx) => {
+    //       if (idx === 0) {
+    //         return undefined
+    //       }
+    //       return [exons[idx - 1].end, exon.start]
+    //     })
+    //     .filter(Boolean) as [number, number][]
+    //   const cdss = Array.from(feature.children.values())
+    //     .flat()
+    //     .filter((f) => f.featureType === 'CDS') as AnnotationFeatureLocationI[]
+    //   const others = Array.from(feature.children.values())
+    //     .flat()
+    //     .filter(
+    //       (f) => !['exon', 'CDS'].includes(f.featureType),
+    //     ) as AnnotationFeatureLocationI[]
+    //   introns.forEach((intron) => {
+    //     const [intronStart, intronEnd] = intron
+    //     const start = intronStart - self.start
+    //     const width = intronEnd - intronStart
+    //     const startPx = start / bpPerPx
+    //     const widthPx = width / bpPerPx
+    //     ctx.beginPath()
+    //     ctx.moveTo(xOffset + startPx, yOffset + rowHeight / 2)
+    //     ctx.lineTo(xOffset + startPx + widthPx / 2, yOffset)
+    //     ctx.lineTo(xOffset + startPx + widthPx, yOffset + rowHeight / 2)
+    //     ctx.lineWidth = 1
+    //     ctx.stroke()
+    //   })
+    //   exons.forEach((exon) => {
+    //     const start = exon.start - self.start
+    //     const width = exon.length
+    //     const startPx = start / bpPerPx
+    //     const widthPx = width / bpPerPx
+    //     const exonHeight = rowHeight / 2
+    //     const exonOffset = rowHeight / 4
+    //     ctx.fillStyle = 'black'
+    //     ctx.fillRect(
+    //       xOffset + startPx,
+    //       yOffset + exonOffset,
+    //       widthPx,
+    //       exonHeight,
+    //     )
+    //     if (widthPx > 2) {
+    //       ctx.clearRect(
+    //         xOffset + startPx + 1,
+    //         yOffset + exonOffset + 1,
+    //         widthPx - 2,
+    //         exonHeight - 2,
+    //       )
+    //       ctx.fillStyle = 'rgba(64,64,256,0.3)'
+    //       ctx.fillRect(
+    //         xOffset + startPx + 1,
+    //         yOffset + exonOffset + 1,
+    //         widthPx - 2,
+    //         exonHeight - 2,
+    //       )
+    //     }
+    //   })
+    //   cdss.forEach((cds) => {
+    //     const start = cds.start - self.start
+    //     const width = cds.length
+    //     const startPx = start / bpPerPx
+    //     const widthPx = width / bpPerPx
+    //     ctx.fillStyle = 'black'
+    //     ctx.fillRect(xOffset + startPx, yOffset, widthPx, rowHeight)
+    //     if (widthPx > 2) {
+    //       ctx.clearRect(
+    //         xOffset + startPx + 1,
+    //         yOffset + 1,
+    //         widthPx - 2,
+    //         rowHeight - 2,
+    //       )
+    //       ctx.fillStyle = 'rgba(256,256,64,0.3)'
+    //       ctx.fillRect(
+    //         xOffset + startPx + 1,
+    //         yOffset + 1,
+    //         widthPx - 2,
+    //         rowHeight - 2,
+    //       )
+    //     }
+    //   })
+    //   others.forEach((other) => {
+    //     const start = other.start - self.start
+    //     const width = other.length
+    //     const startPx = start / bpPerPx
+    //     const widthPx = width / bpPerPx
+    //     ctx.fillStyle = 'black'
+    //     ctx.fillRect(xOffset + startPx, yOffset, widthPx, rowHeight)
+    //     if (widthPx > 2) {
+    //       ctx.clearRect(
+    //         xOffset + startPx + 1,
+    //         yOffset + 1,
+    //         widthPx - 2,
+    //         rowHeight - 2,
+    //       )
+    //       ctx.fillStyle = 'rgba(255,255,255,0.75)'
+    //       ctx.fillRect(
+    //         xOffset + startPx + 1,
+    //         yOffset + 1,
+    //         widthPx - 2,
+    //         rowHeight - 2,
+    //       )
+    //     }
+    //   })
+    // },
   }))
   .views((self) => ({
     parentId() {
@@ -133,9 +413,6 @@ export const AnnotationFeatureLocation = types
         // pass
       }
       return parent?.id
-    },
-    get length() {
-      return self.end - self.start
     },
   }))
 
@@ -172,6 +449,18 @@ export const AnnotationFeature = types
         )
       }
       return max
+    },
+    get featuresForRow() {
+      const features: AnnotationFeatureLocationI[][] = []
+      self.locations.forEach((location) => {
+        location.featuresForRow.forEach((row, idx) => {
+          if (idx > features.length - 1) {
+            features[idx] = []
+          }
+          features[idx].push(...(row as AnnotationFeatureLocationI[]))
+        })
+      })
+      return features
     },
   }))
 

--- a/packages/apollo-shared/src/BackendDrivers/BackendDriver.ts
+++ b/packages/apollo-shared/src/BackendDrivers/BackendDriver.ts
@@ -3,11 +3,14 @@ import { SnapshotIn } from 'mobx-state-tree'
 
 import { Change, ClientDataStore } from '../ChangeManager/Change'
 import { ValidationResultSet } from '../Validations/ValidationSet'
-import { AnnotationFeature } from './AnnotationFeature'
+import { AnnotationFeatureLocation } from './AnnotationFeature'
 
-type FeaturesForRefNameSnapshot = Record<
+// Doing this because `SnapshotIn<typeof FeaturesForRefName>` for some reason
+// resolves to `any`, so this offers better typechecking.
+export type FeaturesForRefNameSnapshot = Record<
   string,
-  Record<string, SnapshotIn<typeof AnnotationFeature> | undefined> | undefined
+  | Record<string, SnapshotIn<typeof AnnotationFeatureLocation> | undefined>
+  | undefined
 >
 
 export abstract class BackendDriver {

--- a/packages/apollo-shared/src/BackendDrivers/CollaborationServerDriver.ts
+++ b/packages/apollo-shared/src/BackendDrivers/CollaborationServerDriver.ts
@@ -200,7 +200,7 @@ function convertFeature(
         throw new Error('Feature location found without feature ID')
       }
     } else if (!childFeatureId) {
-      childFeatureId = Object.values(locations)[0].id
+      childFeatureId = `${Object.values(locations)[0].id}-feature`
     }
     children[childFeatureId] = {
       id: childFeatureId,

--- a/packages/apollo-shared/src/BackendDrivers/CollaborationServerDriver.ts
+++ b/packages/apollo-shared/src/BackendDrivers/CollaborationServerDriver.ts
@@ -4,10 +4,13 @@ import { BaseInternetAccountModel } from '@jbrowse/core/pluggableElementTypes'
 import { AppRootModel, Region, getSession } from '@jbrowse/core/util'
 import { SnapshotIn, getRoot } from 'mobx-state-tree'
 
-import { AnnotationFeature } from '../BackendDrivers/AnnotationFeature'
+import {
+  AnnotationFeature,
+  AnnotationFeatureLocation,
+} from '../BackendDrivers/AnnotationFeature'
 import { Change } from '../ChangeManager/Change'
 import { ValidationResultSet } from '../Validations/ValidationSet'
-import { BackendDriver } from './BackendDriver'
+import { BackendDriver, FeaturesForRefNameSnapshot } from './BackendDriver'
 
 interface ApolloFeatureLine extends GFF3FeatureLine {
   // eslint-disable-next-line camelcase
@@ -146,13 +149,10 @@ function makeFeatures(
   apolloFeatures: ApolloFeatureLine[],
   assemblyName: string,
 ) {
-  const featuresByRefName: Record<
-    string,
-    Record<string, SnapshotIn<typeof AnnotationFeature> | undefined> | undefined
-  > = {}
+  const featuresByRefName: FeaturesForRefNameSnapshot = {}
   for (const apolloFeature of apolloFeatures) {
     const convertedFeature = convertFeature(apolloFeature, assemblyName)
-    const { refName } = convertedFeature.location
+    const { refName } = convertedFeature
     let refRecord = featuresByRefName[refName]
     if (!refRecord) {
       refRecord = {}
@@ -166,7 +166,7 @@ function makeFeatures(
 function convertFeature(
   apolloFeature: ApolloFeatureLine,
   assemblyName: string,
-): SnapshotIn<typeof AnnotationFeature> {
+): SnapshotIn<typeof AnnotationFeatureLocation> {
   if (!apolloFeature.seq_id) {
     throw new Error('Got GFF3 record without an ID')
   }
@@ -184,20 +184,37 @@ function convertFeature(
     throw new Error('Apollo feature without featureId encountered')
   }
   const children: Record<string, SnapshotIn<typeof AnnotationFeature>> = {}
-  apolloFeature.child_features?.forEach((childFeatureLocation) => {
-    childFeatureLocation.forEach((childFeature) => {
-      const childFeat = convertFeature(childFeature, assemblyName)
-      children[childFeat.id] = childFeat
+  apolloFeature.child_features?.forEach((childFeature) => {
+    let childFeatureId: string | undefined = undefined
+    const locations: Record<
+      string,
+      SnapshotIn<typeof AnnotationFeatureLocation>
+    > = {}
+    childFeature.forEach((childFeatureLine) => {
+      childFeatureId = childFeatureLine?.attributes?.ID?.[0]
+      const childFeat = convertFeature(childFeatureLine, assemblyName)
+      locations[childFeat.id] = childFeat
     })
+    if (Object.keys(locations).length > 1) {
+      if (!childFeatureId) {
+        throw new Error('Feature location found without feature ID')
+      }
+    } else if (!childFeatureId) {
+      childFeatureId = Object.values(locations)[0].id
+    }
+    children[childFeatureId] = {
+      id: childFeatureId,
+      type: 'AnnotationFeature',
+      locations,
+    }
   })
-  const newFeature: SnapshotIn<typeof AnnotationFeature> = {
+  const newFeature: SnapshotIn<typeof AnnotationFeatureLocation> = {
     id,
+    type: 'AnnotationFeatureLocation',
     assemblyName,
-    location: {
-      refName: apolloFeature.seq_id,
-      start: apolloFeature.start,
-      end: apolloFeature.end,
-    },
+    refName: apolloFeature.seq_id,
+    start: apolloFeature.start,
+    end: apolloFeature.end,
     featureType: apolloFeature.type,
   }
   if (Array.from(Object.entries(children)).length) {

--- a/packages/apollo-shared/src/ChangeManager/LocationEndChange.ts
+++ b/packages/apollo-shared/src/ChangeManager/LocationEndChange.ts
@@ -1,7 +1,7 @@
 import { FeatureDocument } from 'apollo-schemas'
 import { resolveIdentifier } from 'mobx-state-tree'
 
-import { AnnotationFeature } from '../BackendDrivers/AnnotationFeature'
+import { AnnotationFeatureLocation } from '../BackendDrivers/AnnotationFeature'
 import {
   ChangeOptions,
   ClientDataStore,
@@ -151,14 +151,14 @@ export class LocationEndChange extends FeatureChange {
     }
     this.changedIds.forEach((changedId, idx) => {
       const feature = resolveIdentifier(
-        AnnotationFeature,
+        AnnotationFeatureLocation,
         dataStore.features,
         changedId,
       )
       if (!feature) {
         throw new Error(`Could not find feature with identifier "${changedId}"`)
       }
-      feature.location.setEnd(this.changes[idx].newEnd)
+      feature.setEnd(this.changes[idx].newEnd)
     })
   }
 

--- a/packages/apollo-shared/src/ChangeManager/LocationStartChange.ts
+++ b/packages/apollo-shared/src/ChangeManager/LocationStartChange.ts
@@ -1,7 +1,7 @@
 import { FeatureDocument } from 'apollo-schemas'
 import { resolveIdentifier } from 'mobx-state-tree'
 
-import { AnnotationFeature } from '../BackendDrivers/AnnotationFeature'
+import { AnnotationFeatureLocation } from '../BackendDrivers/AnnotationFeature'
 import {
   ChangeOptions,
   ClientDataStore,
@@ -151,14 +151,14 @@ export class LocationStartChange extends FeatureChange {
     }
     this.changedIds.forEach((changedId, idx) => {
       const feature = resolveIdentifier(
-        AnnotationFeature,
+        AnnotationFeatureLocation,
         dataStore.features,
         changedId,
       )
       if (!feature) {
         throw new Error(`Could not find feature with identifier "${changedId}"`)
       }
-      feature.location.setStart(this.changes[idx].newStart)
+      feature.setStart(this.changes[idx].newStart)
     })
   }
 

--- a/packages/apollo-shared/src/ChangeManager/TypeChange.ts
+++ b/packages/apollo-shared/src/ChangeManager/TypeChange.ts
@@ -1,7 +1,7 @@
 import { FeatureDocument } from 'apollo-schemas'
 import { resolveIdentifier } from 'mobx-state-tree'
 
-import { AnnotationFeature } from '../BackendDrivers/AnnotationFeature'
+import { AnnotationFeatureLocation } from '../BackendDrivers/AnnotationFeature'
 import {
   ChangeOptions,
   ClientDataStore,
@@ -150,7 +150,7 @@ export class TypeChange extends FeatureChange {
     }
     this.changedIds.forEach((changedId, idx) => {
       const feature = resolveIdentifier(
-        AnnotationFeature,
+        AnnotationFeatureLocation,
         dataStore.features,
         changedId,
       )

--- a/packages/jbrowse-plugin-apollo/src/ApolloDetailsView/components/ApolloDetailsView.tsx
+++ b/packages/jbrowse-plugin-apollo/src/ApolloDetailsView/components/ApolloDetailsView.tsx
@@ -9,6 +9,7 @@ import {
   useGridApiContext,
 } from '@mui/x-data-grid'
 import {
+  AnnotationFeatureI,
   Change,
   ChangeManager,
   LocationEndChange,
@@ -93,30 +94,28 @@ export const ApolloDetailsView = observer(
       return <div>click on a feature to see details</div>
     }
     // const sequenceTypes = changeManager?.validations.getPossibleValues('type')
-    const {
-      id,
-      featureType,
-      assemblyName,
-      location: { refName, start, end },
-    } = selectedFeature
+    const { id, featureType, assemblyName, refName, start, end } =
+      selectedFeature
     const selectedFeatureRows = [
       { id, featureType, assemblyName, refName, start, end, model },
     ]
     function addChildFeatures(f: typeof selectedFeature) {
-      f?.children?.forEach((child: typeof selectedFeature, childId: string) => {
-        if (!child) {
-          throw new Error(`No child with id ${childId}`)
-        }
-        selectedFeatureRows.push({
-          id: childId,
-          featureType: child.featureType,
-          assemblyName: child.assemblyName,
-          refName: child.location.refName,
-          start: child.location.start,
-          end: child.location.end,
-          model,
+      f?.children?.forEach((child: AnnotationFeatureI, childId: string) => {
+        child.locations.forEach((childLocation) => {
+          if (!childLocation) {
+            throw new Error(`No child with id ${childId}`)
+          }
+          selectedFeatureRows.push({
+            id: childId,
+            featureType: childLocation.featureType,
+            assemblyName: childLocation.assemblyName,
+            refName: childLocation.refName,
+            start: childLocation.start,
+            end: childLocation.end,
+            model,
+          })
+          addChildFeatures(childLocation)
         })
-        addChildFeatures(child)
       })
     }
     addChildFeatures(selectedFeature)

--- a/packages/jbrowse-plugin-apollo/src/ApolloDetailsView/stateModel.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloDetailsView/stateModel.ts
@@ -1,7 +1,7 @@
 import PluginManager from '@jbrowse/core/PluginManager'
 import { getContainingView, getSession } from '@jbrowse/core/util'
 import { ElementId } from '@jbrowse/core/util/types/mst'
-import { AnnotationFeatureI, ChangeManager } from 'apollo-shared'
+import { AnnotationFeatureLocationI, ChangeManager } from 'apollo-shared'
 import { Instance, getParent, types } from 'mobx-state-tree'
 
 export function stateModelFactory(pluginManager: PluginManager) {
@@ -11,7 +11,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
       type: types.literal('ApolloDetailsView'),
     })
     .views((self) => ({
-      get selectedFeature(): AnnotationFeatureI | undefined {
+      get selectedFeature(): AnnotationFeatureLocationI | undefined {
         return getParent(self).selectedFeature
       },
       get setSelectedFeature() {

--- a/packages/jbrowse-plugin-apollo/src/ApolloView/stateModel.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloView/stateModel.ts
@@ -4,8 +4,8 @@ import { MenuItem } from '@jbrowse/core/ui'
 import { AppRootModel } from '@jbrowse/core/util'
 import { LinearGenomeViewStateModel } from '@jbrowse/plugin-linear-genome-view'
 import {
-  AnnotationFeature,
-  AnnotationFeatureI,
+  AnnotationFeatureLocation,
+  AnnotationFeatureLocationI,
   ChangeManager,
   CollaborationServerDriver,
   CoreValidation,
@@ -62,7 +62,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
           .stateModel as ApolloDetailsViewStateModel,
         { type: 'ApolloDetailsView' },
       ),
-      selectedFeature: types.maybe(types.reference(AnnotationFeature)),
+      selectedFeature: types.maybe(types.reference(AnnotationFeatureLocation)),
       dataStore: types.maybe(ClientDataStore),
       displayName: 'Apollo',
     })
@@ -135,7 +135,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
       setDisplayName(displayName: string) {
         self.displayName = displayName
       },
-      setSelectedFeature(feature: AnnotationFeatureI) {
+      setSelectedFeature(feature: AnnotationFeatureLocationI) {
         self.selectedFeature = feature
       },
     }))

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel.ts
@@ -4,7 +4,7 @@ import PluginManager from '@jbrowse/core/PluginManager'
 import { getContainingView, getSession } from '@jbrowse/core/util'
 import { getParentRenderProps } from '@jbrowse/core/util/tracks'
 import { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
-import { AnnotationFeatureI } from 'apollo-shared'
+import { AnnotationFeatureLocationI } from 'apollo-shared'
 import { autorun } from 'mobx'
 import { Instance, addDisposer, types } from 'mobx-state-tree'
 
@@ -29,7 +29,9 @@ export function stateModelFactory(
       }),
     )
     .volatile(() => ({
-      apolloFeatureUnderMouse: undefined as AnnotationFeatureI | undefined,
+      apolloFeatureUnderMouse: undefined as
+        | AnnotationFeatureLocationI
+        | undefined,
       apolloRowUnderMouse: undefined as number | undefined,
     }))
     .views((self) => {
@@ -80,7 +82,7 @@ export function stateModelFactory(
           }),
         )
       },
-      setApolloFeatureUnderMouse(feature?: AnnotationFeatureI) {
+      setApolloFeatureUnderMouse(feature?: AnnotationFeatureLocationI) {
         self.apolloFeatureUnderMouse = feature
       },
       setApolloRowUnderMouse(row?: number) {
@@ -97,80 +99,68 @@ export function stateModelFactory(
       get features() {
         const { dataStore } = self.apolloView
         if (!dataStore) {
-          return new Map()
+          return undefined
         }
         return dataStore.features
       },
       get featureLayout() {
-        const featureLayout: Map<number, AnnotationFeatureI[]> = new Map()
-        for (const featuresForRefName of this.features.values()) {
-          if (featuresForRefName) {
-            let min: number
-            let max: number
-            const rows: boolean[][] = []
-            ;(Array.from(featuresForRefName.values()) as AnnotationFeatureI[])
-              .sort((f1, f2) => {
-                const { start: start1, end: end1 } = f1.location
-                const { start: start2, end: end2 } = f2.location
-                return start1 - start2 || end1 - end2
-              })
-              .forEach((feature) => {
-                if (min === undefined) {
-                  min = feature.location.start
-                }
-                if (max === undefined) {
-                  max = feature.location.end
-                }
-                if (feature.location.start < min) {
-                  rows.forEach((row) => {
-                    row.unshift(...new Array(min - feature.location.start))
-                  })
-                  min = feature.location.start
-                }
-                if (feature.location.end > max) {
-                  rows.forEach((row) => {
-                    row.push(...new Array(feature.location.end - max))
-                  })
-                  max = feature.location.end
-                }
-                let rowNumber = 0
-                let placed = false
-                while (!placed) {
-                  let row = rows[rowNumber]
-                  if (!row) {
-                    rows[rowNumber] = new Array(max - min)
-                    row = rows[rowNumber]
-                    row.fill(
-                      true,
-                      feature.location.start - min,
-                      feature.location.end - min,
-                    )
-                    featureLayout.set(rowNumber, [feature])
-                    placed = true
+        const featureLayout: Map<number, AnnotationFeatureLocationI[]> =
+          new Map()
+        for (const featuresForRefName of this.features?.values() || []) {
+          let min: number
+          let max: number
+          const rows: boolean[][] = []
+          Array.from(featuresForRefName.values())
+            .sort((f1, f2) => {
+              const { start: start1, end: end1 } = f1
+              const { start: start2, end: end2 } = f2
+              return start1 - start2 || end1 - end2
+            })
+            .forEach((feature) => {
+              if (min === undefined) {
+                min = feature.start
+              }
+              if (max === undefined) {
+                max = feature.end
+              }
+              if (feature.start < min) {
+                rows.forEach((row) => {
+                  row.unshift(...new Array(min - feature.start))
+                })
+                min = feature.start
+              }
+              if (feature.end > max) {
+                rows.forEach((row) => {
+                  row.push(...new Array(feature.end - max))
+                })
+                max = feature.end
+              }
+              let rowNumber = 0
+              let placed = false
+              while (!placed) {
+                let row = rows[rowNumber]
+                if (!row) {
+                  rows[rowNumber] = new Array(max - min)
+                  row = rows[rowNumber]
+                  row.fill(true, feature.start - min, feature.end - min)
+                  featureLayout.set(rowNumber, [feature])
+                  placed = true
+                } else {
+                  if (
+                    row
+                      .slice(feature.start - min, feature.end - min)
+                      .some(Boolean)
+                  ) {
+                    rowNumber += 1
                   } else {
-                    if (
-                      row
-                        .slice(
-                          feature.location.start - min,
-                          feature.location.end - min,
-                        )
-                        .some(Boolean)
-                    ) {
-                      rowNumber += 1
-                    } else {
-                      row.fill(
-                        true,
-                        feature.location.start - min,
-                        feature.location.end - min,
-                      )
-                      const layoutRow = featureLayout.get(rowNumber)
-                      layoutRow?.push(feature)
-                      placed = true
-                    }
+                    row.fill(true, feature.start - min, feature.end - min)
+                    const layoutRow = featureLayout.get(rowNumber)
+                    layoutRow?.push(feature)
+                    placed = true
                   }
                 }
-              })
-          }
+              }
+            })
         }
         return featureLayout
       },
@@ -182,7 +172,7 @@ export function stateModelFactory(
         }
         return assembly.name
       },
-      get selectedFeature(): AnnotationFeatureI | undefined {
+      get selectedFeature(): AnnotationFeatureLocationI | undefined {
         return self.apolloView.selectedFeature
       },
       get setSelectedFeature() {


### PR DESCRIPTION
This adds basic subfeature glyphs that work for any generic number and depth of subfeatures. Each feature and child features can have their boundaries dragged. Specialized glyphs (e.g. gene feature glyphs) to come later.