### PR TITLE
Reduce plugin bundle size

### DIFF
--- a/packages/apollo-collaboration-server/src/changes/changes.service.ts
+++ b/packages/apollo-collaboration-server/src/changes/changes.service.ts
@@ -1,5 +1,3 @@
-import fs from 'fs'
-
 import { Logger, UnprocessableEntityException } from '@nestjs/common'
 import { InjectModel } from '@nestjs/mongoose'
 import {
@@ -31,6 +29,7 @@ import {
 } from 'apollo-shared'
 import { Model } from 'mongoose'
 
+import { FilesService } from '../files/files.service'
 import { CreateChangeDto } from './dto/create-change.dto'
 
 export class ChangesService {
@@ -47,6 +46,7 @@ export class ChangesService {
     private readonly fileModel: Model<FileDocument>,
     @InjectModel(Change.name)
     private readonly changeModel: Model<ChangeDocument>,
+    private readonly filesService: FilesService,
   ) {
     changeRegistry.registerChange(
       'AddAssemblyAndFeaturesFromFileChange',
@@ -98,7 +98,7 @@ export class ChangesService {
           refSeqChunkModel: this.refSeqChunkModel,
           fileModel: this.fileModel,
           session,
-          fs,
+          filesService: this.filesService,
         })
       } catch (e) {
         throw new UnprocessableEntityException(String(e))

--- a/packages/apollo-collaboration-server/src/files/files.controller.ts
+++ b/packages/apollo-collaboration-server/src/files/files.controller.ts
@@ -1,7 +1,3 @@
-import { createReadStream } from 'fs'
-import { join } from 'path'
-import { createGunzip } from 'zlib'
-
 import {
   Body,
   Controller,
@@ -93,13 +89,11 @@ export class FilesController {
       'Content-Type': file.type,
       'Content-Disposition': `attachment; filename="${file.basename}"`,
     })
-    const fileStream = createReadStream(join(FILE_UPLOAD_FOLDER, file.checksum))
     if (acceptGzip) {
       res.set({ 'Content-Encoding': 'gzip' })
-      return new StreamableFile(fileStream)
+      return new StreamableFile(this.filesService.getFileStream(file, true))
     }
-    const gunzip = createGunzip()
-    return new StreamableFile(fileStream.pipe(gunzip))
+    return new StreamableFile(this.filesService.getFileStream(file))
   }
 
   /**

--- a/packages/apollo-collaboration-server/src/files/files.module.ts
+++ b/packages/apollo-collaboration-server/src/files/files.module.ts
@@ -19,6 +19,6 @@ import { FilesService } from './files.service'
     RefSeqsModule,
     RefSeqChunksModule,
   ],
-  exports: [MongooseModule],
+  exports: [MongooseModule, FilesService],
 })
 export class FilesModule {}

--- a/packages/apollo-collaboration-server/src/files/files.service.ts
+++ b/packages/apollo-collaboration-server/src/files/files.service.ts
@@ -3,6 +3,7 @@ import { unlink } from 'fs/promises'
 import { join } from 'path'
 import { Gunzip, createGunzip } from 'zlib'
 
+import gff from '@gmod/gff'
 import {
   Injectable,
   InternalServerErrorException,
@@ -74,6 +75,18 @@ export class FilesService {
     }
     const gunzip = createGunzip()
     return fileStream.pipe(gunzip)
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  parseGFF3(stream: ReadStream): any {
+    return stream.pipe(
+      gff.parseStream({
+        parseSequences: false,
+        parseComments: false,
+        parseDirectives: false,
+        parseFeatures: true,
+      }),
+    )
   }
 
   /**

--- a/packages/apollo-shared/src/ChangeManager/AddAssemblyAndFeaturesFromFileChange.ts
+++ b/packages/apollo-shared/src/ChangeManager/AddAssemblyAndFeaturesFromFileChange.ts
@@ -1,4 +1,4 @@
-import gff, { GFF3Feature } from '@gmod/gff'
+import { GFF3Feature } from '@gmod/gff'
 
 import {
   ChangeOptions,
@@ -106,13 +106,8 @@ export class AddAssemblyAndFeaturesFromFileChange extends FeatureChange {
       await this.addRefSeqIntoDb(fileDoc, newAssemblyDoc._id, backend)
 
       // Loop all features
-      const featureStream = filesService.getFileStream(fileDoc).pipe(
-        gff.parseStream({
-          parseSequences: false,
-          parseComments: false,
-          parseDirectives: false,
-          parseFeatures: true,
-        }),
+      const featureStream = filesService.parseGFF3(
+        filesService.getFileStream(fileDoc),
       )
       for await (const f of featureStream) {
         const gff3Feature = f as GFF3Feature

--- a/packages/apollo-shared/src/ChangeManager/AddAssemblyFromFileChange.ts
+++ b/packages/apollo-shared/src/ChangeManager/AddAssemblyFromFileChange.ts
@@ -1,5 +1,3 @@
-import { join } from 'path'
-
 import {
   ChangeOptions,
   ClientDataStore,
@@ -84,7 +82,6 @@ export class AddAssemblyFromFileChange extends FeatureChange {
         throw new Error(`File "${fileId}" not found in Mongo`)
       }
       this.logger.debug?.(`FileId "${fileId}", checksum "${fileDoc.checksum}"`)
-      const compressedFullFileName = join(FILE_UPLOAD_FOLDER, fileDoc.checksum)
 
       // Check and add new assembly
       const assemblyDoc = await assemblyModel
@@ -105,12 +102,7 @@ export class AddAssemblyFromFileChange extends FeatureChange {
       this.logger.debug?.(`File type: "${fileDoc.type}"`)
 
       // Add refSeqs
-      await this.addRefSeqIntoDb(
-        fileDoc.type,
-        compressedFullFileName,
-        newAssemblyDoc._id,
-        backend,
-      )
+      await this.addRefSeqIntoDb(fileDoc, newAssemblyDoc._id, backend)
     }
   }
 

--- a/packages/apollo-shared/src/ChangeManager/AddFeaturesFromFileChange.ts
+++ b/packages/apollo-shared/src/ChangeManager/AddFeaturesFromFileChange.ts
@@ -1,6 +1,3 @@
-import { join } from 'path'
-import { createGunzip } from 'zlib'
-
 import gff, { GFF3Feature } from '@gmod/gff'
 
 import {
@@ -70,7 +67,7 @@ export class AddFeaturesFromFileChange extends FeatureChange {
    * @returns
    */
   async applyToServer(backend: ServerDataStore) {
-    const { fs, fileModel, session } = backend
+    const { filesService, fileModel, session } = backend
     const { changes } = this
 
     for (const change of changes) {
@@ -86,20 +83,16 @@ export class AddFeaturesFromFileChange extends FeatureChange {
         throw new Error(`File "${fileId}" not found in Mongo`)
       }
       this.logger.debug?.(`FileId "${fileId}", checksum "${fileDoc.checksum}"`)
-      const compressedFullFileName = join(FILE_UPLOAD_FOLDER, fileDoc.checksum)
 
       // Read data from compressed file and parse the content
-      const featureStream = fs
-        .createReadStream(compressedFullFileName)
-        .pipe(createGunzip())
-        .pipe(
-          gff.parseStream({
-            parseSequences: false,
-            parseComments: false,
-            parseDirectives: false,
-            parseFeatures: true,
-          }),
-        )
+      const featureStream = filesService.getFileStream(fileDoc).pipe(
+        gff.parseStream({
+          parseSequences: false,
+          parseComments: false,
+          parseDirectives: false,
+          parseFeatures: true,
+        }),
+      )
       for await (const f of featureStream) {
         const gff3Feature = f as GFF3Feature
         this.logger.verbose?.(`ENTRY=${JSON.stringify(gff3Feature)}`)

--- a/packages/apollo-shared/src/ChangeManager/AddFeaturesFromFileChange.ts
+++ b/packages/apollo-shared/src/ChangeManager/AddFeaturesFromFileChange.ts
@@ -1,4 +1,4 @@
-import gff, { GFF3Feature } from '@gmod/gff'
+import { GFF3Feature } from '@gmod/gff'
 
 import {
   ChangeOptions,
@@ -85,13 +85,8 @@ export class AddFeaturesFromFileChange extends FeatureChange {
       this.logger.debug?.(`FileId "${fileId}", checksum "${fileDoc.checksum}"`)
 
       // Read data from compressed file and parse the content
-      const featureStream = filesService.getFileStream(fileDoc).pipe(
-        gff.parseStream({
-          parseSequences: false,
-          parseComments: false,
-          parseDirectives: false,
-          parseFeatures: true,
-        }),
+      const featureStream = filesService.parseGFF3(
+        filesService.getFileStream(fileDoc),
       )
       for await (const f of featureStream) {
         const gff3Feature = f as GFF3Feature

--- a/packages/apollo-shared/src/ChangeManager/Change.ts
+++ b/packages/apollo-shared/src/ChangeManager/Change.ts
@@ -30,7 +30,9 @@ export interface ServerDataStore {
   refSeqChunkModel: import('mongoose').Model<RefSeqChunkDocument>
   fileModel: import('mongoose').Model<FileDocument>
   session: import('mongoose').ClientSession
-  fs: typeof import('fs')
+  filesService: {
+    getFileStream(file: FileDocument): import('fs').ReadStream
+  }
 }
 
 export interface SerializedChange {

--- a/packages/apollo-shared/src/ChangeManager/Change.ts
+++ b/packages/apollo-shared/src/ChangeManager/Change.ts
@@ -1,3 +1,5 @@
+import { ReadStream } from 'fs'
+
 import {
   AssemblyDocument,
   FeatureDocument,
@@ -32,6 +34,7 @@ export interface ServerDataStore {
   session: import('mongoose').ClientSession
   filesService: {
     getFileStream(file: FileDocument): import('fs').ReadStream
+    parseGFF3(stream: ReadStream): ReadStream
   }
 }
 

--- a/packages/apollo-shared/src/ChangeManager/FeatureChange.ts
+++ b/packages/apollo-shared/src/ChangeManager/FeatureChange.ts
@@ -1,7 +1,5 @@
-import { createGunzip } from 'zlib'
-
 import { GFF3Feature, GFF3FeatureLine } from '@gmod/gff'
-import { RefSeqDocument } from 'apollo-schemas'
+import { FileDocument, RefSeqDocument } from 'apollo-schemas'
 import { v4 as uuidv4 } from 'uuid'
 
 import {
@@ -76,23 +74,20 @@ export abstract class FeatureChange extends Change {
   }
 
   async addRefSeqIntoDb(
-    fileDocType: string,
-    compressedFullFileName: string,
+    fileDoc: FileDocument,
     assemblyId: string,
     backend: ServerDataStore,
   ) {
-    const { refSeqModel, refSeqChunkModel, session, fs } = backend
+    const { refSeqModel, refSeqChunkModel, session, filesService } = backend
     const { CHUNK_SIZE } = process.env
     const chunkSize = Number(CHUNK_SIZE)
     let chunkIndex = 0
     let refSeqLen = 0
     let refSeqDoc: RefSeqDocument | undefined = undefined
-    let fastaInfoStarted = fileDocType !== 'text/x-gff3'
+    let fastaInfoStarted = fileDoc.type !== 'text/x-gff3'
 
     // Read data from compressed file and parse the content
-    const sequenceStream = fs
-      .createReadStream(compressedFullFileName)
-      .pipe(createGunzip())
+    const sequenceStream = filesService.getFileStream(fileDoc)
     let sequenceBuffer = ''
     let incompleteLine = ''
     let lastLineIsIncomplete = true

--- a/packages/jbrowse-plugin-apollo/package.json
+++ b/packages/jbrowse-plugin-apollo/package.json
@@ -51,7 +51,6 @@
     "@gmod/gff": "^1.2.0",
     "@jbrowse/plugin-linear-genome-view": "^1.7.4",
     "apollo-shared": "workspace:^",
-    "bson": "^4.6.4",
     "clsx": "^1.1.1",
     "regenerator-runtime": "^0.13.9",
     "streamsaver": "^2.0.6",

--- a/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/configSchema.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/configSchema.ts
@@ -1,5 +1,5 @@
 import { ConfigurationSchema } from '@jbrowse/core/configuration'
-import { BaseInternetAccountConfig } from '@jbrowse/core/pluggableElementTypes/models'
+import { BaseInternetAccountConfig } from '@jbrowse/core/pluggableElementTypes'
 import { Instance } from 'mobx-state-tree'
 
 const ApolloConfigSchema = ConfigurationSchema(

--- a/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
@@ -1,5 +1,5 @@
 import { ConfigurationReference, getConf } from '@jbrowse/core/configuration'
-import { InternetAccount } from '@jbrowse/core/pluggableElementTypes/models'
+import { InternetAccount } from '@jbrowse/core/pluggableElementTypes'
 import { Instance, getRoot, types } from 'mobx-state-tree'
 
 import { ApolloLoginForm } from './components/ApolloLoginForm'

--- a/packages/jbrowse-plugin-apollo/src/components/AddAssembly.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/AddAssembly.tsx
@@ -1,3 +1,5 @@
+import { Buffer } from 'buffer'
+
 import { AbstractSessionModel, AppRootModel } from '@jbrowse/core/util'
 import {
   Button,
@@ -15,7 +17,6 @@ import {
   RadioGroup,
   TextField,
 } from '@material-ui/core'
-import { ObjectID } from 'bson'
 import { getRoot } from 'mobx-state-tree'
 import React, { useState } from 'react'
 
@@ -115,7 +116,7 @@ export function AddAssembly({ session, handleClose }: AddAssemblyProps) {
         body: JSON.stringify({
           changedIds: ['1'],
           typeName,
-          assemblyId: new ObjectID(),
+          assemblyId: generateObjectId(),
           fileId,
           assemblyName,
         }),
@@ -240,4 +241,44 @@ export function AddAssembly({ session, handleClose }: AddAssemblyProps) {
       ) : null}
     </Dialog>
   )
+}
+
+let index = Math.floor(Math.random() * 0xffffff)
+
+function getInc(): number {
+  return (index = (index + 1) % 0xffffff)
+}
+
+/**
+ * Generate a 12 byte id buffer used in ObjectId's
+ *
+ * @param time - pass in a second based timestamp.
+ */
+function generateObjectId(time?: number): Buffer {
+  if ('number' !== typeof time) {
+    time = Math.floor(Date.now() / 1000)
+  }
+
+  const inc = getInc()
+  const buffer = Buffer.alloc(12)
+
+  // 4-byte timestamp
+  buffer.writeUInt32BE(time, 0)
+
+  // // set PROCESS_UNIQUE if yet not initialized
+  // if (PROCESS_UNIQUE === null) {
+  //   PROCESS_UNIQUE = randomBytes(5)
+  // }
+
+  const PROCESS_UNIQUE = window.crypto.getRandomValues(Buffer.alloc(5))
+
+  // 5-byte process unique
+  ;[buffer[4], buffer[5], buffer[6], buffer[7], buffer[8]] = PROCESS_UNIQUE
+
+  // 3-byte counter
+  buffer[11] = inc & 0xff
+  buffer[10] = (inc >> 8) & 0xff
+  buffer[9] = (inc >> 16) & 0xff
+
+  return buffer
 }

--- a/packages/jbrowse-plugin-apollo/src/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/index.ts
@@ -1,12 +1,12 @@
 import { ConfigurationSchema } from '@jbrowse/core/configuration'
-import DisplayType from '@jbrowse/core/pluggableElementTypes/DisplayType'
-import InternetAccountType from '@jbrowse/core/pluggableElementTypes/InternetAccountType'
 import {
+  DisplayType,
+  InternetAccountType,
+  TrackType,
+  ViewType,
   createBaseTrackConfig,
   createBaseTrackModel,
-} from '@jbrowse/core/pluggableElementTypes/models'
-import TrackType from '@jbrowse/core/pluggableElementTypes/TrackType'
-import ViewType from '@jbrowse/core/pluggableElementTypes/ViewType'
+} from '@jbrowse/core/pluggableElementTypes'
 import Plugin from '@jbrowse/core/Plugin'
 import PluginManager from '@jbrowse/core/PluginManager'
 import { AbstractSessionModel, isAbstractMenuManager } from '@jbrowse/core/util'

--- a/yarn.lock
+++ b/yarn.lock
@@ -6519,15 +6519,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bson@npm:^4.6.4":
-  version: 4.6.4
-  resolution: "bson@npm:4.6.4"
-  dependencies:
-    buffer: ^5.6.0
-  checksum: f56375865c8fc048179075296019a0d2e058edbbb6692e54e2751da738840968de678a48a2276faf2ec8f8b36c5c26f14670ab4d414fe68f0169215efe15d570
-  languageName: node
-  linkType: hard
-
 "buffer-crc32@npm:~0.2.3":
   version: 0.2.13
   resolution: "buffer-crc32@npm:0.2.13"
@@ -11251,7 +11242,6 @@ __metadata:
     "@types/react": ^17.0.34
     "@types/streamsaver": ^2.0.1
     apollo-shared: "workspace:^"
-    bson: ^4.6.4
     clsx: ^1.1.1
     cypress: ^8.7.0
     jest: ^27.3.1


### PR DESCRIPTION
This PR reduces the plugin bundle size. As a reference, the development UMD build before this was 27966 lines (24.5s to build) and after this is 10730 lines (19.4s to build). Main changes were:

- Use more standard imports from `@jbrowse/core` so as to not accidentally bundle JBrowse core code
- Do node operations (e.g. unzipping, creating streams) in the server and pass the handles for those methods into the shared changes
- Use our own ObjectId generator and remove `bson` package, since it wasn't being tree-shaken.