### PR TITLE
Standardize feature structure on front and back ends

### DIFF
--- a/packages/apollo-collaboration-server/package.json
+++ b/packages/apollo-collaboration-server/package.json
@@ -47,8 +47,7 @@
     "react-dom": "^17.0.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.4.0",
-    "tslib": "^2.3.1",
-    "uuid": "^8.3.2"
+    "tslib": "^2.3.1"
   },
   "devDependencies": {
     "@nestjs/cli": "^8.1.2",
@@ -61,7 +60,7 @@
     "@types/passport-jwt": "^3.0.6",
     "@types/passport-local": "^1.0.34",
     "@types/supertest": "^2.0.11",
-    "@types/uuid": "^8",
+    "apollo-mst": "workspace:^",
     "jest": "^27.0.6",
     "prettier": "^2.3.2",
     "rimraf": "^3.0.2",

--- a/packages/apollo-collaboration-server/test/data/features.json
+++ b/packages/apollo-collaboration-server/test/data/features.json
@@ -1,6092 +1,6619 @@
 [{
-  "_id": {
-    "$oid": "624ea14c50a96c2271925b3e"
-  },
-  "attributes": {
-    "Name": [
-      "ctgA"
-    ],
-    "multivalue": [
-      "val1",
-      "val2",
-      "val3"
-    ]
-  },
-  "phase": null,
-  "strand": null,
-  "score": null,
-  "end": 50001,
-  "start": 1,
-  "type": "contig",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "4f88b7c4-dfb2-49a0-91e6-b00d28506c3b",
-  "featureIds": [
-    "4f88b7c4-dfb2-49a0-91e6-b00d28506c3b"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea14c50a96c2271925b42"
-  },
-  "attributes": {
-    "Name": [
-      "Remark:hga"
-    ],
-    "Alias": [
-      "hga"
-    ]
-  },
-  "phase": null,
-  "strand": null,
-  "score": null,
-  "end": 2000,
-  "start": 1000,
-  "type": "remark",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "abb2f0d9-5999-421a-9e0d-b1387de9b78b",
-  "featureIds": [
-    "abb2f0d9-5999-421a-9e0d-b1387de9b78b"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea14c50a96c2271925b46"
-  },
-  "attributes": {
-    "Name": [
-      "Gene:hga"
-    ],
-    "Alias": [
-      "hga"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 2000,
-  "start": 1100,
-  "type": "protein_coding_primary_transcript",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "80e2d556-afd2-4b0b-aff1-ec1e755473de",
-  "featureIds": [
-    "80e2d556-afd2-4b0b-aff1-ec1e755473de"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea14c50a96c2271925b4a"
-  },
-  "attributes": {
-    "Name": [
-      "Protein:HGA"
-    ],
-    "Alias": [
-      "hga"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 1900,
-  "start": 1200,
-  "type": "polypeptide",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "b097ca2c-62a1-4eda-8fe4-c88e3a83767c",
-  "featureIds": [
-    "b097ca2c-62a1-4eda-8fe4-c88e3a83767c"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea14d50a96c2271925b4e"
-  },
-  "attributes": {
-    "Name": [
-      "Gene:hgb"
-    ],
-    "Alias": [
-      "hgb"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 3000,
-  "start": 1600,
-  "type": "protein_coding_primary_transcript",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "c84d74e1-889b-4085-960c-55f532cea2e1",
-  "featureIds": [
-    "c84d74e1-889b-4085-960c-55f532cea2e1"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea14d50a96c2271925b52"
-  },
-  "attributes": {
-    "Name": [
-      "f07"
-    ],
-    "Note": [
-      "This is an example"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 1984,
-  "start": 1659,
-  "type": "remark",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "08b32608-12ab-4cf0-af71-975c2eb48997",
-  "featureIds": [
-    "08b32608-12ab-4cf0-af71-975c2eb48997"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea14d50a96c2271925b56"
-  },
-  "attributes": {
-    "Name": [
-      "Protein:HGB"
-    ],
-    "Alias": [
-      "hgb"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 2900,
-  "start": 1800,
-  "type": "polypeptide",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "ff43a94a-6997-47df-a2f2-5a04597aaee4",
-  "featureIds": [
-    "ff43a94a-6997-47df-a2f2-5a04597aaee4"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea14d50a96c2271925b5a"
-  },
-  "attributes": {
-    "Name": [
-      "f06"
-    ],
-    "Note": [
-      "This is another example"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 6130,
-  "start": 3014,
-  "type": "remark",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "a58bad26-d4ef-4739-8f68-46debd1be601",
-  "featureIds": [
-    "a58bad26-d4ef-4739-8f68-46debd1be601"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea14e50a96c2271925b5e"
-  },
-  "attributes": {
-    "Name": [
-      "f05"
-    ],
-    "Note": [
-      "Ok! Ok! I get the message."
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 5968,
-  "start": 4715,
-  "type": "remark",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "e1605395-1aa3-44a6-a7e9-9a56f7e0d973",
-  "featureIds": [
-    "e1605395-1aa3-44a6-a7e9-9a56f7e0d973"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea14e50a96c2271925b62"
-  },
-  "attributes": {
-    "Name": [
-      "seg04"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 5302,
-  "start": 5233,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "3e168940-73c1-402a-8825-6deba2e4c1d0",
-  "featureIds": [
-    "3e168940-73c1-402a-8825-6deba2e4c1d0"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea14e50a96c2271925b66"
-  },
-  "attributes": {
-    "Name": [
-      "seg04"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 6101,
-  "start": 5800,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "b7e9bd25-2ec3-460d-a306-58ddc140b398",
-  "featureIds": [
-    "b7e9bd25-2ec3-460d-a306-58ddc140b398"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea14e50a96c2271925b6a"
-  },
-  "attributes": {
-    "Name": [
-      "seg04"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 6854,
-  "start": 6442,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "19847d2f-0c13-4605-8ea9-91f8a0e8d604",
-  "featureIds": [
-    "19847d2f-0c13-4605-8ea9-91f8a0e8d604"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea14f50a96c2271925b6e"
-  },
-  "attributes": {
-    "Name": [
-      "seg03"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 7241,
-  "start": 6885,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "6bc7286c-be9d-4e1a-8d57-9bdc46378b02",
-  "featureIds": [
-    "6bc7286c-be9d-4e1a-8d57-9bdc46378b02"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea14f50a96c2271925b72"
-  },
-  "attributes": {
-    "Name": [
-      "seg04"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 7211,
-  "start": 7106,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "2a490420-6b1b-4a29-ab2c-25b00a5a8ba4",
-  "featureIds": [
-    "2a490420-6b1b-4a29-ab2c-25b00a5a8ba4"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea14f50a96c2271925b76"
-  },
-  "attributes": {
-    "Name": [
-      "seg03"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 7737,
-  "start": 7410,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "4d87bc99-70b6-4744-bd2b-581f871c214d",
-  "featureIds": [
-    "4d87bc99-70b6-4744-bd2b-581f871c214d"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea14f50a96c2271925b7a"
-  },
-  "attributes": {
-    "Name": [
-      "seg04"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 8177,
-  "start": 7695,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "c37ea285-1dc0-44cf-b107-760de8a62ee5",
-  "featureIds": [
-    "c37ea285-1dc0-44cf-b107-760de8a62ee5"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15050a96c2271925b7e"
-  },
-  "attributes": {
-    "Name": [
-      "seg03"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 8080,
-  "start": 8055,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "710b8bdd-0348-4750-b5be-82a8d13125c7",
-  "featureIds": [
-    "710b8bdd-0348-4750-b5be-82a8d13125c7"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15050a96c2271925b82"
-  },
-  "attributes": {
-    "Name": [
-      "seg03"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 8999,
-  "start": 8306,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "f4322fb8-49da-4c14-bd40-17cf8708f088",
-  "featureIds": [
-    "f4322fb8-49da-4c14-bd40-17cf8708f088"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15050a96c2271925b86"
-  },
-  "attributes": {
-    "Name": [
-      "seg04"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 8783,
-  "start": 8545,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "09bec62c-998d-46b6-afc0-1ab153475e8d",
-  "featureIds": [
-    "09bec62c-998d-46b6-afc0-1ab153475e8d"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15050a96c2271925b8a"
-  },
-  "attributes": {
-    "Name": [
-      "seg04"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 8935,
-  "start": 8869,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "1b65ad93-fe18-449a-999f-27b0d94940d9",
-  "featureIds": [
-    "1b65ad93-fe18-449a-999f-27b0d94940d9"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15150a96c2271925b8e"
-  },
-  "attributes": {
-    "Name": [
-      "seg04"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 9825,
-  "start": 9404,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "01545a97-9cf0-47a8-8686-3425b2396dec",
-  "featureIds": [
-    "01545a97-9cf0-47a8-8686-3425b2396dec"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15150a96c2271925b92"
-  },
-  "attributes": {
-    "Name": [
-      "Apple1"
-    ],
-    "Note": [
-      "CDS with no parent"
-    ]
-  },
-  "phase": "0",
-  "strand": "+",
-  "score": null,
-  "end": 11500,
-  "start": 10000,
-  "type": "CDS",
-  "source": "bare_predicted",
-  "seq_id": "ctgA",
-  "featureId": "95b4329d-e764-46df-be4b-2506e0602556",
-  "featureIds": [
-    "95b4329d-e764-46df-be4b-2506e0602556"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15150a96c2271925b96"
-  },
-  "attributes": {
-    "Name": [
-      "m11"
-    ],
-    "Note": [
-      "kinase"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 15561,
-  "start": 11911,
-  "type": "polypeptide_domain",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "80c7e31f-926f-4818-a910-386769783177",
-  "featureIds": [
-    "80c7e31f-926f-4818-a910-386769783177"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15150a96c2271925b9a"
-  },
-  "attributes": {
-    "Name": [
-      "seg12"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 12895,
-  "start": 12531,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "3ed712f5-f119-4267-8153-03bc729832b6",
-  "featureIds": [
-    "3ed712f5-f119-4267-8153-03bc729832b6"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15150a96c2271925b9e"
-  },
-  "attributes": {
-    "Name": [
-      "seg12"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 13449,
-  "start": 13122,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "fc86ecd5-b24b-4419-97c5-7f3872f6a9ce",
-  "featureIds": [
-    "fc86ecd5-b24b-4419-97c5-7f3872f6a9ce"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15250a96c2271925ba2"
-  },
-  "attributes": {
-    "Name": [
-      "f08"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 16394,
-  "start": 13280,
-  "type": "remark",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "ec71b825-78af-4805-9654-d17e80ecb9c3",
-  "featureIds": [
-    "ec71b825-78af-4805-9654-d17e80ecb9c3"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15250a96c2271925ba6"
-  },
-  "attributes": {
-    "Name": [
-      "seg12"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 13745,
-  "start": 13452,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "f13a41f9-bcf9-4500-acba-1564ef02e697",
-  "featureIds": [
-    "f13a41f9-bcf9-4500-acba-1564ef02e697"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15250a96c2271925baa"
-  },
-  "attributes": {
-    "Name": [
-      "m05"
-    ],
-    "Note": [
-      "helix loop helix"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 14007,
-  "start": 13801,
-  "type": "polypeptide_domain",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "5371a445-e0fc-4ba2-90a3-f84a397b0085",
-  "featureIds": [
-    "5371a445-e0fc-4ba2-90a3-f84a397b0085"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15350a96c2271925bae"
-  },
-  "attributes": {
-    "Name": [
-      "seg12"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 13965,
-  "start": 13908,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "c8114176-78f9-4cb2-a4c1-2cd32c52dc56",
-  "featureIds": [
-    "c8114176-78f9-4cb2-a4c1-2cd32c52dc56"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15350a96c2271925bb2"
-  },
-  "attributes": {
-    "Name": [
-      "seg12"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 14488,
-  "start": 13998,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "6453ba05-fa3f-4394-a9f1-39e5d069922e",
-  "featureIds": [
-    "6453ba05-fa3f-4394-a9f1-39e5d069922e"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15350a96c2271925bb6"
-  },
-  "attributes": {
-    "Name": [
-      "seg12"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 14899,
-  "start": 14564,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "e4753093-b87e-4475-b9ee-3cb223184c1f",
-  "featureIds": [
-    "e4753093-b87e-4475-b9ee-3cb223184c1f"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15350a96c2271925bba"
-  },
-  "attributes": {
-    "Name": [
-      "m14"
-    ],
-    "Note": [
-      "kinase"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 17239,
-  "start": 14731,
-  "type": "polypeptide_domain",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "e2f98a86-f463-4ab3-881e-d305574a500c",
-  "featureIds": [
-    "e2f98a86-f463-4ab3-881e-d305574a500c"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15450a96c2271925bbe"
-  },
-  "attributes": {
-    "Name": [
-      "seg12"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 15276,
-  "start": 15185,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "cca67ec3-2164-47ae-bda6-8720f9e6d83c",
-  "featureIds": [
-    "cca67ec3-2164-47ae-bda6-8720f9e6d83c"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15450a96c2271925bc2"
-  },
-  "attributes": {
-    "Name": [
-      "f10"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 15533,
-  "start": 15329,
-  "type": "remark",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "a5fde89a-92ff-4c2f-af94-a4dbcd60cc39",
-  "featureIds": [
-    "a5fde89a-92ff-4c2f-af94-a4dbcd60cc39"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15450a96c2271925bc6"
-  },
-  "attributes": {
-    "Name": [
-      "m03"
-    ],
-    "Note": [
-      "zinc finger"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 16159,
-  "start": 15396,
-  "type": "polypeptide_domain",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "48c6b75a-6ad8-4177-990a-fef499fb11aa",
-  "featureIds": [
-    "48c6b75a-6ad8-4177-990a-fef499fb11aa"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15450a96c2271925bca"
-  },
-  "attributes": {
-    "Name": [
-      "seg12"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 15736,
-  "start": 15639,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "035b1eef-cbc0-4fa0-86a0-602a82c5f121",
-  "featureIds": [
-    "035b1eef-cbc0-4fa0-86a0-602a82c5f121"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15550a96c2271925bce"
-  },
-  "attributes": {
-    "Name": [
-      "seg12"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 15870,
-  "start": 15745,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "fce09723-97e1-40a5-9acd-4ba8d7d09cfc",
-  "featureIds": [
-    "fce09723-97e1-40a5-9acd-4ba8d7d09cfc"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15550a96c2271925bd2"
-  },
-  "attributes": {
-    "Name": [
-      "m08"
-    ],
-    "Note": [
-      "7-transmembrane"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 17675,
-  "start": 17023,
-  "type": "polypeptide_domain",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "aefaad3c-295b-4833-b837-7d31712c6315",
-  "featureIds": [
-    "aefaad3c-295b-4833-b837-7d31712c6315"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15550a96c2271925bd6"
-  },
-  "attributes": {
-    "Name": [
-      "m13"
-    ],
-    "Note": [
-      "DEAD box"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 17690,
-  "start": 17667,
-  "type": "polypeptide_domain",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "8d14c6e3-c618-47a7-82ad-b6643974d8cd",
-  "featureIds": [
-    "8d14c6e3-c618-47a7-82ad-b6643974d8cd"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15550a96c2271925bda"
-  },
-  "attributes": {
-    "Name": [
-      "m07"
-    ],
-    "Note": [
-      "7-transmembrane"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 18552,
-  "start": 18048,
-  "type": "polypeptide_domain",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "de780978-71ea-4866-a077-9f32582fc6f4",
-  "featureIds": [
-    "de780978-71ea-4866-a077-9f32582fc6f4"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15650a96c2271925bde"
-  },
-  "attributes": {
-    "Name": [
-      "seg08"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 18985,
-  "start": 18509,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "355b6a61-f2b8-4acc-9c51-1020870cdcd8",
-  "featureIds": [
-    "355b6a61-f2b8-4acc-9c51-1020870cdcd8"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15650a96c2271925be2"
-  },
-  "attributes": {
-    "Name": [
-      "seg08"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 19388,
-  "start": 18989,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "4a816f31-4484-4446-ac2e-c07d073c5f12",
-  "featureIds": [
-    "4a816f31-4484-4446-ac2e-c07d073c5f12"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15650a96c2271925be6"
-  },
-  "attributes": {
-    "Name": [
-      "f13"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 22915,
-  "start": 19157,
-  "type": "remark",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "ec79b984-22af-4571-9966-5299f792ce9d",
-  "featureIds": [
-    "ec79b984-22af-4571-9966-5299f792ce9d"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15650a96c2271925bea"
-  },
-  "attributes": {
-    "Name": [
-      "seg06"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 19559,
-  "start": 19249,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "6fd0d673-6eb5-4cd6-902f-dea0c4b2fd44",
-  "featureIds": [
-    "6fd0d673-6eb5-4cd6-902f-dea0c4b2fd44"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15750a96c2271925bee"
-  },
-  "attributes": {
-    "Name": [
-      "seg08"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 19962,
-  "start": 19496,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "4f7e50fd-f108-41ad-972c-a80a2cdab7ac",
-  "featureIds": [
-    "4f7e50fd-f108-41ad-972c-a80a2cdab7ac"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15750a96c2271925bf2"
-  },
-  "attributes": {
-    "Name": [
-      "seg06"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 20260,
-  "start": 19975,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "abbcbf88-7486-49e5-97ff-d8c01c47c2e9",
-  "featureIds": [
-    "abbcbf88-7486-49e5-97ff-d8c01c47c2e9"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15750a96c2271925bf6"
-  },
-  "attributes": {
-    "Name": [
-      "seg08"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 20580,
-  "start": 20093,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "ffc02ea7-e3b5-4e72-b600-40f745eaef88",
-  "featureIds": [
-    "ffc02ea7-e3b5-4e72-b600-40f745eaef88"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15750a96c2271925bfa"
-  },
-  "attributes": {
-    "Name": [
-      "seg06"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 20491,
-  "start": 20379,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "e456a3ea-bd4d-466b-8aff-6c9687469139",
-  "featureIds": [
-    "e456a3ea-bd4d-466b-8aff-6c9687469139"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15850a96c2271925bfe"
-  },
-  "attributes": {
-    "Name": [
-      "seg06"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 21005,
-  "start": 20533,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "624aefb6-93b7-47a5-a2a7-13a2d2e40a63",
-  "featureIds": [
-    "624aefb6-93b7-47a5-a2a7-13a2d2e40a63"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15850a96c2271925c02"
-  },
-  "attributes": {
-    "Name": [
-      "seg08"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 21052,
-  "start": 20970,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "39286dbc-b644-4078-92a0-be5440ad8ad4",
-  "featureIds": [
-    "39286dbc-b644-4078-92a0-be5440ad8ad4"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15850a96c2271925c06"
-  },
-  "attributes": {
-    "Name": [
-      "seg06"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 21331,
-  "start": 21122,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "ce954aca-5c41-4756-9762-831f5a89f5c7",
-  "featureIds": [
-    "ce954aca-5c41-4756-9762-831f5a89f5c7"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15850a96c2271925c0a"
-  },
-  "attributes": {
-    "Name": [
-      "seg08"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 21277,
-  "start": 21270,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "31fef215-bbae-49ae-a3e4-0f2cf09cd1d3",
-  "featureIds": [
-    "31fef215-bbae-49ae-a3e4-0f2cf09cd1d3"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15950a96c2271925c0e"
-  },
-  "attributes": {
-    "Name": [
-      "seg06"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 22176,
-  "start": 21682,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "464ced75-772e-4782-b481-9f3d21ffd4c9",
-  "featureIds": [
-    "464ced75-772e-4782-b481-9f3d21ffd4c9"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15950a96c2271925c12"
-  },
-  "attributes": {
-    "Name": [
-      "seg08"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 22168,
-  "start": 21685,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "e093692c-5334-418e-bcc8-4b8d07ff05a9",
-  "featureIds": [
-    "e093692c-5334-418e-bcc8-4b8d07ff05a9"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15950a96c2271925c16"
-  },
-  "attributes": {
-    "Name": [
-      "m12"
-    ],
-    "Note": [
-      "kinase"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 25612,
-  "start": 21748,
-  "type": "polypeptide_domain",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "0ec8a9a8-89f0-48a4-a068-1f92f390c83d",
-  "featureIds": [
-    "0ec8a9a8-89f0-48a4-a068-1f92f390c83d"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15950a96c2271925c1a"
-  },
-  "attributes": {
-    "Name": [
-      "f15"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 24633,
-  "start": 22132,
-  "type": "remark",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "3af6dd22-ee54-42c2-a572-b4785f2cb40c",
-  "featureIds": [
-    "3af6dd22-ee54-42c2-a572-b4785f2cb40c"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15a50a96c2271925c1e"
-  },
-  "attributes": {
-    "Name": [
-      "seg06"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 22570,
-  "start": 22374,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "317a25d5-6259-40f8-9a32-cc99a06d6770",
-  "featureIds": [
-    "317a25d5-6259-40f8-9a32-cc99a06d6770"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15a50a96c2271925c22"
-  },
-  "attributes": {
-    "Name": [
-      "seg08"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 22869,
-  "start": 22564,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "697d3130-10ae-4451-9f9f-42faa88167fe",
-  "featureIds": [
-    "697d3130-10ae-4451-9f9f-42faa88167fe"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15a50a96c2271925c26"
-  },
-  "attributes": {
-    "Name": [
-      "seg08"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 23298,
-  "start": 22958,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "78539f9e-44f2-4098-8be4-218a9ed50c5f",
-  "featureIds": [
-    "78539f9e-44f2-4098-8be4-218a9ed50c5f"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15a50a96c2271925c2a"
-  },
-  "attributes": {
-    "Name": [
-      "seg06"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 23427,
-  "start": 23025,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "5d1474d2-05df-47df-8399-8d59a3129ac9",
-  "featureIds": [
-    "5d1474d2-05df-47df-8399-8d59a3129ac9"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15b50a96c2271925c2e"
-  },
-  "attributes": {
-    "Name": [
-      "f14"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 23185,
-  "start": 23072,
-  "type": "remark",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "dd690fed-dabb-43da-9f75-1d9a69f437ad",
-  "featureIds": [
-    "dd690fed-dabb-43da-9f75-1d9a69f437ad"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15b50a96c2271925c32"
-  },
-  "attributes": {
-    "Name": [
-      "seg08"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 23469,
-  "start": 23412,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "5be285e2-8209-42a6-9617-b3a4dbd7877a",
-  "featureIds": [
-    "5be285e2-8209-42a6-9617-b3a4dbd7877a"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15b50a96c2271925c36"
-  },
-  "attributes": {
-    "Name": [
-      "seg08"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 23932,
-  "start": 23932,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "b72c1711-e2bb-4e65-b691-05a74507c82b",
-  "featureIds": [
-    "b72c1711-e2bb-4e65-b691-05a74507c82b"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15b50a96c2271925c3a"
-  },
-  "attributes": {
-    "Name": [
-      "seg11"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 24510,
-  "start": 24228,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "8627f271-eafe-4242-acfb-8d2f55b818cc",
-  "featureIds": [
-    "8627f271-eafe-4242-acfb-8d2f55b818cc"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15c50a96c2271925c3e"
-  },
-  "attributes": {
-    "Name": [
-      "seg08"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 24787,
-  "start": 24328,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "7e8a1bc1-6cdc-416e-8c0c-68723bf1a70c",
-  "featureIds": [
-    "7e8a1bc1-6cdc-416e-8c0c-68723bf1a70c"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15c50a96c2271925c42"
-  },
-  "attributes": {
-    "Name": [
-      "f02"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 28338,
-  "start": 24562,
-  "type": "remark",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "39b15250-ed6f-45e6-a66e-de91c5848025",
-  "featureIds": [
-    "39b15250-ed6f-45e6-a66e-de91c5848025"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15c50a96c2271925c46"
-  },
-  "attributes": {
-    "Name": [
-      "seg11"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 25012,
-  "start": 24868,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "427e25e8-f6d3-483b-94f9-5dbb7c4b1535",
-  "featureIds": [
-    "427e25e8-f6d3-483b-94f9-5dbb7c4b1535"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15c50a96c2271925c4a"
-  },
-  "attributes": {
-    "Name": [
-      "seg11"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 25426,
-  "start": 25212,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "f67b77b6-d6d2-4733-814a-5825c53f23c4",
-  "featureIds": [
-    "f67b77b6-d6d2-4733-814a-5825c53f23c4"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15d50a96c2271925c4e"
-  },
-  "attributes": {
-    "Name": [
-      "seg08"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 25367,
-  "start": 25228,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "0476ec7d-1cee-4821-a73b-a37aeea31fae",
-  "featureIds": [
-    "0476ec7d-1cee-4821-a73b-a37aeea31fae"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15d50a96c2271925c52"
-  },
-  "attributes": {
-    "Name": [
-      "seg11"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 25874,
-  "start": 25794,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "b2122c5f-7eb3-4ed2-ae26-dabf17408078",
-  "featureIds": [
-    "b2122c5f-7eb3-4ed2-ae26-dabf17408078"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15d50a96c2271925c56"
-  },
-  "attributes": {
-    "Name": [
-      "seg11"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 26519,
-  "start": 26075,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "70faf34d-e244-4749-ade0-ef397aa510ab",
-  "featureIds": [
-    "70faf34d-e244-4749-ade0-ef397aa510ab"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15d50a96c2271925c5a"
-  },
-  "attributes": {
-    "Name": [
-      "seg02"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 26126,
-  "start": 26122,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "4f77ddf1-0b21-417f-82f5-e99f43dad724",
-  "featureIds": [
-    "4f77ddf1-0b21-417f-82f5-e99f43dad724"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15e50a96c2271925c5e"
-  },
-  "attributes": {
-    "Name": [
-      "seg02"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 26869,
-  "start": 26497,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "da6a41d8-234d-4df5-94d4-860bddb3a4bb",
-  "featureIds": [
-    "da6a41d8-234d-4df5-94d4-860bddb3a4bb"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15e50a96c2271925c62"
-  },
-  "attributes": {
-    "Name": [
-      "seg05"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 26799,
-  "start": 26503,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "6403fe53-b593-4017-b070-da62b3e2df5a",
-  "featureIds": [
-    "6403fe53-b593-4017-b070-da62b3e2df5a"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15e50a96c2271925c66"
-  },
-  "attributes": {
-    "Name": [
-      "seg11"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 26940,
-  "start": 26930,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "5c3c4b26-1533-4556-9885-4f90e9ae9d41",
-  "featureIds": [
-    "5c3c4b26-1533-4556-9885-4f90e9ae9d41"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15e50a96c2271925c6a"
-  },
-  "attributes": {
-    "Name": [
-      "seg11"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 27063,
-  "start": 26975,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "2e58e92e-db09-437d-bbdd-9ebe9411e79b",
-  "featureIds": [
-    "2e58e92e-db09-437d-bbdd-9ebe9411e79b"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15f50a96c2271925c6e"
-  },
-  "attributes": {
-    "Name": [
-      "seg05"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 27185,
-  "start": 27172,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "b135271b-abc1-4f9a-bd24-3f342d2a1ada",
-  "featureIds": [
-    "b135271b-abc1-4f9a-bd24-3f342d2a1ada"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15f50a96c2271925c72"
-  },
-  "attributes": {
-    "Name": [
-      "seg02"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 27325,
-  "start": 27201,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "b4ba9015-80f3-4615-ae95-e122ba71b966",
-  "featureIds": [
-    "b4ba9015-80f3-4615-ae95-e122ba71b966"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15f50a96c2271925c76"
-  },
-  "attributes": {
-    "Name": [
-      "seg02"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 27433,
-  "start": 27372,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "2a0145ff-4543-498d-873d-8840900232bc",
-  "featureIds": [
-    "2a0145ff-4543-498d-873d-8840900232bc"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea15f50a96c2271925c7a"
-  },
-  "attributes": {
-    "Name": [
-      "seg11"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 27799,
-  "start": 27415,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "f24bd30d-04b6-4dc8-ae5f-aa3e639eb425",
-  "featureIds": [
-    "f24bd30d-04b6-4dc8-ae5f-aa3e639eb425"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16050a96c2271925c7e"
-  },
-  "attributes": {
-    "Name": [
-      "seg05"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 27860,
-  "start": 27448,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "8536f238-4bac-476a-9252-70216e452dd1",
-  "featureIds": [
-    "8536f238-4bac-476a-9252-70216e452dd1"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16050a96c2271925c82"
-  },
-  "attributes": {
-    "Name": [
-      "seg02"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 27565,
-  "start": 27565,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "205f8021-ee08-4982-b857-abc896bfb090",
-  "featureIds": [
-    "205f8021-ee08-4982-b857-abc896bfb090"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16050a96c2271925c86"
-  },
-  "attributes": {
-    "Name": [
-      "seg02"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 28091,
-  "start": 27813,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "1578d9c4-9047-489a-acde-2e7971650157",
-  "featureIds": [
-    "1578d9c4-9047-489a-acde-2e7971650157"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16050a96c2271925c8a"
-  },
-  "attributes": {
-    "Name": [
-      "seg11"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 27943,
-  "start": 27880,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "8b81488f-5dc9-4cf2-a166-a3a9d4be0bc3",
-  "featureIds": [
-    "8b81488f-5dc9-4cf2-a166-a3a9d4be0bc3"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16150a96c2271925c8e"
-  },
-  "attributes": {
-    "Name": [
-      "seg05"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 28076,
-  "start": 27887,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "6f61a5dd-edde-4d87-832c-6c8985bb2133",
-  "featureIds": [
-    "6f61a5dd-edde-4d87-832c-6c8985bb2133"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16150a96c2271925c92"
-  },
-  "attributes": {
-    "Name": [
-      "seg02"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 28201,
-  "start": 28093,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "165fb7e5-2d91-4e1a-8554-9c86f1581e72",
-  "featureIds": [
-    "165fb7e5-2d91-4e1a-8554-9c86f1581e72"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16150a96c2271925c96"
-  },
-  "attributes": {
-    "Name": [
-      "seg05"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 28316,
-  "start": 28225,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "3e86ada8-d166-4175-8abe-cc71396fcf2d",
-  "featureIds": [
-    "3e86ada8-d166-4175-8abe-cc71396fcf2d"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16150a96c2271925c9a"
-  },
-  "attributes": {
-    "Name": [
-      "seg11"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 28346,
-  "start": 28225,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "f009a235-0df2-4f49-97bf-e608c6aa3908",
-  "featureIds": [
-    "f009a235-0df2-4f49-97bf-e608c6aa3908"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16250a96c2271925c9e"
-  },
-  "attributes": {
-    "Name": [
-      "seg02"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 28377,
-  "start": 28329,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "0dff6214-881f-4dec-a05c-e6851d2e6923",
-  "featureIds": [
-    "0dff6214-881f-4dec-a05c-e6851d2e6923"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16250a96c2271925ca2"
-  },
-  "attributes": {
-    "Name": [
-      "m02"
-    ],
-    "Note": [
-      "HOX"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 30033,
-  "start": 28332,
-  "type": "polypeptide_domain",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "d9f622b5-2ed0-4aa2-bdfc-0c8d5ff1670e",
-  "featureIds": [
-    "d9f622b5-2ed0-4aa2-bdfc-0c8d5ff1670e"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16250a96c2271925ca6"
-  },
-  "attributes": {
-    "Name": [
-      "m10"
-    ],
-    "Note": [
-      "DEAD box"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 28447,
-  "start": 28342,
-  "type": "polypeptide_domain",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "0a969c5a-5a15-49e1-98e3-7792f0b02a03",
-  "featureIds": [
-    "0a969c5a-5a15-49e1-98e3-7792f0b02a03"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16250a96c2271925caa"
-  },
-  "attributes": {
-    "Name": [
-      "seg11"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 28570,
-  "start": 28375,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "6f69799c-278c-4802-a608-a862ca6fea10",
-  "featureIds": [
-    "6f69799c-278c-4802-a608-a862ca6fea10"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16350a96c2271925cae"
-  },
-  "attributes": {
-    "Name": [
-      "seg11"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 29041,
-  "start": 28758,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "0705a4a5-f3c1-4e7c-a5ec-286a31b9c0f0",
-  "featureIds": [
-    "0705a4a5-f3c1-4e7c-a5ec-286a31b9c0f0"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16350a96c2271925cb2"
-  },
-  "attributes": {
-    "Name": [
-      "seg05"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 29058,
-  "start": 28777,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "e8f54651-b94c-411f-bd65-d121d844becf",
-  "featureIds": [
-    "e8f54651-b94c-411f-bd65-d121d844becf"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16350a96c2271925cb6"
-  },
-  "attributes": {
-    "Name": [
-      "seg02"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 29194,
-  "start": 28829,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "92cdda6b-4358-4c68-a619-374df1d9ad01",
-  "featureIds": [
-    "92cdda6b-4358-4c68-a619-374df1d9ad01"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16350a96c2271925cba"
-  },
-  "attributes": {
-    "Name": [
-      "seg11"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 29302,
-  "start": 29101,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "70906ea7-1277-4c73-b58d-9089b0fbedc4",
-  "featureIds": [
-    "70906ea7-1277-4c73-b58d-9089b0fbedc4"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16450a96c2271925cbe"
-  },
-  "attributes": {
-    "Name": [
-      "seg05"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 29647,
-  "start": 29513,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "7efd0f58-5b66-45e0-9bcd-e30afd18a327",
-  "featureIds": [
-    "7efd0f58-5b66-45e0-9bcd-e30afd18a327"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16450a96c2271925cc2"
-  },
-  "attributes": {
-    "Name": [
-      "seg02"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 29702,
-  "start": 29517,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "532c489b-799f-4bb8-9a86-d217255d6a66",
-  "featureIds": [
-    "532c489b-799f-4bb8-9a86-d217255d6a66"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16450a96c2271925cc6"
-  },
-  "attributes": {
-    "Name": [
-      "seg11"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 29702,
-  "start": 29604,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "35cb2d57-7015-42df-9eba-b820db9df0e9",
-  "featureIds": [
-    "35cb2d57-7015-42df-9eba-b820db9df0e9"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16450a96c2271925cca"
-  },
-  "attributes": {
-    "Name": [
-      "seg02"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 30061,
-  "start": 29713,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "d9794611-8791-45e4-afca-d18d4b23f40c",
-  "featureIds": [
-    "d9794611-8791-45e4-afca-d18d4b23f40c"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16550a96c2271925cce"
-  },
-  "attributes": {
-    "Name": [
-      "seg10"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 29942,
-  "start": 29771,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "1e1c7689-215a-4832-9eef-fce31567a781",
-  "featureIds": [
-    "1e1c7689-215a-4832-9eef-fce31567a781"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16550a96c2271925cd2"
-  },
-  "attributes": {
-    "Name": [
-      "seg11"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 29885,
-  "start": 29867,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "7c756894-cd0a-45d4-be1b-842612c7b084",
-  "featureIds": [
-    "7c756894-cd0a-45d4-be1b-842612c7b084"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16550a96c2271925cd6"
-  },
-  "attributes": {
-    "Name": [
-      "seg10"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 30340,
-  "start": 30042,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "b01db09d-df8f-46a0-b331-90da54e09e3a",
-  "featureIds": [
-    "b01db09d-df8f-46a0-b331-90da54e09e3a"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16550a96c2271925cda"
-  },
-  "attributes": {
-    "Name": [
-      "seg05"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 30216,
-  "start": 30108,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "8d3af89a-49f1-4817-a053-4aff5c8e80c7",
-  "featureIds": [
-    "8d3af89a-49f1-4817-a053-4aff5c8e80c7"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16650a96c2271925cde"
-  },
-  "attributes": {
-    "Name": [
-      "seg11"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 30246,
-  "start": 30241,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "11744bf5-cfaf-4857-adc5-a681a6ddeff7",
-  "featureIds": [
-    "11744bf5-cfaf-4857-adc5-a681a6ddeff7"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16650a96c2271925ce2"
-  },
-  "attributes": {
-    "Name": [
-      "seg02"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 30774,
-  "start": 30329,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "8e83e702-6825-412e-ba26-6343cca96d30",
-  "featureIds": [
-    "8e83e702-6825-412e-ba26-6343cca96d30"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16650a96c2271925ce6"
-  },
-  "attributes": {
-    "Name": [
-      "seg05"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 30798,
-  "start": 30465,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "1107fbf7-bf32-4c7c-809b-599ff576a563",
-  "featureIds": [
-    "1107fbf7-bf32-4c7c-809b-599ff576a563"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16650a96c2271925cea"
-  },
-  "attributes": {
-    "Name": [
-      "seg11"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 30738,
-  "start": 30575,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "b92ea6ed-7a50-4f66-add0-7486d6846845",
-  "featureIds": [
-    "b92ea6ed-7a50-4f66-add0-7486d6846845"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16750a96c2271925cee"
-  },
-  "attributes": {
-    "Name": [
-      "m06"
-    ],
-    "Note": [
-      "SUSHI repeat"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 31748,
-  "start": 30578,
-  "type": "polypeptide_domain",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "1f9cfd3f-7fba-484d-9396-b0560d39042d",
-  "featureIds": [
-    "1f9cfd3f-7fba-484d-9396-b0560d39042d"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16750a96c2271925cf2"
-  },
-  "attributes": {
-    "Name": [
-      "seg02"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 31306,
-  "start": 30808,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "341d4ca5-3fcc-4c08-8e0b-ce1986b4de4d",
-  "featureIds": [
-    "341d4ca5-3fcc-4c08-8e0b-ce1986b4de4d"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16750a96c2271925cf6"
-  },
-  "attributes": {
-    "Name": [
-      "seg10"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 31307,
-  "start": 30810,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "d2b7014a-bdf0-4f86-a265-620fa901f163",
-  "featureIds": [
-    "d2b7014a-bdf0-4f86-a265-620fa901f163"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16750a96c2271925cfa"
-  },
-  "attributes": {
-    "Name": [
-      "seg05"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 31236,
-  "start": 31232,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "71e70376-55db-4d5a-898e-918da4443bf3",
-  "featureIds": [
-    "71e70376-55db-4d5a-898e-918da4443bf3"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16850a96c2271925cfe"
-  },
-  "attributes": {
-    "Name": [
-      "seg05"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 31817,
-  "start": 31421,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "d81aaf93-80b3-4eb4-8c54-fcead0e5cd2c",
-  "featureIds": [
-    "d81aaf93-80b3-4eb4-8c54-fcead0e5cd2c"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16850a96c2271925d02"
-  },
-  "attributes": {
-    "Name": [
-      "seg02"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 31729,
-  "start": 31516,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "19b58851-0860-49ad-a68d-8a0d4a327290",
-  "featureIds": [
-    "19b58851-0860-49ad-a68d-8a0d4a327290"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16850a96c2271925d06"
-  },
-  "attributes": {
-    "Name": [
-      "seg02"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 32154,
-  "start": 31753,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "8036e642-5ba0-472e-be24-e3d25c5c5407",
-  "featureIds": [
-    "8036e642-5ba0-472e-be24-e3d25c5c5407"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16850a96c2271925d0a"
-  },
-  "attributes": {
-    "Name": [
-      "seg10"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 31984,
-  "start": 31761,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "8b7f9e5b-42a6-4435-a0cd-d92a99a672bd",
-  "featureIds": [
-    "8b7f9e5b-42a6-4435-a0cd-d92a99a672bd"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16950a96c2271925d0e"
-  },
-  "attributes": {
-    "Name": [
-      "seg05"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 32057,
-  "start": 32010,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "05295a4c-2d73-4065-a84e-24ef0ec492e3",
-  "featureIds": [
-    "05295a4c-2d73-4065-a84e-24ef0ec492e3"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16950a96c2271925d12"
-  },
-  "attributes": {
-    "Name": [
-      "seg05"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 32680,
-  "start": 32208,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "c80c80a9-f4d0-4e99-82af-cd77b434ac24",
-  "featureIds": [
-    "c80c80a9-f4d0-4e99-82af-cd77b434ac24"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16950a96c2271925d16"
-  },
-  "attributes": {
-    "Name": [
-      "seg01"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 32359,
-  "start": 32329,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "99606be9-5aae-4155-b19c-50b3a20eb22e",
-  "featureIds": [
-    "99606be9-5aae-4155-b19c-50b3a20eb22e"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16950a96c2271925d1a"
-  },
-  "attributes": {
-    "Name": [
-      "seg10"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 32937,
-  "start": 32374,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "3e0b6fe4-720f-4343-9781-7fa2ef729e60",
-  "featureIds": [
-    "3e0b6fe4-720f-4343-9781-7fa2ef729e60"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16950a96c2271925d1e"
-  },
-  "attributes": {
-    "Name": [
-      "seg02"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 32696,
-  "start": 32595,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "f25acd80-6ec9-4a1d-b140-416349b976bb",
-  "featureIds": [
-    "f25acd80-6ec9-4a1d-b140-416349b976bb"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16a50a96c2271925d22"
-  },
-  "attributes": {
-    "Name": [
-      "seg02"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 32901,
-  "start": 32892,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "8f475d37-e1c8-4182-9993-c7a2bec7e75b",
-  "featureIds": [
-    "8f475d37-e1c8-4182-9993-c7a2bec7e75b"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16a50a96c2271925d26"
-  },
-  "attributes": {
-    "Name": [
-      "seg05"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 33325,
-  "start": 33053,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "8be3db44-b0ce-4649-aab8-7a757ce6b857",
-  "featureIds": [
-    "8be3db44-b0ce-4649-aab8-7a757ce6b857"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16a50a96c2271925d2a"
-  },
-  "attributes": {
-    "Name": [
-      "seg02"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 33388,
-  "start": 33127,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "eef8dee2-d1ba-4859-adfe-205a7df0a09c",
-  "featureIds": [
-    "eef8dee2-d1ba-4859-adfe-205a7df0a09c"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16a50a96c2271925d2e"
-  },
-  "attributes": {
-    "Name": [
-      "m04"
-    ],
-    "Note": [
-      "Ig-like"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 35791,
-  "start": 33325,
-  "type": "polypeptide_domain",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "5be3cce8-5b86-4d75-8eb1-e5b9e887f097",
-  "featureIds": [
-    "5be3cce8-5b86-4d75-8eb1-e5b9e887f097"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16b50a96c2271925d32"
-  },
-  "attributes": {
-    "Name": [
-      "seg05"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 33868,
-  "start": 33438,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "1e10e941-2ea9-4bc2-8a46-a88b945fc713",
-  "featureIds": [
-    "1e10e941-2ea9-4bc2-8a46-a88b945fc713"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16b50a96c2271925d36"
-  },
-  "attributes": {
-    "Name": [
-      "seg02"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 33443,
-  "start": 33439,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "3b7c18a0-b312-4e4a-99a1-818633816cd0",
-  "featureIds": [
-    "3b7c18a0-b312-4e4a-99a1-818633816cd0"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16b50a96c2271925d3a"
-  },
-  "attributes": {
-    "Name": [
-      "seg02"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 34209,
-  "start": 33759,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "898eb51b-4991-408a-bfa8-98f93dee9c48",
-  "featureIds": [
-    "898eb51b-4991-408a-bfa8-98f93dee9c48"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16b50a96c2271925d3e"
-  },
-  "attributes": {
-    "Name": [
-      "seg05"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 34313,
-  "start": 34244,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "a6a7b840-ccff-4963-b544-c42afbc88d07",
-  "featureIds": [
-    "a6a7b840-ccff-4963-b544-c42afbc88d07"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16c50a96c2271925d42"
-  },
-  "attributes": {
-    "Name": [
-      "seg02"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 34466,
-  "start": 34401,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "8fb7765e-770f-45d8-88ff-a8ec6c586565",
-  "featureIds": [
-    "8fb7765e-770f-45d8-88ff-a8ec6c586565"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16c50a96c2271925d46"
-  },
-  "attributes": {
-    "Name": [
-      "seg05"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 34983,
-  "start": 34605,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "358de79a-38ad-472c-a38b-46daa2fd97c2",
-  "featureIds": [
-    "358de79a-38ad-472c-a38b-46daa2fd97c2"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16c50a96c2271925d4a"
-  },
-  "attributes": {
-    "Name": [
-      "seg05"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 35507,
-  "start": 35333,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "b38f7f2e-f7c9-4388-b02f-9e724543785c",
-  "featureIds": [
-    "b38f7f2e-f7c9-4388-b02f-9e724543785c"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16c50a96c2271925d4e"
-  },
-  "attributes": {
-    "Name": [
-      "seg05"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 35904,
-  "start": 35642,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "f44e2152-019b-48f9-a2b4-73ad33a17da3",
-  "featureIds": [
-    "f44e2152-019b-48f9-a2b4-73ad33a17da3"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16d50a96c2271925d52"
-  },
-  "attributes": {
-    "Name": [
-      "f09"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 38167,
-  "start": 36034,
-  "type": "remark",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "081742f8-8cff-46a9-84af-91d71b59baaa",
-  "featureIds": [
-    "081742f8-8cff-46a9-84af-91d71b59baaa"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16d50a96c2271925d56"
-  },
-  "attributes": {
-    "Name": [
-      "seg09"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 37057,
-  "start": 36616,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "7fad616e-2e52-4035-b87a-df6c6cf76539",
-  "featureIds": [
-    "7fad616e-2e52-4035-b87a-df6c6cf76539"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16d50a96c2271925d5a"
-  },
-  "attributes": {
-    "Name": [
-      "f03"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 40440,
-  "start": 36649,
-  "type": "remark",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "5948275d-266d-4056-8bc6-b5b6bfcdd149",
-  "featureIds": [
-    "5948275d-266d-4056-8bc6-b5b6bfcdd149"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16d50a96c2271925d5e"
-  },
-  "attributes": {
-    "Name": [
-      "seg09"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 37227,
-  "start": 37208,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "dc211302-d7e8-40a0-9244-2484c4108a4f",
-  "featureIds": [
-    "dc211302-d7e8-40a0-9244-2484c4108a4f"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16e50a96c2271925d62"
-  },
-  "attributes": {
-    "Name": [
-      "f04"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 38653,
-  "start": 37242,
-  "type": "remark",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "8e420d3b-b293-4610-ac4b-f1e7f95cbca7",
-  "featureIds": [
-    "8e420d3b-b293-4610-ac4b-f1e7f95cbca7"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16e50a96c2271925d66"
-  },
-  "attributes": {
-    "Name": [
-      "m15"
-    ],
-    "Note": [
-      "7-transmembrane"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 40559,
-  "start": 37497,
-  "type": "polypeptide_domain",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "19c740e8-59ed-47c0-86ee-c418ea58a777",
-  "featureIds": [
-    "19c740e8-59ed-47c0-86ee-c418ea58a777"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16e50a96c2271925d6a"
-  },
-  "attributes": {
-    "Name": [
-      "seg15"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 39361,
-  "start": 39265,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "09e78488-f5d0-4eb6-950f-5cf185aab80d",
-  "featureIds": [
-    "09e78488-f5d0-4eb6-950f-5cf185aab80d"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16e50a96c2271925d6e"
-  },
-  "attributes": {
-    "Name": [
-      "seg15"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 40034,
-  "start": 39753,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "af672452-f0e5-4a2c-97ef-4a8e36886c6a",
-  "featureIds": [
-    "af672452-f0e5-4a2c-97ef-4a8e36886c6a"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16f50a96c2271925d72"
-  },
-  "attributes": {
-    "Name": [
-      "seg15"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 40954,
-  "start": 40515,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "9e891791-9d24-42e1-b401-554a77df13b4",
-  "featureIds": [
-    "9e891791-9d24-42e1-b401-554a77df13b4"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16f50a96c2271925d76"
-  },
-  "attributes": {
-    "Name": [
-      "seg14"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 41318,
-  "start": 41137,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "6625c6ef-12a5-4135-9f41-c340903e6468",
-  "featureIds": [
-    "6625c6ef-12a5-4135-9f41-c340903e6468"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16f50a96c2271925d7a"
-  },
-  "attributes": {
-    "Name": [
-      "seg15"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 41365,
-  "start": 41252,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "f51a3981-fc91-431c-bf26-8b5b75ff9353",
-  "featureIds": [
-    "f51a3981-fc91-431c-bf26-8b5b75ff9353"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea16f50a96c2271925d7e"
-  },
-  "attributes": {
-    "Name": [
-      "seg15"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 41504,
-  "start": 41492,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "807df4dc-dda5-4c0c-a40b-088d5267996d",
-  "featureIds": [
-    "807df4dc-dda5-4c0c-a40b-088d5267996d"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17050a96c2271925d82"
-  },
-  "attributes": {
-    "Name": [
-      "seg14"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 41948,
-  "start": 41754,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "38fef1d6-6df3-446c-b90f-6a7ce655bd1f",
-  "featureIds": [
-    "38fef1d6-6df3-446c-b90f-6a7ce655bd1f"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17050a96c2271925d86"
-  },
-  "attributes": {
-    "Name": [
-      "seg15"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 42377,
-  "start": 41941,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "b7766b05-4c37-4267-a47d-eadb8c458db7",
-  "featureIds": [
-    "b7766b05-4c37-4267-a47d-eadb8c458db7"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17050a96c2271925d8a"
-  },
-  "attributes": {
-    "Name": [
-      "seg14"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 42474,
-  "start": 42057,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "753f3ab9-9159-4850-abf2-d3b117701ca2",
-  "featureIds": [
-    "753f3ab9-9159-4850-abf2-d3b117701ca2"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17050a96c2271925d8e"
-  },
-  "attributes": {
-    "Name": [
-      "seg15"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 42954,
-  "start": 42748,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "2f46dd02-1252-479e-9acf-4aa74344a522",
-  "featureIds": [
-    "2f46dd02-1252-479e-9acf-4aa74344a522"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17150a96c2271925d92"
-  },
-  "attributes": {
-    "Name": [
-      "seg14"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 43270,
-  "start": 42890,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "7149bde0-1490-4505-8fe1-def786fa0416",
-  "featureIds": [
-    "7149bde0-1490-4505-8fe1-def786fa0416"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17150a96c2271925d96"
-  },
-  "attributes": {
-    "Name": [
-      "seg14"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 43811,
-  "start": 43395,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "ba4fd8c2-77aa-47e6-b41c-4c0e66a8e6e9",
-  "featureIds": [
-    "ba4fd8c2-77aa-47e6-b41c-4c0e66a8e6e9"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17150a96c2271925d9a"
-  },
-  "attributes": {
-    "Name": [
-      "seg15"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 43897,
-  "start": 43401,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "5083c684-1df1-4f2e-9dab-decfa0b5b800",
-  "featureIds": [
-    "5083c684-1df1-4f2e-9dab-decfa0b5b800"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17150a96c2271925d9e"
-  },
-  "attributes": {
-    "Name": [
-      "seg15"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 44113,
-  "start": 44043,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "4ce8fe4e-642c-48d4-9976-1a0616226223",
-  "featureIds": [
-    "4ce8fe4e-642c-48d4-9976-1a0616226223"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17150a96c2271925da2"
-  },
-  "attributes": {
-    "Name": [
-      "seg14"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 44556,
-  "start": 44065,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "748458d2-923b-437d-9daf-c4052c404740",
-  "featureIds": [
-    "748458d2-923b-437d-9daf-c4052c404740"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17250a96c2271925da6"
-  },
-  "attributes": {
-    "Name": [
-      "seg07"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 44514,
-  "start": 44191,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "75aad623-9c81-4457-bb13-0eb26522c5ef",
-  "featureIds": [
-    "75aad623-9c81-4457-bb13-0eb26522c5ef"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17250a96c2271925daa"
-  },
-  "attributes": {
-    "Name": [
-      "seg15"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 44888,
-  "start": 44399,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "764d9eaa-6a66-4660-a594-7130d07c5637",
-  "featureIds": [
-    "764d9eaa-6a66-4660-a594-7130d07c5637"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17250a96c2271925dae"
-  },
-  "attributes": {
-    "Name": [
-      "seg07"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 45043,
-  "start": 44552,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "5dd9ad88-6677-48dd-b68e-96ca6cbe599d",
-  "featureIds": [
-    "5dd9ad88-6677-48dd-b68e-96ca6cbe599d"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17250a96c2271925db2"
-  },
-  "attributes": {
-    "Name": [
-      "f01"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 47713,
-  "start": 44705,
-  "type": "remark",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "8f4b0c5f-4729-40c3-9559-4bb44736a82c",
-  "featureIds": [
-    "8f4b0c5f-4729-40c3-9559-4bb44736a82c"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17350a96c2271925db6"
-  },
-  "attributes": {
-    "Name": [
-      "seg14"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 45030,
-  "start": 44763,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "48aa459d-2de2-414c-adcc-41392bfddf3b",
-  "featureIds": [
-    "48aa459d-2de2-414c-adcc-41392bfddf3b"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17350a96c2271925dba"
-  },
-  "attributes": {
-    "Name": [
-      "seg14"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 45488,
-  "start": 45231,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "831eeaf6-780b-49de-a1e0-d9ce56f89a9f",
-  "featureIds": [
-    "831eeaf6-780b-49de-a1e0-d9ce56f89a9f"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17350a96c2271925dbe"
-  },
-  "attributes": {
-    "Name": [
-      "seg15"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 45375,
-  "start": 45281,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "2b5c2f73-6e28-4abd-ac05-1bbaafe4664b",
-  "featureIds": [
-    "2b5c2f73-6e28-4abd-ac05-1bbaafe4664b"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17350a96c2271925dc2"
-  },
-  "attributes": {
-    "Name": [
-      "seg07"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 45600,
-  "start": 45373,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "4ba47780-92ed-4b14-816e-b2a01184876a",
-  "featureIds": [
-    "4ba47780-92ed-4b14-816e-b2a01184876a"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17450a96c2271925dc6"
-  },
-  "attributes": {
-    "Name": [
-      "seg15"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 46041,
-  "start": 45711,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "360dd1cc-5e7b-4894-b16e-e858b049dd45",
-  "featureIds": [
-    "360dd1cc-5e7b-4894-b16e-e858b049dd45"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17450a96c2271925dca"
-  },
-  "attributes": {
-    "Name": [
-      "seg14"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 46022,
-  "start": 45790,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "da6c5e61-ff54-4d9f-9d2a-3ce1b7cbf101",
-  "featureIds": [
-    "da6c5e61-ff54-4d9f-9d2a-3ce1b7cbf101"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17450a96c2271925dce"
-  },
-  "attributes": {
-    "Name": [
-      "seg07"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 46315,
-  "start": 45897,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "e6f4eb34-f8a4-46be-9a4b-8adece277463",
-  "featureIds": [
-    "e6f4eb34-f8a4-46be-9a4b-8adece277463"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17450a96c2271925dd2"
-  },
-  "attributes": {
-    "Name": [
-      "m09"
-    ],
-    "Note": [
-      "kinase"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 48851,
-  "start": 46012,
-  "type": "polypeptide_domain",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "75d2da02-f307-475b-bdac-ad704694666f",
-  "featureIds": [
-    "75d2da02-f307-475b-bdac-ad704694666f"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17550a96c2271925dd6"
-  },
-  "attributes": {
-    "Name": [
-      "seg14"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 46318,
-  "start": 46092,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "960a4431-7d9e-44c4-b20d-d604961ad6dc",
-  "featureIds": [
-    "960a4431-7d9e-44c4-b20d-d604961ad6dc"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17550a96c2271925dda"
-  },
-  "attributes": {
-    "Name": [
-      "seg15"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 46564,
-  "start": 46425,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "2ac140db-574d-4c1c-b382-d710df7969ed",
-  "featureIds": [
-    "2ac140db-574d-4c1c-b382-d710df7969ed"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17550a96c2271925dde"
-  },
-  "attributes": {
-    "Name": [
-      "seg07"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 46890,
-  "start": 46491,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "2dbc7e6c-7bf6-48e9-ba98-d1f2b67d0d46",
-  "featureIds": [
-    "2dbc7e6c-7bf6-48e9-ba98-d1f2b67d0d46"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17550a96c2271925de2"
-  },
-  "attributes": {
-    "Name": [
-      "seg15"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 47087,
-  "start": 46738,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "4428fafc-294d-4c10-893b-8a0c1faf5238",
-  "featureIds": [
-    "4428fafc-294d-4c10-893b-8a0c1faf5238"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17650a96c2271925de6"
-  },
-  "attributes": {
-    "Name": [
-      "seg14"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 46992,
-  "start": 46816,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "78eb05e3-a1d8-4672-a9de-339cd65cfb7e",
-  "featureIds": [
-    "78eb05e3-a1d8-4672-a9de-339cd65cfb7e"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17650a96c2271925dea"
-  },
-  "attributes": {
-    "Name": [
-      "f11"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 48410,
-  "start": 46990,
-  "type": "remark",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "e57bf0e2-2c63-4b2e-870b-bfbbea1485bc",
-  "featureIds": [
-    "e57bf0e2-2c63-4b2e-870b-bfbbea1485bc"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17650a96c2271925dee"
-  },
-  "attributes": {
-    "Name": [
-      "seg07"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 47297,
-  "start": 47126,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "328c4574-ea70-4b94-8e26-9bf00e742f88",
-  "featureIds": [
-    "328c4574-ea70-4b94-8e26-9bf00e742f88"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17650a96c2271925df2"
-  },
-  "attributes": {
-    "Name": [
-      "seg15"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 47595,
-  "start": 47329,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "670a6689-d6c6-4810-98bc-16f5d229e2f1",
-  "featureIds": [
-    "670a6689-d6c6-4810-98bc-16f5d229e2f1"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17750a96c2271925df6"
-  },
-  "attributes": {
-    "Name": [
-      "seg14"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 47829,
-  "start": 47449,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "fa6f9868-6eec-473c-aad0-5c0b87ab17e7",
-  "featureIds": [
-    "fa6f9868-6eec-473c-aad0-5c0b87ab17e7"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17750a96c2271925dfa"
-  },
-  "attributes": {
-    "Name": [
-      "seg07"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 47983,
-  "start": 47735,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "42e93d63-1ceb-49c8-a7a4-c61e150c1bf4",
-  "featureIds": [
-    "42e93d63-1ceb-49c8-a7a4-c61e150c1bf4"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17750a96c2271925dfe"
-  },
-  "attributes": {
-    "Name": [
-      "seg15"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 47979,
-  "start": 47858,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "53c9a17c-a597-46c1-a3d0-c488ee1fcf2b",
-  "featureIds": [
-    "53c9a17c-a597-46c1-a3d0-c488ee1fcf2b"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17750a96c2271925e02"
-  },
-  "attributes": {
-    "Name": [
-      "seg15"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 48453,
-  "start": 48169,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "e3705a14-69db-4893-9608-e3e6225d92a6",
-  "featureIds": [
-    "e3705a14-69db-4893-9608-e3e6225d92a6"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17850a96c2271925e06"
-  },
-  "attributes": {
-    "Name": [
-      "m01"
-    ],
-    "Note": [
-      "WD40"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 48366,
-  "start": 48253,
-  "type": "polypeptide_domain",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "8d3f942b-8582-4bd8-81e2-f08b7f61c339",
-  "featureIds": [
-    "8d3f942b-8582-4bd8-81e2-f08b7f61c339"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17850a96c2271925e0a"
-  },
-  "attributes": {
-    "Name": [
-      "seg07"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 48709,
-  "start": 48447,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "8ea63acf-ca3c-45bd-bc77-6b8713b36ad2",
-  "featureIds": [
-    "8ea63acf-ca3c-45bd-bc77-6b8713b36ad2"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17850a96c2271925e0e"
-  },
-  "attributes": {
-    "Name": [
-      "seg07"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 49186,
-  "start": 48931,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "22cb76c9-98b0-484f-b350-99a4b531adef",
-  "featureIds": [
-    "22cb76c9-98b0-484f-b350-99a4b531adef"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17850a96c2271925e12"
-  },
-  "attributes": {
-    "Name": [
-      "seg13"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 49476,
-  "start": 49406,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "033c98a2-9fbe-4e42-8f5f-e74f460614c3",
-  "featureIds": [
-    "033c98a2-9fbe-4e42-8f5f-e74f460614c3"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17850a96c2271925e16"
-  },
-  "attributes": {
-    "Name": [
-      "seg07"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 49699,
-  "start": 49472,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "26ff5172-34de-49b9-a89a-10f49e1b6a9c",
-  "featureIds": [
-    "26ff5172-34de-49b9-a89a-10f49e1b6a9c"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17950a96c2271925e1a"
-  },
-  "attributes": {
-    "Name": [
-      "f12"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 50000,
-  "start": 49758,
-  "type": "remark",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "0d6210c5-c433-4c5b-a782-88509cc50e48",
-  "featureIds": [
-    "0d6210c5-c433-4c5b-a782-88509cc50e48"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17950a96c2271925e1e"
-  },
-  "attributes": {
-    "Name": [
-      "seg13"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 50000,
-  "start": 49762,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "414cdee4-867d-44fb-9b40-7629d46a407e",
-  "featureIds": [
-    "414cdee4-867d-44fb-9b40-7629d46a407e"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17950a96c2271925e22"
-  },
-  "attributes": {
-    "Name": [
-      "seg07"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 50000,
-  "start": 49957,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "a6711522-16c8-4684-8acb-cb899505b4d0",
-  "featureIds": [
-    "a6711522-16c8-4684-8acb-cb899505b4d0"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17950a96c2271925e26"
-  },
-  "attributes": {
-    "Name": [
-      "seg07"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 50000,
-  "start": 49957,
-  "type": "match",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "b79f018d-9166-4bb6-9d83-5574ce1cb696",
-  "featureIds": [
-    "b79f018d-9166-4bb6-9d83-5574ce1cb696"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17a50a96c2271925e2a"
-  },
-  "attributes": {
-    "Name": [
-      "ctgB"
-    ]
-  },
-  "phase": null,
-  "strand": null,
-  "score": null,
-  "end": 6079,
-  "start": 1,
-  "type": "contig",
-  "source": "example",
-  "seq_id": "ctgB",
-  "featureId": "710e70f0-cfa7-472e-8a89-51f600498b3a",
-  "featureIds": [
-    "710e70f0-cfa7-472e-8a89-51f600498b3a"
-  ],
-  "refSeq": {
-    "$oid": "624ab4d1f8ac0187ed22b566"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17a50a96c2271925e2e"
-  },
-  "attributes": {
-    "Name": [
-      "f07"
-    ],
-    "Note": [
-      "This is an example"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 1984,
-  "start": 1659,
-  "type": "remark",
-  "source": "example",
-  "seq_id": "ctgB",
-  "featureId": "8ef1a63a-e81b-4741-96d0-739ac85b279b",
-  "featureIds": [
-    "8ef1a63a-e81b-4741-96d0-739ac85b279b"
-  ],
-  "refSeq": {
-    "$oid": "624ab4d1f8ac0187ed22b566"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17a50a96c2271925e32"
-  },
-  "attributes": {
-    "Name": [
-      "f06"
-    ],
-    "Note": [
-      "This is another example"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 6130,
-  "start": 3014,
-  "type": "remark",
-  "source": "example",
-  "seq_id": "ctgB",
-  "featureId": "63b700ca-3991-4237-8bf1-01febba05491",
-  "featureIds": [
-    "63b700ca-3991-4237-8bf1-01febba05491"
-  ],
-  "refSeq": {
-    "$oid": "624ab4d1f8ac0187ed22b566"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17a50a96c2271925e36"
-  },
-  "attributes": {
-    "Name": [
-      "f05"
-    ],
-    "Note": [
-      "ああ、この機能は、世界中を旅しています！"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 5968,
-  "start": 4715,
-  "type": "remark",
-  "source": "example",
-  "seq_id": "ctgB",
-  "featureId": "72918adf-970d-473b-8a96-31e44082ff1f",
-  "featureIds": [
-    "72918adf-970d-473b-8a96-31e44082ff1f"
-  ],
-  "refSeq": {
-    "$oid": "624ab4d1f8ac0187ed22b566"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17b50a96c2271925e3a"
-  },
-  "child_features": [
-    [
-      {
-        "seq_id": "ctgA",
-        "source": "example",
-        "type": "clone_start",
-        "start": 1000,
-        "end": 1500,
-        "score": null,
-        "strand": "+",
-        "phase": null,
-        "attributes": {
-          "Parent": [
-            "b101.2"
-          ]
-        },
-        "featureId": "574a728d-1d73-46a4-9329-0d2807a2d21c"
-      }
-    ],
-    [
-      {
-        "seq_id": "ctgA",
-        "source": "example",
-        "type": "clone_end",
-        "start": 19500,
-        "end": 20000,
-        "score": null,
-        "strand": "-",
-        "phase": null,
-        "attributes": {
-          "Parent": [
-            "b101.2"
-          ]
-        },
-        "featureId": "4be59c3a-848e-4eda-871c-82d1a4ad3d74"
-      }
-    ]
-  ],
-  "derived_features": [],
-  "attributes": {
-    "ID": [
-      "b101.2"
-    ],
-    "Name": [
-      "b101.2"
-    ],
-    "Note": [
-      "Fingerprinted BAC with end reads"
-    ]
-  },
-  "phase": null,
-  "strand": null,
-  "score": null,
-  "end": 20000,
-  "start": 1000,
-  "type": "BAC",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "1c89681d-20e4-4a7e-abc9-dce43242b110",
-  "featureIds": [
-    "1c89681d-20e4-4a7e-abc9-dce43242b110",
-    "574a728d-1d73-46a4-9329-0d2807a2d21c",
-    "4be59c3a-848e-4eda-871c-82d1a4ad3d74"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17b50a96c2271925e3e"
-  },
-  "attributes": {
-    "ID": [
-      "FakeSNP1"
-    ],
-    "Name": [
-      "FakeSNP"
-    ],
-    "Note": [
-      "This is a fake SNP that should appear at 1000 with length 1"
-    ]
-  },
-  "phase": null,
-  "strand": null,
-  "score": 0.987,
-  "end": 1000,
-  "start": 1000,
-  "type": "SNP",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "dc97a122-1012-4334-a429-9ae69ae7c71b",
-  "featureIds": [
-    "dc97a122-1012-4334-a429-9ae69ae7c71b"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17b50a96c2271925e42"
-  },
-  "child_features": [
-    [
-      {
-        "seq_id": "ctgA",
-        "source": "est",
-        "type": "match_part",
-        "start": 1050,
-        "end": 1500,
-        "score": null,
-        "strand": "+",
-        "phase": null,
-        "attributes": {
-          "Parent": [
-            "Match1"
-          ],
-          "Name": [
-            "agt830.5"
-          ],
-          "Target": [
-            "agt830.5 1 451"
-          ]
-        },
-        "featureId": "4b15c01c-4a2c-4c6d-84ba-90d3f7def827"
-      }
-    ],
-    [
-      {
-        "seq_id": "ctgA",
-        "source": "est",
-        "type": "match_part",
-        "start": 3000,
-        "end": 3202,
-        "score": null,
-        "strand": "+",
-        "phase": null,
-        "attributes": {
-          "Parent": [
-            "Match1"
-          ],
-          "Name": [
-            "agt830.5"
-          ],
-          "Target": [
-            "agt830.5 452 654"
-          ]
-        },
-        "featureId": "d9862db6-e130-4319-8e40-bb05007a1cc9"
-      }
-    ]
-  ],
-  "derived_features": [],
-  "attributes": {
-    "ID": [
-      "Match1"
-    ],
-    "Name": [
-      "agt830.5"
-    ],
-    "Target": [
-      "agt830.5 1 654"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 3202,
-  "start": 1050,
-  "type": "EST_match",
-  "source": "est",
-  "seq_id": "ctgA",
-  "featureId": "d598b968-c5dd-469a-91d0-0550a6170499",
-  "featureIds": [
-    "d598b968-c5dd-469a-91d0-0550a6170499",
-    "4b15c01c-4a2c-4c6d-84ba-90d3f7def827",
-    "d9862db6-e130-4319-8e40-bb05007a1cc9"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17b50a96c2271925e46"
-  },
-  "child_features": [
-    [
-      {
-        "seq_id": "ctgA",
-        "source": "est",
-        "type": "match_part",
-        "start": 1050,
-        "end": 1500,
-        "score": null,
-        "strand": "+",
-        "phase": null,
-        "attributes": {
-          "Parent": [
-            "Match3"
-          ],
-          "Name": [
-            "agt221.5"
-          ],
-          "Target": [
-            "agt221.5 1 451"
-          ]
-        },
-        "featureId": "d2269de9-c1b0-40a0-8180-2bb9ce49cd58"
-      }
-    ],
-    [
-      {
-        "seq_id": "ctgA",
-        "source": "est",
-        "type": "match_part",
-        "start": 5000,
-        "end": 5500,
-        "score": null,
-        "strand": "+",
-        "phase": null,
-        "attributes": {
-          "Parent": [
-            "Match3"
-          ],
-          "Name": [
-            "agt221.5"
-          ],
-          "Target": [
-            "agt221.5 452 952"
-          ]
-        },
-        "featureId": "bf3740ff-5f3f-410d-b448-e2eb9bb10f85"
-      }
-    ],
-    [
-      {
-        "seq_id": "ctgA",
-        "source": "est",
-        "type": "match_part",
-        "start": 7000,
-        "end": 7300,
-        "score": null,
-        "strand": "+",
-        "phase": null,
-        "attributes": {
-          "Parent": [
-            "Match3"
-          ],
-          "Name": [
-            "agt221.5"
-          ],
-          "Target": [
-            "agt221.5 953 1253"
-          ]
-        },
-        "featureId": "f38abe94-6201-4dc9-b508-d3bdfdf5a278"
-      }
-    ]
-  ],
-  "derived_features": [],
-  "attributes": {
-    "ID": [
-      "Match3"
-    ],
-    "Name": [
-      "agt221.5"
-    ],
-    "Target": [
-      "agt221.5 1 1253"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 7300,
-  "start": 1050,
-  "type": "EST_match",
-  "source": "est",
-  "seq_id": "ctgA",
-  "featureId": "f94c2113-e8b0-4e48-84b1-b0c8b71f50cc",
-  "featureIds": [
-    "f94c2113-e8b0-4e48-84b1-b0c8b71f50cc",
-    "d2269de9-c1b0-40a0-8180-2bb9ce49cd58",
-    "bf3740ff-5f3f-410d-b448-e2eb9bb10f85",
-    "f38abe94-6201-4dc9-b508-d3bdfdf5a278"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17c50a96c2271925e4a"
-  },
-  "child_features": [
-    [
-      {
-        "seq_id": "ctgA",
-        "source": "example",
-        "type": "mRNA",
-        "start": 1050,
-        "end": 9000,
-        "score": null,
-        "strand": "+",
-        "phase": null,
-        "attributes": {
-          "ID": [
-            "EDEN.1"
-          ],
-          "Parent": [
-            "EDEN"
-          ],
-          "Name": [
-            "EDEN.1"
-          ],
-          "Note": [
-            "Eden splice form 1"
-          ],
-          "Index": [
-            "1"
-          ]
-        },
-        "child_features": [
-          [
-            {
-              "seq_id": "ctgA",
-              "source": "example",
-              "type": "five_prime_UTR",
-              "start": 1050,
-              "end": 1200,
-              "score": null,
-              "strand": "+",
-              "phase": null,
-              "attributes": {
-                "Parent": [
-                  "EDEN.1"
-                ]
-              },
-              "featureId": "dac499a4-c01d-4e6c-bf94-d0c7b25f1266"
-            }
-          ],
-          [
-            {
-              "seq_id": "ctgA",
-              "source": "example",
-              "type": "CDS",
-              "start": 1201,
-              "end": 1500,
-              "score": null,
-              "strand": "+",
-              "phase": "0",
-              "attributes": {
-                "Parent": [
-                  "EDEN.1"
-                ]
-              },
-              "featureId": "9a65fde3-fa39-463a-b91a-a3e32fd4dfbc"
-            }
-          ],
-          [
-            {
-              "seq_id": "ctgA",
-              "source": "example",
-              "type": "CDS",
-              "start": 3000,
-              "end": 3902,
-              "score": null,
-              "strand": "+",
-              "phase": "0",
-              "attributes": {
-                "Parent": [
-                  "EDEN.1"
-                ]
-              },
-              "featureId": "d9bc2380-028c-4c56-9d18-63e3509fc1e1"
-            }
-          ],
-          [
-            {
-              "seq_id": "ctgA",
-              "source": "example",
-              "type": "CDS",
-              "start": 5000,
-              "end": 5500,
-              "score": null,
-              "strand": "+",
-              "phase": "0",
-              "attributes": {
-                "Parent": [
-                  "EDEN.1"
-                ]
-              },
-              "featureId": "c7d72fbf-8148-408b-8f13-cdfd61b28ef9"
-            }
-          ],
-          [
-            {
-              "seq_id": "ctgA",
-              "source": "example",
-              "type": "CDS",
-              "start": 7000,
-              "end": 7608,
-              "score": null,
-              "strand": "+",
-              "phase": "0",
-              "attributes": {
-                "Parent": [
-                  "EDEN.1"
-                ]
-              },
-              "featureId": "18a22885-ecf0-460f-b1bf-72d4ec360f73"
-            }
-          ],
-          [
-            {
-              "seq_id": "ctgA",
-              "source": "example",
-              "type": "three_prime_UTR",
-              "start": 7609,
-              "end": 9000,
-              "score": null,
-              "strand": "+",
-              "phase": null,
-              "attributes": {
-                "Parent": [
-                  "EDEN.1"
-                ]
-              },
-              "featureId": "af6c5760-2087-418d-94a0-10a3f5e67f01"
-            }
-          ]
-        ],
-        "derived_features": [],
-        "featureId": "566c20e8-2a4e-46da-9f5d-44f0594f4325"
-      }
-    ],
-    [
-      {
-        "seq_id": "ctgA",
-        "source": "example",
-        "type": "mRNA",
-        "start": 1050,
-        "end": 9000,
-        "score": null,
-        "strand": "+",
-        "phase": null,
-        "attributes": {
-          "ID": [
-            "EDEN.2"
-          ],
-          "Parent": [
-            "EDEN"
-          ],
-          "Name": [
-            "EDEN.2"
-          ],
-          "Note": [
-            "Eden splice form 2"
-          ],
-          "Index": [
-            "1"
-          ]
-        },
-        "child_features": [
-          [
-            {
-              "seq_id": "ctgA",
-              "source": "example",
-              "type": "five_prime_UTR",
-              "start": 1050,
-              "end": 1200,
-              "score": null,
-              "strand": "+",
-              "phase": null,
-              "attributes": {
-                "Parent": [
-                  "EDEN.2"
-                ]
-              },
-              "featureId": "34d6cf23-6058-482d-8449-d768adfeaf1c"
-            }
-          ],
-          [
-            {
-              "seq_id": "ctgA",
-              "source": "example",
-              "type": "CDS",
-              "start": 1201,
-              "end": 1500,
-              "score": null,
-              "strand": "+",
-              "phase": "0",
-              "attributes": {
-                "Parent": [
-                  "EDEN.2"
-                ]
-              },
-              "featureId": "2ca64e76-9561-4bc0-a42d-72dc8c5cbc25"
-            }
-          ],
-          [
-            {
-              "seq_id": "ctgA",
-              "source": "example",
-              "type": "CDS",
-              "start": 5000,
-              "end": 5500,
-              "score": null,
-              "strand": "+",
-              "phase": "0",
-              "attributes": {
-                "Parent": [
-                  "EDEN.2"
-                ]
-              },
-              "featureId": "2156d644-1256-47db-bdec-fa4eda60db3e"
-            }
-          ],
-          [
-            {
-              "seq_id": "ctgA",
-              "source": "example",
-              "type": "CDS",
-              "start": 7000,
-              "end": 7608,
-              "score": null,
-              "strand": "+",
-              "phase": "0",
-              "attributes": {
-                "Parent": [
-                  "EDEN.2"
-                ]
-              },
-              "featureId": "57475cf2-52c5-4987-b934-9bfe8e9afd82"
-            }
-          ],
-          [
-            {
-              "seq_id": "ctgA",
-              "source": "example",
-              "type": "three_prime_UTR",
-              "start": 7609,
-              "end": 9000,
-              "score": null,
-              "strand": "+",
-              "phase": null,
-              "attributes": {
-                "Parent": [
-                  "EDEN.2"
-                ]
-              },
-              "featureId": "35c35a2a-8909-4438-b8ed-a9b07e384c3e"
-            }
-          ]
-        ],
-        "derived_features": [],
-        "featureId": "1f4a59f2-704c-45cd-a02f-c639f8195c6f"
-      }
-    ],
-    [
-      {
-        "seq_id": "ctgA",
-        "source": "example",
-        "type": "mRNA",
-        "start": 1300,
-        "end": 9000,
-        "score": null,
-        "strand": "+",
-        "phase": null,
-        "attributes": {
-          "ID": [
-            "EDEN.3"
-          ],
-          "Parent": [
-            "EDEN"
-          ],
-          "Name": [
-            "EDEN.3"
-          ],
-          "Note": [
-            "Eden splice form 3"
-          ],
-          "Index": [
-            "1"
-          ]
-        },
-        "child_features": [
-          [
-            {
-              "seq_id": "ctgA",
-              "source": "example",
-              "type": "five_prime_UTR",
-              "start": 1300,
-              "end": 1500,
-              "score": null,
-              "strand": "+",
-              "phase": null,
-              "attributes": {
-                "Parent": [
-                  "EDEN.3"
-                ]
-              },
-              "featureId": "1abc4442-d05b-4dc9-8049-c02b6e0fa13e"
-            }
-          ],
-          [
-            {
-              "seq_id": "ctgA",
-              "source": "example",
-              "type": "five_prime_UTR",
-              "start": 3000,
-              "end": 3300,
-              "score": null,
-              "strand": "+",
-              "phase": null,
-              "attributes": {
-                "Parent": [
-                  "EDEN.3"
-                ]
-              },
-              "featureId": "04c97bd5-c9f6-4eb6-aca3-52cba86fe85a"
-            }
-          ],
-          [
-            {
-              "seq_id": "ctgA",
-              "source": "example",
-              "type": "CDS",
-              "start": 3301,
-              "end": 3902,
-              "score": null,
-              "strand": "+",
-              "phase": "0",
-              "attributes": {
-                "Parent": [
-                  "EDEN.3"
-                ]
-              },
-              "featureId": "0e92f07e-f95c-42b1-8305-0cb24985b88c"
-            }
-          ],
-          [
-            {
-              "seq_id": "ctgA",
-              "source": "example",
-              "type": "CDS",
-              "start": 5000,
-              "end": 5500,
-              "score": null,
-              "strand": "+",
-              "phase": "1",
-              "attributes": {
-                "Parent": [
-                  "EDEN.3"
-                ]
-              },
-              "featureId": "4dadd592-05f6-43aa-8b64-f2a67108f854"
-            }
-          ],
-          [
-            {
-              "seq_id": "ctgA",
-              "source": "example",
-              "type": "CDS",
-              "start": 7000,
-              "end": 7600,
-              "score": null,
-              "strand": "+",
-              "phase": "1",
-              "attributes": {
-                "Parent": [
-                  "EDEN.3"
-                ]
-              },
-              "featureId": "bb59ab5b-1235-46d7-bf42-ff0fd756bd72"
-            }
-          ],
-          [
-            {
-              "seq_id": "ctgA",
-              "source": "example",
-              "type": "three_prime_UTR",
-              "start": 7601,
-              "end": 9000,
-              "score": null,
-              "strand": "+",
-              "phase": null,
-              "attributes": {
-                "Parent": [
-                  "EDEN.3"
-                ]
-              },
-              "featureId": "622fdec8-6603-4791-b773-94e4ffd6e048"
-            }
-          ]
-        ],
-        "derived_features": [],
-        "featureId": "424e930c-a1dc-4cfe-9582-46f84a6c5670"
-      }
-    ]
-  ],
-  "derived_features": [],
-  "attributes": {
-    "ID": [
-      "EDEN"
-    ],
-    "Name": [
-      "EDEN"
-    ],
-    "Note": [
-      "protein kinase"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 9000,
-  "start": 1050,
-  "type": "gene",
-  "source": "example",
-  "seq_id": "ctgA",
-  "featureId": "f2484e69-3174-4203-be48-edbd162c6ded",
-  "featureIds": [
-    "f2484e69-3174-4203-be48-edbd162c6ded",
-    "566c20e8-2a4e-46da-9f5d-44f0594f4325",
-    "dac499a4-c01d-4e6c-bf94-d0c7b25f1266",
-    "9a65fde3-fa39-463a-b91a-a3e32fd4dfbc",
-    "d9bc2380-028c-4c56-9d18-63e3509fc1e1",
-    "c7d72fbf-8148-408b-8f13-cdfd61b28ef9",
-    "18a22885-ecf0-460f-b1bf-72d4ec360f73",
-    "af6c5760-2087-418d-94a0-10a3f5e67f01",
-    "1f4a59f2-704c-45cd-a02f-c639f8195c6f",
-    "34d6cf23-6058-482d-8449-d768adfeaf1c",
-    "2ca64e76-9561-4bc0-a42d-72dc8c5cbc25",
-    "2156d644-1256-47db-bdec-fa4eda60db3e",
-    "57475cf2-52c5-4987-b934-9bfe8e9afd82",
-    "35c35a2a-8909-4438-b8ed-a9b07e384c3e",
-    "424e930c-a1dc-4cfe-9582-46f84a6c5670",
-    "1abc4442-d05b-4dc9-8049-c02b6e0fa13e",
-    "04c97bd5-c9f6-4eb6-aca3-52cba86fe85a",
-    "0e92f07e-f95c-42b1-8305-0cb24985b88c",
-    "4dadd592-05f6-43aa-8b64-f2a67108f854",
-    "bb59ab5b-1235-46d7-bf42-ff0fd756bd72",
-    "622fdec8-6603-4791-b773-94e4ffd6e048"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 2
-},{
-  "_id": {
-    "$oid": "624ea17c50a96c2271925e4e"
-  },
-  "child_features": [
-    [
-      {
-        "seq_id": "ctgA",
-        "source": "est",
-        "type": "match_part",
-        "start": 1150,
-        "end": 1500,
-        "score": null,
-        "strand": "+",
-        "phase": null,
-        "attributes": {
-          "Parent": [
-            "Match5"
-          ],
-          "Name": [
-            "agt767.5"
-          ],
-          "Target": [
-            "agt767.5 1 351"
-          ]
-        },
-        "featureId": "41bb927a-5b7d-480b-b0af-0b06b379832e"
-      }
-    ],
-    [
-      {
-        "seq_id": "ctgA",
-        "source": "est",
-        "type": "match_part",
-        "start": 5000,
-        "end": 5500,
-        "score": null,
-        "strand": "+",
-        "phase": null,
-        "attributes": {
-          "Parent": [
-            "Match5"
-          ],
-          "Name": [
-            "agt767.5"
-          ],
-          "Target": [
-            "agt767.5 352 852"
-          ]
-        },
-        "featureId": "cd7f76d4-f742-43d1-bf7e-ce1e02d812d0"
-      }
-    ],
-    [
-      {
-        "seq_id": "ctgA",
-        "source": "est",
-        "type": "match_part",
-        "start": 7000,
-        "end": 7200,
-        "score": null,
-        "strand": "+",
-        "phase": null,
-        "attributes": {
-          "Parent": [
-            "Match5"
-          ],
-          "Name": [
-            "agt767.5"
-          ],
-          "Target": [
-            "agt767.5 853 1153"
-          ]
-        },
-        "featureId": "95afab2d-d20c-4917-9e51-d10b79f4f121"
-      }
-    ]
-  ],
-  "derived_features": [],
-  "attributes": {
-    "ID": [
-      "Match5"
-    ],
-    "Name": [
-      "agt767.5"
-    ],
-    "Target": [
-      "agt767.5 1 1153"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 7200,
-  "start": 1150,
-  "type": "EST_match",
-  "source": "est",
-  "seq_id": "ctgA",
-  "featureId": "713b0753-b241-4d8f-a667-522c7e2514a7",
-  "featureIds": [
-    "713b0753-b241-4d8f-a667-522c7e2514a7",
-    "41bb927a-5b7d-480b-b0af-0b06b379832e",
-    "cd7f76d4-f742-43d1-bf7e-ce1e02d812d0",
-    "95afab2d-d20c-4917-9e51-d10b79f4f121"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17c50a96c2271925e52"
-  },
-  "child_features": [
-    [
-      {
-        "seq_id": "ctgA",
-        "source": "est",
-        "type": "match_part",
-        "start": 5410,
-        "end": 5510,
-        "score": null,
-        "strand": "-",
-        "phase": null,
-        "attributes": {
-          "Parent": [
-            "Match2"
-          ],
-          "Name": [
-            "agt830.3"
-          ],
-          "Target": [
-            "agt830.3 505 595"
-          ]
-        },
-        "featureId": "f2c16bea-bbdd-4cfe-97a2-13fec70feb91"
-      }
-    ],
-    [
-      {
-        "seq_id": "ctgA",
-        "source": "est",
-        "type": "match_part",
-        "start": 7000,
-        "end": 7503,
-        "score": null,
-        "strand": "-",
-        "phase": null,
-        "attributes": {
-          "Parent": [
-            "Match2"
-          ],
-          "Name": [
-            "agt830.3"
-          ],
-          "Target": [
-            "agt830.3 1 504"
-          ]
-        },
-        "featureId": "d4157404-707a-47ac-b9db-5ea3f973c61c"
-      }
-    ]
-  ],
-  "derived_features": [],
-  "attributes": {
-    "ID": [
-      "Match2"
-    ],
-    "Name": [
-      "agt830.3"
-    ],
-    "Target": [
-      "agt830.3 1 595"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 7505,
-  "start": 5410,
-  "type": "EST_match",
-  "source": "est",
-  "seq_id": "ctgA",
-  "featureId": "cdc405af-e6f5-4c76-b95f-989ab4c835c0",
-  "featureIds": [
-    "cdc405af-e6f5-4c76-b95f-989ab4c835c0",
-    "f2c16bea-bbdd-4cfe-97a2-13fec70feb91",
-    "d4157404-707a-47ac-b9db-5ea3f973c61c"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 2
-},{
-  "_id": {
-    "$oid": "624ea17c50a96c2271925e56"
-  },
-  "attributes": {
-    "ID": [
-      "Match4"
-    ],
-    "Name": [
-      "agt221.3"
-    ],
-    "Target": [
-      "agt221.3 1 501"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 8000,
-  "start": 7500,
-  "type": "EST_match",
-  "source": "est",
-  "seq_id": "ctgA",
-  "featureId": "21aacd2f-5492-49b5-a259-a2b990b41d59",
-  "featureIds": [
-    "21aacd2f-5492-49b5-a259-a2b990b41d59"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17d50a96c2271925e5a"
-  },
-  "attributes": {
-    "ID": [
-      "Match6"
-    ],
-    "Name": [
-      "agt767.3"
-    ],
-    "Target": [
-      "agt767.3 1 1001"
-    ]
-  },
-  "phase": null,
-  "strand": "-",
-  "score": null,
-  "end": 9000,
-  "start": 8000,
-  "type": "EST_match",
-  "source": "est",
-  "seq_id": "ctgA",
-  "featureId": "612d43ad-dc46-4c74-9f85-712829fa40ad",
-  "featureIds": [
-    "612d43ad-dc46-4c74-9f85-712829fa40ad"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17d50a96c2271925e5e"
-  },
-  "child_features": [
-    [
-      {
-        "seq_id": "ctgA",
-        "source": "predicted",
-        "type": "CDS",
-        "start": 13500,
-        "end": 13800,
-        "score": null,
-        "strand": "+",
-        "phase": "0",
-        "attributes": {
-          "Parent": [
-            "cds-Apple2"
-          ]
-        },
-        "featureId": "e3394fbe-d0e8-4cac-8854-a2fe7d89f83d"
-      }
-    ],
-    [
-      {
-        "seq_id": "ctgA",
-        "source": "predicted",
-        "type": "CDS",
-        "start": 15000,
-        "end": 15500,
-        "score": null,
-        "strand": "+",
-        "phase": "1",
-        "attributes": {
-          "Parent": [
-            "cds-Apple2"
-          ]
-        },
-        "featureId": "3a3284c9-4053-439a-a356-747f474bb6ab"
-      }
-    ],
-    [
-      {
-        "seq_id": "ctgA",
-        "source": "predicted",
-        "type": "CDS",
-        "start": 16500,
-        "end": 17000,
-        "score": null,
-        "strand": "+",
-        "phase": "2",
-        "attributes": {
-          "Parent": [
-            "cds-Apple2"
-          ]
-        },
-        "featureId": "656345c0-60c9-4714-a6b6-efa74cf837c1"
-      }
-    ]
-  ],
-  "derived_features": [],
-  "attributes": {
-    "ID": [
-      "cds-Apple2"
-    ],
-    "Name": [
-      "Apple2"
-    ],
-    "Note": [
-      "mRNA with CDSs but no UTRs"
-    ]
-  },
-  "phase": "0",
-  "strand": "+",
-  "score": null,
-  "end": 17200,
-  "start": 13000,
-  "type": "mRNA",
-  "source": "predicted",
-  "seq_id": "ctgA",
-  "featureId": "3b809954-47ca-494a-9685-e18838dbb7a7",
-  "featureIds": [
-    "3b809954-47ca-494a-9685-e18838dbb7a7",
-    "e3394fbe-d0e8-4cac-8854-a2fe7d89f83d",
-    "3a3284c9-4053-439a-a356-747f474bb6ab",
-    "656345c0-60c9-4714-a6b6-efa74cf837c1"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
-},{
-  "_id": {
-    "$oid": "624ea17d50a96c2271925e62"
-  },
-  "child_features": [
-    [
-      {
-        "seq_id": "ctgA",
-        "source": "exonerate",
-        "type": "UTR",
-        "start": 17400,
-        "end": 17999,
-        "score": null,
-        "strand": "+",
-        "phase": null,
-        "attributes": {
-          "Parent": [
-            "rna-Apple3"
-          ]
-        },
-        "featureId": "4ffdf6f8-bb10-4777-834b-4a5cc8886bca"
-      }
-    ],
-    [
-      {
-        "seq_id": "ctgA",
-        "source": "exonerate",
-        "type": "CDS",
-        "start": 18000,
-        "end": 18800,
-        "score": null,
-        "strand": "+",
-        "phase": "0",
-        "attributes": {
-          "Parent": [
-            "rna-Apple3"
-          ]
-        },
-        "featureId": "c2c756d1-efbc-48e0-a5d0-0e5318e004fd"
-      }
-    ],
-    [
-      {
-        "seq_id": "ctgA",
-        "source": "exonerate",
-        "type": "CDS",
-        "start": 19000,
-        "end": 19500,
-        "score": null,
-        "strand": "+",
-        "phase": "1",
-        "attributes": {
-          "Parent": [
-            "rna-Apple3"
-          ]
-        },
-        "featureId": "186f049d-13f2-4dac-9644-bc0943c209b6"
-      }
-    ],
-    [
-      {
-        "seq_id": "ctgA",
-        "source": "exonerate",
-        "type": "CDS",
-        "start": 21000,
-        "end": 21200,
-        "score": null,
-        "strand": "+",
-        "phase": "2",
-        "attributes": {
-          "Parent": [
-            "rna-Apple3"
-          ]
-        },
-        "featureId": "7c1c4995-763a-4a61-866f-163f6bbe7577"
-      }
-    ],
-    [
-      {
-        "seq_id": "ctgA",
-        "source": "exonerate",
-        "type": "UTR",
-        "start": 21201,
-        "end": 23000,
-        "score": null,
-        "strand": "+",
-        "phase": null,
-        "attributes": {
-          "Parent": [
-            "rna-Apple3"
-          ]
-        },
-        "featureId": "92f236ed-90c6-4aaf-a606-9be98b0912bf"
-      }
-    ]
-  ],
-  "derived_features": [],
-  "attributes": {
-    "ID": [
-      "rna-Apple3"
-    ],
-    "Name": [
-      "Apple3"
-    ],
-    "Note": [
-      "mRNA with both CDSs and UTRs"
-    ]
-  },
-  "phase": null,
-  "strand": "+",
-  "score": null,
-  "end": 23000,
-  "start": 17400,
-  "type": "mRNA",
-  "source": "exonerate",
-  "seq_id": "ctgA",
-  "featureId": "5caea88b-1386-4479-a980-8e0a95335483",
-  "featureIds": [
-    "5caea88b-1386-4479-a980-8e0a95335483",
-    "4ffdf6f8-bb10-4777-834b-4a5cc8886bca",
-    "c2c756d1-efbc-48e0-a5d0-0e5318e004fd",
-    "186f049d-13f2-4dac-9644-bc0943c209b6",
-    "7c1c4995-763a-4a61-866f-163f6bbe7577",
-    "92f236ed-90c6-4aaf-a606-9be98b0912bf"
-  ],
-  "refSeq": {
-    "$oid": "624ab4c0f8ac0187ed22b563"
-  },
-  "__v": 0
+	"_id": {
+		"$oid": "63124b59f3968c7457745853"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745853"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "contig",
+	"start": 1,
+	"end": 50001,
+	"discontinuousLocations": [],
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"ctgA"
+		],
+		"multivalue": [
+			"val1",
+			"val2",
+			"val3"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745854"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745854"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "remark",
+	"start": 1000,
+	"end": 2000,
+	"discontinuousLocations": [],
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"Remark:hga"
+		],
+		"alias": [
+			"hga"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745855"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745855"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "protein_coding_primary_transcript",
+	"start": 1100,
+	"end": 2000,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"Gene:hga"
+		],
+		"alias": [
+			"hga"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745856"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745856"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "polypeptide",
+	"start": 1200,
+	"end": 1900,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"Protein:HGA"
+		],
+		"alias": [
+			"hga"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745857"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745857"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "protein_coding_primary_transcript",
+	"start": 1600,
+	"end": 3000,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"Gene:hgb"
+		],
+		"alias": [
+			"hgb"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745858"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745858"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "remark",
+	"start": 1659,
+	"end": 1984,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"f07"
+		],
+		"note": [
+			"This is an example"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745859"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745859"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "polypeptide",
+	"start": 1800,
+	"end": 2900,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"Protein:HGB"
+		],
+		"alias": [
+			"hgb"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774585a"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774585a"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "remark",
+	"start": 3014,
+	"end": 6130,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"f06"
+		],
+		"note": [
+			"This is another example"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774585b"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774585b"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "remark",
+	"start": 4715,
+	"end": 5968,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"f05"
+		],
+		"note": [
+			"Ok! Ok! I get the message."
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774585c"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774585c"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 5233,
+	"end": 5302,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg04"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774585d"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774585d"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 5800,
+	"end": 6101,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg04"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774585e"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774585e"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 6442,
+	"end": 6854,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg04"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774585f"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774585f"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 6885,
+	"end": 7241,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg03"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745860"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745860"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 7106,
+	"end": 7211,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg04"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745861"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745861"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 7410,
+	"end": 7737,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg03"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745862"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745862"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 7695,
+	"end": 8177,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg04"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745863"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745863"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 8055,
+	"end": 8080,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg03"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745864"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745864"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 8306,
+	"end": 8999,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg03"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745865"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745865"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 8545,
+	"end": 8783,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg04"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745866"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745866"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 8869,
+	"end": 8935,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg04"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745867"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745867"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 9404,
+	"end": 9825,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg04"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745868"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745868"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "CDS",
+	"start": 10000,
+	"end": 11500,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"phase": 0,
+	"attributes": {
+		"source": [
+			"bare_predicted"
+		],
+		"name": [
+			"Apple1"
+		],
+		"note": [
+			"CDS with no parent"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745869"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745869"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "polypeptide_domain",
+	"start": 11911,
+	"end": 15561,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"m11"
+		],
+		"note": [
+			"kinase"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774586a"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774586a"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 12531,
+	"end": 12895,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg12"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774586b"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774586b"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 13122,
+	"end": 13449,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg12"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774586c"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774586c"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "remark",
+	"start": 13280,
+	"end": 16394,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"f08"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774586d"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774586d"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 13452,
+	"end": 13745,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg12"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774586e"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774586e"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "polypeptide_domain",
+	"start": 13801,
+	"end": 14007,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"m05"
+		],
+		"note": [
+			"helix loop helix"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774586f"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774586f"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 13908,
+	"end": 13965,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg12"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745870"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745870"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 13998,
+	"end": 14488,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg12"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745871"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745871"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 14564,
+	"end": 14899,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg12"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745872"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745872"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "polypeptide_domain",
+	"start": 14731,
+	"end": 17239,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"m14"
+		],
+		"note": [
+			"kinase"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745873"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745873"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 15185,
+	"end": 15276,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg12"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745874"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745874"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "remark",
+	"start": 15329,
+	"end": 15533,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"f10"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745875"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745875"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "polypeptide_domain",
+	"start": 15396,
+	"end": 16159,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"m03"
+		],
+		"note": [
+			"zinc finger"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745876"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745876"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 15639,
+	"end": 15736,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg12"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745877"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745877"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 15745,
+	"end": 15870,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg12"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745878"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745878"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "polypeptide_domain",
+	"start": 17023,
+	"end": 17675,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"m08"
+		],
+		"note": [
+			"7-transmembrane"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745879"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745879"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "polypeptide_domain",
+	"start": 17667,
+	"end": 17690,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"m13"
+		],
+		"note": [
+			"DEAD box"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774587a"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774587a"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "polypeptide_domain",
+	"start": 18048,
+	"end": 18552,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"m07"
+		],
+		"note": [
+			"7-transmembrane"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774587b"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774587b"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 18509,
+	"end": 18985,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg08"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774587c"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774587c"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 18989,
+	"end": 19388,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg08"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774587d"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774587d"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "remark",
+	"start": 19157,
+	"end": 22915,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"f13"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774587e"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774587e"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 19249,
+	"end": 19559,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg06"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774587f"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774587f"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 19496,
+	"end": 19962,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg08"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745880"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745880"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 19975,
+	"end": 20260,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg06"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745881"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745881"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 20093,
+	"end": 20580,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg08"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745882"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745882"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 20379,
+	"end": 20491,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg06"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745883"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745883"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 20533,
+	"end": 21005,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg06"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745884"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745884"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 20970,
+	"end": 21052,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg08"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745885"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745885"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 21122,
+	"end": 21331,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg06"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745886"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745886"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 21270,
+	"end": 21277,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg08"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745887"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745887"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 21682,
+	"end": 22176,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg06"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745888"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745888"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 21685,
+	"end": 22168,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg08"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745889"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745889"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "polypeptide_domain",
+	"start": 21748,
+	"end": 25612,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"m12"
+		],
+		"note": [
+			"kinase"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774588a"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774588a"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "remark",
+	"start": 22132,
+	"end": 24633,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"f15"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774588b"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774588b"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 22374,
+	"end": 22570,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg06"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774588c"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774588c"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 22564,
+	"end": 22869,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg08"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774588d"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774588d"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 22958,
+	"end": 23298,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg08"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774588e"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774588e"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 23025,
+	"end": 23427,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg06"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774588f"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774588f"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "remark",
+	"start": 23072,
+	"end": 23185,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"f14"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745890"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745890"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 23412,
+	"end": 23469,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg08"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745891"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745891"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 23932,
+	"end": 23932,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg08"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745892"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745892"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 24228,
+	"end": 24510,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg11"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745893"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745893"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 24328,
+	"end": 24787,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg08"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745894"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745894"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "remark",
+	"start": 24562,
+	"end": 28338,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"f02"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745895"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745895"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 24868,
+	"end": 25012,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg11"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745896"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745896"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 25212,
+	"end": 25426,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg11"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745897"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745897"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 25228,
+	"end": 25367,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg08"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745898"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745898"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 25794,
+	"end": 25874,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg11"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745899"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745899"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 26075,
+	"end": 26519,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg11"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774589a"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774589a"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 26122,
+	"end": 26126,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg02"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774589b"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774589b"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 26497,
+	"end": 26869,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg02"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774589c"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774589c"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 26503,
+	"end": 26799,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg05"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774589d"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774589d"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 26930,
+	"end": 26940,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg11"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774589e"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774589e"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 26975,
+	"end": 27063,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg11"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774589f"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774589f"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 27172,
+	"end": 27185,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg05"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458a0"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458a0"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 27201,
+	"end": 27325,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg02"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458a1"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458a1"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 27372,
+	"end": 27433,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg02"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458a2"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458a2"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 27415,
+	"end": 27799,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg11"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458a3"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458a3"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 27448,
+	"end": 27860,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg05"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458a4"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458a4"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 27565,
+	"end": 27565,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg02"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458a5"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458a5"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 27813,
+	"end": 28091,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg02"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458a6"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458a6"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 27880,
+	"end": 27943,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg11"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458a7"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458a7"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 27887,
+	"end": 28076,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg05"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458a8"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458a8"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 28093,
+	"end": 28201,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg02"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458a9"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458a9"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 28225,
+	"end": 28316,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg05"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458aa"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458aa"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 28225,
+	"end": 28346,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg11"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458ab"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458ab"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 28329,
+	"end": 28377,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg02"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458ac"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458ac"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "polypeptide_domain",
+	"start": 28332,
+	"end": 30033,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"m02"
+		],
+		"note": [
+			"HOX"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458ad"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458ad"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "polypeptide_domain",
+	"start": 28342,
+	"end": 28447,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"m10"
+		],
+		"note": [
+			"DEAD box"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458ae"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458ae"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 28375,
+	"end": 28570,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg11"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458af"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458af"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 28758,
+	"end": 29041,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg11"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458b0"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458b0"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 28777,
+	"end": 29058,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg05"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458b1"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458b1"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 28829,
+	"end": 29194,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg02"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458b2"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458b2"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 29101,
+	"end": 29302,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg11"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458b3"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458b3"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 29513,
+	"end": 29647,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg05"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458b4"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458b4"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 29517,
+	"end": 29702,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg02"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458b5"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458b5"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 29604,
+	"end": 29702,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg11"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458b6"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458b6"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 29713,
+	"end": 30061,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg02"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458b7"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458b7"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 29771,
+	"end": 29942,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg10"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458b8"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458b8"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 29867,
+	"end": 29885,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg11"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458b9"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458b9"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 30042,
+	"end": 30340,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg10"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458ba"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458ba"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 30108,
+	"end": 30216,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg05"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458bb"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458bb"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 30241,
+	"end": 30246,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg11"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458bc"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458bc"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 30329,
+	"end": 30774,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg02"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458bd"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458bd"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 30465,
+	"end": 30798,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg05"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458be"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458be"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 30575,
+	"end": 30738,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg11"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458bf"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458bf"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "polypeptide_domain",
+	"start": 30578,
+	"end": 31748,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"m06"
+		],
+		"note": [
+			"SUSHI repeat"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458c0"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458c0"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 30808,
+	"end": 31306,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg02"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458c1"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458c1"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 30810,
+	"end": 31307,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg10"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458c2"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458c2"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 31232,
+	"end": 31236,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg05"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458c3"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458c3"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 31421,
+	"end": 31817,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg05"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458c4"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458c4"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 31516,
+	"end": 31729,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg02"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458c5"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458c5"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 31753,
+	"end": 32154,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg02"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458c6"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458c6"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 31761,
+	"end": 31984,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg10"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458c7"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458c7"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 32010,
+	"end": 32057,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg05"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458c8"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458c8"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 32208,
+	"end": 32680,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg05"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458c9"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458c9"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 32329,
+	"end": 32359,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg01"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458ca"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458ca"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 32374,
+	"end": 32937,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg10"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458cb"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458cb"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 32595,
+	"end": 32696,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg02"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458cc"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458cc"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 32892,
+	"end": 32901,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg02"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458cd"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458cd"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 33053,
+	"end": 33325,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg05"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458ce"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458ce"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 33127,
+	"end": 33388,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg02"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458cf"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458cf"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "polypeptide_domain",
+	"start": 33325,
+	"end": 35791,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"m04"
+		],
+		"note": [
+			"Ig-like"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458d0"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458d0"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 33438,
+	"end": 33868,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg05"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458d1"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458d1"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 33439,
+	"end": 33443,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg02"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458d2"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458d2"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 33759,
+	"end": 34209,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg02"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458d3"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458d3"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 34244,
+	"end": 34313,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg05"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458d4"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458d4"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 34401,
+	"end": 34466,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg02"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458d5"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458d5"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 34605,
+	"end": 34983,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg05"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458d6"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458d6"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 35333,
+	"end": 35507,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg05"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458d7"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458d7"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 35642,
+	"end": 35904,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg05"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458d8"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458d8"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "remark",
+	"start": 36034,
+	"end": 38167,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"f09"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458d9"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458d9"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 36616,
+	"end": 37057,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg09"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458da"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458da"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "remark",
+	"start": 36649,
+	"end": 40440,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"f03"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458db"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458db"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 37208,
+	"end": 37227,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg09"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458dc"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458dc"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "remark",
+	"start": 37242,
+	"end": 38653,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"f04"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458dd"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458dd"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "polypeptide_domain",
+	"start": 37497,
+	"end": 40559,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"m15"
+		],
+		"note": [
+			"7-transmembrane"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458de"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458de"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 39265,
+	"end": 39361,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg15"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458df"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458df"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 39753,
+	"end": 40034,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg15"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458e0"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458e0"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 40515,
+	"end": 40954,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg15"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458e1"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458e1"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 41137,
+	"end": 41318,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg14"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458e2"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458e2"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 41252,
+	"end": 41365,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg15"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458e3"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458e3"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 41492,
+	"end": 41504,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg15"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458e4"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458e4"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 41754,
+	"end": 41948,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg14"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458e5"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458e5"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 41941,
+	"end": 42377,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg15"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458e6"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458e6"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 42057,
+	"end": 42474,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg14"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458e7"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458e7"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 42748,
+	"end": 42954,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg15"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458e8"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458e8"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 42890,
+	"end": 43270,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg14"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458e9"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458e9"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 43395,
+	"end": 43811,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg14"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458ea"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458ea"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 43401,
+	"end": 43897,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg15"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458eb"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458eb"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 44043,
+	"end": 44113,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg15"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458ec"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458ec"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 44065,
+	"end": 44556,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg14"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458ed"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458ed"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 44191,
+	"end": 44514,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg07"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458ee"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458ee"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 44399,
+	"end": 44888,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg15"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458ef"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458ef"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 44552,
+	"end": 45043,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg07"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458f0"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458f0"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "remark",
+	"start": 44705,
+	"end": 47713,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"f01"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458f1"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458f1"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 44763,
+	"end": 45030,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg14"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458f2"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458f2"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 45231,
+	"end": 45488,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg14"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458f3"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458f3"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 45281,
+	"end": 45375,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg15"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458f4"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458f4"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 45373,
+	"end": 45600,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg07"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458f5"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458f5"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 45711,
+	"end": 46041,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg15"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458f6"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458f6"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 45790,
+	"end": 46022,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg14"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458f7"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458f7"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 45897,
+	"end": 46315,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg07"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458f8"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458f8"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "polypeptide_domain",
+	"start": 46012,
+	"end": 48851,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"m09"
+		],
+		"note": [
+			"kinase"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458f9"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458f9"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 46092,
+	"end": 46318,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg14"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458fa"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458fa"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 46425,
+	"end": 46564,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg15"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458fb"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458fb"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 46491,
+	"end": 46890,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg07"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458fc"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458fc"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 46738,
+	"end": 47087,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg15"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458fd"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458fd"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 46816,
+	"end": 46992,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg14"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458fe"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458fe"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "remark",
+	"start": 46990,
+	"end": 48410,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"f11"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c74577458ff"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c74577458ff"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 47126,
+	"end": 47297,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg07"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745900"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745900"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 47329,
+	"end": 47595,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg15"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745901"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745901"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 47449,
+	"end": 47829,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg14"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745902"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745902"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 47735,
+	"end": 47983,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg07"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745903"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745903"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 47858,
+	"end": 47979,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg15"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745904"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745904"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 48169,
+	"end": 48453,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg15"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745905"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745905"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "polypeptide_domain",
+	"start": 48253,
+	"end": 48366,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"m01"
+		],
+		"note": [
+			"WD40"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745906"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745906"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 48447,
+	"end": 48709,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg07"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745907"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745907"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 48931,
+	"end": 49186,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg07"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745908"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745908"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 49406,
+	"end": 49476,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg13"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745909"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745909"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 49472,
+	"end": 49699,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg07"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774590a"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774590a"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "remark",
+	"start": 49758,
+	"end": 50000,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"f12"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774590b"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774590b"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 49762,
+	"end": 50000,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg13"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774590c"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774590c"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 49957,
+	"end": 50000,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg07"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774590d"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774590d"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "match",
+	"start": 49957,
+	"end": 50000,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"seg07"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774590e"
+	},
+	"refSeq": {
+		"$oid": "624ab4d1f8ac0187ed22b566"
+	},
+	"allIds": [
+		"63124b59f3968c745774590e"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgB",
+	"type": "contig",
+	"start": 1,
+	"end": 6079,
+	"discontinuousLocations": [],
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"ctgB"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774590f"
+	},
+	"refSeq": {
+		"$oid": "624ab4d1f8ac0187ed22b566"
+	},
+	"allIds": [
+		"63124b59f3968c745774590f"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgB",
+	"type": "remark",
+	"start": 1659,
+	"end": 1984,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"f07"
+		],
+		"note": [
+			"This is an example"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745910"
+	},
+	"refSeq": {
+		"$oid": "624ab4d1f8ac0187ed22b566"
+	},
+	"allIds": [
+		"63124b59f3968c7457745910"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgB",
+	"type": "remark",
+	"start": 3014,
+	"end": 6130,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"f06"
+		],
+		"note": [
+			"This is another example"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745911"
+	},
+	"refSeq": {
+		"$oid": "624ab4d1f8ac0187ed22b566"
+	},
+	"allIds": [
+		"63124b59f3968c7457745911"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgB",
+	"type": "remark",
+	"start": 4715,
+	"end": 5968,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"name": [
+			"f05"
+		],
+		"note": [
+			"ああ、この機能は、世界中を旅しています！"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745912"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745912",
+		"63124b59f3968c7457745913",
+		"63124b59f3968c7457745914"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "BAC",
+	"start": 1000,
+	"end": 20000,
+	"discontinuousLocations": [],
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"id": [
+			"b101.2"
+		],
+		"name": [
+			"b101.2"
+		],
+		"note": [
+			"Fingerprinted BAC with end reads"
+		]
+	},
+	"children": {
+		"63124b59f3968c7457745913": {
+			"refSeq": {
+				"$oid": "624ab4c0f8ac0187ed22b563"
+			},
+			"allIds": [],
+			"assemblyName": "changeme",
+			"refName": "ctgA",
+			"type": "clone_start",
+			"start": 1000,
+			"end": 1500,
+			"discontinuousLocations": [],
+			"strand": 1,
+			"attributes": {
+				"source": [
+					"example"
+				]
+			},
+			"_id": {
+				"$oid": "63124b59f3968c7457745913"
+			}
+		},
+		"63124b59f3968c7457745914": {
+			"refSeq": {
+				"$oid": "624ab4c0f8ac0187ed22b563"
+			},
+			"allIds": [],
+			"assemblyName": "changeme",
+			"refName": "ctgA",
+			"type": "clone_end",
+			"start": 19500,
+			"end": 20000,
+			"discontinuousLocations": [],
+			"strand": -1,
+			"attributes": {
+				"source": [
+					"example"
+				]
+			},
+			"_id": {
+				"$oid": "63124b59f3968c7457745914"
+			}
+		}
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745915"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745915"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "SNP",
+	"start": 1000,
+	"end": 1000,
+	"discontinuousLocations": [],
+	"score": 0.987,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"id": [
+			"FakeSNP1"
+		],
+		"name": [
+			"FakeSNP"
+		],
+		"note": [
+			"This is a fake SNP that should appear at 1000 with length 1"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745916"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745916",
+		"63124b59f3968c7457745917",
+		"63124b59f3968c7457745918"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "EST_match",
+	"start": 1050,
+	"end": 3202,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"est"
+		],
+		"id": [
+			"Match1"
+		],
+		"name": [
+			"agt830.5"
+		],
+		"target": [
+			"agt830.5 1 654"
+		]
+	},
+	"children": {
+		"63124b59f3968c7457745917": {
+			"refSeq": {
+				"$oid": "624ab4c0f8ac0187ed22b563"
+			},
+			"allIds": [],
+			"assemblyName": "changeme",
+			"refName": "ctgA",
+			"type": "match_part",
+			"start": 1050,
+			"end": 1500,
+			"discontinuousLocations": [],
+			"strand": 1,
+			"attributes": {
+				"source": [
+					"est"
+				],
+				"name": [
+					"agt830.5"
+				],
+				"target": [
+					"agt830.5 1 451"
+				]
+			},
+			"_id": {
+				"$oid": "63124b59f3968c7457745917"
+			}
+		},
+		"63124b59f3968c7457745918": {
+			"refSeq": {
+				"$oid": "624ab4c0f8ac0187ed22b563"
+			},
+			"allIds": [],
+			"assemblyName": "changeme",
+			"refName": "ctgA",
+			"type": "match_part",
+			"start": 3000,
+			"end": 3202,
+			"discontinuousLocations": [],
+			"strand": 1,
+			"attributes": {
+				"source": [
+					"est"
+				],
+				"name": [
+					"agt830.5"
+				],
+				"target": [
+					"agt830.5 452 654"
+				]
+			},
+			"_id": {
+				"$oid": "63124b59f3968c7457745918"
+			}
+		}
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745919"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745919",
+		"63124b59f3968c745774591a",
+		"63124b59f3968c745774591b",
+		"63124b59f3968c745774591c"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "EST_match",
+	"start": 1050,
+	"end": 7300,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"est"
+		],
+		"id": [
+			"Match3"
+		],
+		"name": [
+			"agt221.5"
+		],
+		"target": [
+			"agt221.5 1 1253"
+		]
+	},
+	"children": {
+		"63124b59f3968c745774591a": {
+			"refSeq": {
+				"$oid": "624ab4c0f8ac0187ed22b563"
+			},
+			"allIds": [],
+			"assemblyName": "changeme",
+			"refName": "ctgA",
+			"type": "match_part",
+			"start": 1050,
+			"end": 1500,
+			"discontinuousLocations": [],
+			"strand": 1,
+			"attributes": {
+				"source": [
+					"est"
+				],
+				"name": [
+					"agt221.5"
+				],
+				"target": [
+					"agt221.5 1 451"
+				]
+			},
+			"_id": {
+				"$oid": "63124b59f3968c745774591a"
+			}
+		},
+		"63124b59f3968c745774591b": {
+			"refSeq": {
+				"$oid": "624ab4c0f8ac0187ed22b563"
+			},
+			"allIds": [],
+			"assemblyName": "changeme",
+			"refName": "ctgA",
+			"type": "match_part",
+			"start": 5000,
+			"end": 5500,
+			"discontinuousLocations": [],
+			"strand": 1,
+			"attributes": {
+				"source": [
+					"est"
+				],
+				"name": [
+					"agt221.5"
+				],
+				"target": [
+					"agt221.5 452 952"
+				]
+			},
+			"_id": {
+				"$oid": "63124b59f3968c745774591b"
+			}
+		},
+		"63124b59f3968c745774591c": {
+			"refSeq": {
+				"$oid": "624ab4c0f8ac0187ed22b563"
+			},
+			"allIds": [],
+			"assemblyName": "changeme",
+			"refName": "ctgA",
+			"type": "match_part",
+			"start": 7000,
+			"end": 7300,
+			"discontinuousLocations": [],
+			"strand": 1,
+			"attributes": {
+				"source": [
+					"est"
+				],
+				"name": [
+					"agt221.5"
+				],
+				"target": [
+					"agt221.5 953 1253"
+				]
+			},
+			"_id": {
+				"$oid": "63124b59f3968c745774591c"
+			}
+		}
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774591d"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774591d",
+		"63124b59f3968c745774591e",
+		"63124b59f3968c745774591f",
+		"63124b59f3968c7457745920",
+		"63124b59f3968c7457745921",
+		"63124b59f3968c7457745922",
+		"63124b59f3968c7457745923",
+		"63124b59f3968c7457745924",
+		"63124b59f3968c7457745925",
+		"63124b59f3968c7457745926",
+		"63124b59f3968c7457745927",
+		"63124b59f3968c7457745928",
+		"63124b59f3968c7457745929",
+		"63124b59f3968c745774592a",
+		"63124b59f3968c745774592b",
+		"63124b59f3968c745774592c",
+		"63124b59f3968c745774592d",
+		"63124b59f3968c745774592e",
+		"63124b59f3968c745774592f",
+		"63124b59f3968c7457745930",
+		"63124b59f3968c7457745931"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "gene",
+	"start": 1050,
+	"end": 9000,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"example"
+		],
+		"id": [
+			"EDEN"
+		],
+		"name": [
+			"EDEN"
+		],
+		"note": [
+			"protein kinase"
+		]
+	},
+	"children": {
+		"63124b59f3968c745774591e": {
+			"refSeq": {
+				"$oid": "624ab4c0f8ac0187ed22b563"
+			},
+			"allIds": [],
+			"assemblyName": "changeme",
+			"refName": "ctgA",
+			"type": "mRNA",
+			"start": 1050,
+			"end": 9000,
+			"discontinuousLocations": [],
+			"strand": 1,
+			"attributes": {
+				"source": [
+					"example"
+				],
+				"id": [
+					"EDEN.1"
+				],
+				"name": [
+					"EDEN.1"
+				],
+				"note": [
+					"Eden splice form 1"
+				],
+				"index": [
+					"1"
+				]
+			},
+			"_id": {
+				"$oid": "63124b59f3968c745774591e"
+			},
+			"children": {
+				"63124b59f3968c745774591f": {
+					"refSeq": {
+						"$oid": "624ab4c0f8ac0187ed22b563"
+					},
+					"allIds": [],
+					"assemblyName": "changeme",
+					"refName": "ctgA",
+					"type": "five_prime_UTR",
+					"start": 1050,
+					"end": 1200,
+					"discontinuousLocations": [],
+					"strand": 1,
+					"attributes": {
+						"source": [
+							"example"
+						]
+					},
+					"_id": {
+						"$oid": "63124b59f3968c745774591f"
+					}
+				},
+				"63124b59f3968c7457745920": {
+					"refSeq": {
+						"$oid": "624ab4c0f8ac0187ed22b563"
+					},
+					"allIds": [],
+					"assemblyName": "changeme",
+					"refName": "ctgA",
+					"type": "CDS",
+					"start": 1201,
+					"end": 1500,
+					"discontinuousLocations": [],
+					"strand": 1,
+					"phase": 0,
+					"attributes": {
+						"source": [
+							"example"
+						]
+					},
+					"_id": {
+						"$oid": "63124b59f3968c7457745920"
+					}
+				},
+				"63124b59f3968c7457745921": {
+					"refSeq": {
+						"$oid": "624ab4c0f8ac0187ed22b563"
+					},
+					"allIds": [],
+					"assemblyName": "changeme",
+					"refName": "ctgA",
+					"type": "CDS",
+					"start": 3000,
+					"end": 3902,
+					"discontinuousLocations": [],
+					"strand": 1,
+					"phase": 0,
+					"attributes": {
+						"source": [
+							"example"
+						]
+					},
+					"_id": {
+						"$oid": "63124b59f3968c7457745921"
+					}
+				},
+				"63124b59f3968c7457745922": {
+					"refSeq": {
+						"$oid": "624ab4c0f8ac0187ed22b563"
+					},
+					"allIds": [],
+					"assemblyName": "changeme",
+					"refName": "ctgA",
+					"type": "CDS",
+					"start": 5000,
+					"end": 5500,
+					"discontinuousLocations": [],
+					"strand": 1,
+					"phase": 0,
+					"attributes": {
+						"source": [
+							"example"
+						]
+					},
+					"_id": {
+						"$oid": "63124b59f3968c7457745922"
+					}
+				},
+				"63124b59f3968c7457745923": {
+					"refSeq": {
+						"$oid": "624ab4c0f8ac0187ed22b563"
+					},
+					"allIds": [],
+					"assemblyName": "changeme",
+					"refName": "ctgA",
+					"type": "CDS",
+					"start": 7000,
+					"end": 7608,
+					"discontinuousLocations": [],
+					"strand": 1,
+					"phase": 0,
+					"attributes": {
+						"source": [
+							"example"
+						]
+					},
+					"_id": {
+						"$oid": "63124b59f3968c7457745923"
+					}
+				},
+				"63124b59f3968c7457745924": {
+					"refSeq": {
+						"$oid": "624ab4c0f8ac0187ed22b563"
+					},
+					"allIds": [],
+					"assemblyName": "changeme",
+					"refName": "ctgA",
+					"type": "three_prime_UTR",
+					"start": 7609,
+					"end": 9000,
+					"discontinuousLocations": [],
+					"strand": 1,
+					"attributes": {
+						"source": [
+							"example"
+						]
+					},
+					"_id": {
+						"$oid": "63124b59f3968c7457745924"
+					}
+				}
+			}
+		},
+		"63124b59f3968c7457745925": {
+			"refSeq": {
+				"$oid": "624ab4c0f8ac0187ed22b563"
+			},
+			"allIds": [],
+			"assemblyName": "changeme",
+			"refName": "ctgA",
+			"type": "mRNA",
+			"start": 1050,
+			"end": 9000,
+			"discontinuousLocations": [],
+			"strand": 1,
+			"attributes": {
+				"source": [
+					"example"
+				],
+				"id": [
+					"EDEN.2"
+				],
+				"name": [
+					"EDEN.2"
+				],
+				"note": [
+					"Eden splice form 2"
+				],
+				"index": [
+					"1"
+				]
+			},
+			"_id": {
+				"$oid": "63124b59f3968c7457745925"
+			},
+			"children": {
+				"63124b59f3968c7457745926": {
+					"refSeq": {
+						"$oid": "624ab4c0f8ac0187ed22b563"
+					},
+					"allIds": [],
+					"assemblyName": "changeme",
+					"refName": "ctgA",
+					"type": "five_prime_UTR",
+					"start": 1050,
+					"end": 1200,
+					"discontinuousLocations": [],
+					"strand": 1,
+					"attributes": {
+						"source": [
+							"example"
+						]
+					},
+					"_id": {
+						"$oid": "63124b59f3968c7457745926"
+					}
+				},
+				"63124b59f3968c7457745927": {
+					"refSeq": {
+						"$oid": "624ab4c0f8ac0187ed22b563"
+					},
+					"allIds": [],
+					"assemblyName": "changeme",
+					"refName": "ctgA",
+					"type": "CDS",
+					"start": 1201,
+					"end": 1500,
+					"discontinuousLocations": [],
+					"strand": 1,
+					"phase": 0,
+					"attributes": {
+						"source": [
+							"example"
+						]
+					},
+					"_id": {
+						"$oid": "63124b59f3968c7457745927"
+					}
+				},
+				"63124b59f3968c7457745928": {
+					"refSeq": {
+						"$oid": "624ab4c0f8ac0187ed22b563"
+					},
+					"allIds": [],
+					"assemblyName": "changeme",
+					"refName": "ctgA",
+					"type": "CDS",
+					"start": 5000,
+					"end": 5500,
+					"discontinuousLocations": [],
+					"strand": 1,
+					"phase": 0,
+					"attributes": {
+						"source": [
+							"example"
+						]
+					},
+					"_id": {
+						"$oid": "63124b59f3968c7457745928"
+					}
+				},
+				"63124b59f3968c7457745929": {
+					"refSeq": {
+						"$oid": "624ab4c0f8ac0187ed22b563"
+					},
+					"allIds": [],
+					"assemblyName": "changeme",
+					"refName": "ctgA",
+					"type": "CDS",
+					"start": 7000,
+					"end": 7608,
+					"discontinuousLocations": [],
+					"strand": 1,
+					"phase": 0,
+					"attributes": {
+						"source": [
+							"example"
+						]
+					},
+					"_id": {
+						"$oid": "63124b59f3968c7457745929"
+					}
+				},
+				"63124b59f3968c745774592a": {
+					"refSeq": {
+						"$oid": "624ab4c0f8ac0187ed22b563"
+					},
+					"allIds": [],
+					"assemblyName": "changeme",
+					"refName": "ctgA",
+					"type": "three_prime_UTR",
+					"start": 7609,
+					"end": 9000,
+					"discontinuousLocations": [],
+					"strand": 1,
+					"attributes": {
+						"source": [
+							"example"
+						]
+					},
+					"_id": {
+						"$oid": "63124b59f3968c745774592a"
+					}
+				}
+			}
+		},
+		"63124b59f3968c745774592b": {
+			"refSeq": {
+				"$oid": "624ab4c0f8ac0187ed22b563"
+			},
+			"allIds": [],
+			"assemblyName": "changeme",
+			"refName": "ctgA",
+			"type": "mRNA",
+			"start": 1300,
+			"end": 9000,
+			"discontinuousLocations": [],
+			"strand": 1,
+			"attributes": {
+				"source": [
+					"example"
+				],
+				"id": [
+					"EDEN.3"
+				],
+				"name": [
+					"EDEN.3"
+				],
+				"note": [
+					"Eden splice form 3"
+				],
+				"index": [
+					"1"
+				]
+			},
+			"_id": {
+				"$oid": "63124b59f3968c745774592b"
+			},
+			"children": {
+				"63124b59f3968c745774592c": {
+					"refSeq": {
+						"$oid": "624ab4c0f8ac0187ed22b563"
+					},
+					"allIds": [],
+					"assemblyName": "changeme",
+					"refName": "ctgA",
+					"type": "five_prime_UTR",
+					"start": 1300,
+					"end": 1500,
+					"discontinuousLocations": [],
+					"strand": 1,
+					"attributes": {
+						"source": [
+							"example"
+						]
+					},
+					"_id": {
+						"$oid": "63124b59f3968c745774592c"
+					}
+				},
+				"63124b59f3968c745774592d": {
+					"refSeq": {
+						"$oid": "624ab4c0f8ac0187ed22b563"
+					},
+					"allIds": [],
+					"assemblyName": "changeme",
+					"refName": "ctgA",
+					"type": "five_prime_UTR",
+					"start": 3000,
+					"end": 3300,
+					"discontinuousLocations": [],
+					"strand": 1,
+					"attributes": {
+						"source": [
+							"example"
+						]
+					},
+					"_id": {
+						"$oid": "63124b59f3968c745774592d"
+					}
+				},
+				"63124b59f3968c745774592e": {
+					"refSeq": {
+						"$oid": "624ab4c0f8ac0187ed22b563"
+					},
+					"allIds": [],
+					"assemblyName": "changeme",
+					"refName": "ctgA",
+					"type": "CDS",
+					"start": 3301,
+					"end": 3902,
+					"discontinuousLocations": [],
+					"strand": 1,
+					"phase": 0,
+					"attributes": {
+						"source": [
+							"example"
+						]
+					},
+					"_id": {
+						"$oid": "63124b59f3968c745774592e"
+					}
+				},
+				"63124b59f3968c745774592f": {
+					"refSeq": {
+						"$oid": "624ab4c0f8ac0187ed22b563"
+					},
+					"allIds": [],
+					"assemblyName": "changeme",
+					"refName": "ctgA",
+					"type": "CDS",
+					"start": 5000,
+					"end": 5500,
+					"discontinuousLocations": [],
+					"strand": 1,
+					"phase": 1,
+					"attributes": {
+						"source": [
+							"example"
+						]
+					},
+					"_id": {
+						"$oid": "63124b59f3968c745774592f"
+					}
+				},
+				"63124b59f3968c7457745930": {
+					"refSeq": {
+						"$oid": "624ab4c0f8ac0187ed22b563"
+					},
+					"allIds": [],
+					"assemblyName": "changeme",
+					"refName": "ctgA",
+					"type": "CDS",
+					"start": 7000,
+					"end": 7600,
+					"discontinuousLocations": [],
+					"strand": 1,
+					"phase": 1,
+					"attributes": {
+						"source": [
+							"example"
+						]
+					},
+					"_id": {
+						"$oid": "63124b59f3968c7457745930"
+					}
+				},
+				"63124b59f3968c7457745931": {
+					"refSeq": {
+						"$oid": "624ab4c0f8ac0187ed22b563"
+					},
+					"allIds": [],
+					"assemblyName": "changeme",
+					"refName": "ctgA",
+					"type": "three_prime_UTR",
+					"start": 7601,
+					"end": 9000,
+					"discontinuousLocations": [],
+					"strand": 1,
+					"attributes": {
+						"source": [
+							"example"
+						]
+					},
+					"_id": {
+						"$oid": "63124b59f3968c7457745931"
+					}
+				}
+			}
+		}
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745932"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745932",
+		"63124b59f3968c7457745933",
+		"63124b59f3968c7457745934",
+		"63124b59f3968c7457745935"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "EST_match",
+	"start": 1150,
+	"end": 7200,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"est"
+		],
+		"id": [
+			"Match5"
+		],
+		"name": [
+			"agt767.5"
+		],
+		"target": [
+			"agt767.5 1 1153"
+		]
+	},
+	"children": {
+		"63124b59f3968c7457745933": {
+			"refSeq": {
+				"$oid": "624ab4c0f8ac0187ed22b563"
+			},
+			"allIds": [],
+			"assemblyName": "changeme",
+			"refName": "ctgA",
+			"type": "match_part",
+			"start": 1150,
+			"end": 1500,
+			"discontinuousLocations": [],
+			"strand": 1,
+			"attributes": {
+				"source": [
+					"est"
+				],
+				"name": [
+					"agt767.5"
+				],
+				"target": [
+					"agt767.5 1 351"
+				]
+			},
+			"_id": {
+				"$oid": "63124b59f3968c7457745933"
+			}
+		},
+		"63124b59f3968c7457745934": {
+			"refSeq": {
+				"$oid": "624ab4c0f8ac0187ed22b563"
+			},
+			"allIds": [],
+			"assemblyName": "changeme",
+			"refName": "ctgA",
+			"type": "match_part",
+			"start": 5000,
+			"end": 5500,
+			"discontinuousLocations": [],
+			"strand": 1,
+			"attributes": {
+				"source": [
+					"est"
+				],
+				"name": [
+					"agt767.5"
+				],
+				"target": [
+					"agt767.5 352 852"
+				]
+			},
+			"_id": {
+				"$oid": "63124b59f3968c7457745934"
+			}
+		},
+		"63124b59f3968c7457745935": {
+			"refSeq": {
+				"$oid": "624ab4c0f8ac0187ed22b563"
+			},
+			"allIds": [],
+			"assemblyName": "changeme",
+			"refName": "ctgA",
+			"type": "match_part",
+			"start": 7000,
+			"end": 7200,
+			"discontinuousLocations": [],
+			"strand": 1,
+			"attributes": {
+				"source": [
+					"est"
+				],
+				"name": [
+					"agt767.5"
+				],
+				"target": [
+					"agt767.5 853 1153"
+				]
+			},
+			"_id": {
+				"$oid": "63124b59f3968c7457745935"
+			}
+		}
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745936"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745936",
+		"63124b59f3968c7457745937",
+		"63124b59f3968c7457745938"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "EST_match",
+	"start": 5410,
+	"end": 7503,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"est"
+		],
+		"id": [
+			"Match2"
+		],
+		"name": [
+			"agt830.3"
+		],
+		"target": [
+			"agt830.3 1 595"
+		]
+	},
+	"children": {
+		"63124b59f3968c7457745937": {
+			"refSeq": {
+				"$oid": "624ab4c0f8ac0187ed22b563"
+			},
+			"allIds": [],
+			"assemblyName": "changeme",
+			"refName": "ctgA",
+			"type": "match_part",
+			"start": 5410,
+			"end": 5500,
+			"discontinuousLocations": [],
+			"strand": -1,
+			"attributes": {
+				"source": [
+					"est"
+				],
+				"name": [
+					"agt830.3"
+				],
+				"target": [
+					"agt830.3 505 595"
+				]
+			},
+			"_id": {
+				"$oid": "63124b59f3968c7457745937"
+			}
+		},
+		"63124b59f3968c7457745938": {
+			"refSeq": {
+				"$oid": "624ab4c0f8ac0187ed22b563"
+			},
+			"allIds": [],
+			"assemblyName": "changeme",
+			"refName": "ctgA",
+			"type": "match_part",
+			"start": 7000,
+			"end": 7503,
+			"discontinuousLocations": [],
+			"strand": -1,
+			"attributes": {
+				"source": [
+					"est"
+				],
+				"name": [
+					"agt830.3"
+				],
+				"target": [
+					"agt830.3 1 504"
+				]
+			},
+			"_id": {
+				"$oid": "63124b59f3968c7457745938"
+			}
+		}
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c7457745939"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c7457745939"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "EST_match",
+	"start": 7500,
+	"end": 8000,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"est"
+		],
+		"id": [
+			"Match4"
+		],
+		"name": [
+			"agt221.3"
+		],
+		"target": [
+			"agt221.3 1 501"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774593a"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774593a"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "EST_match",
+	"start": 8000,
+	"end": 9000,
+	"discontinuousLocations": [],
+	"strand": -1,
+	"attributes": {
+		"source": [
+			"est"
+		],
+		"id": [
+			"Match6"
+		],
+		"name": [
+			"agt767.3"
+		],
+		"target": [
+			"agt767.3 1 1001"
+		]
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774593b"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774593b",
+		"63124b59f3968c745774593c",
+		"63124b59f3968c745774593d",
+		"63124b59f3968c745774593e"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "mRNA",
+	"start": 13000,
+	"end": 17200,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"phase": 0,
+	"attributes": {
+		"source": [
+			"predicted"
+		],
+		"id": [
+			"cds-Apple2"
+		],
+		"name": [
+			"Apple2"
+		],
+		"note": [
+			"mRNA with CDSs but no UTRs"
+		]
+	},
+	"children": {
+		"63124b59f3968c745774593c": {
+			"refSeq": {
+				"$oid": "624ab4c0f8ac0187ed22b563"
+			},
+			"allIds": [],
+			"assemblyName": "changeme",
+			"refName": "ctgA",
+			"type": "CDS",
+			"start": 13500,
+			"end": 13800,
+			"discontinuousLocations": [],
+			"strand": 1,
+			"phase": 0,
+			"attributes": {
+				"source": [
+					"predicted"
+				]
+			},
+			"_id": {
+				"$oid": "63124b59f3968c745774593c"
+			}
+		},
+		"63124b59f3968c745774593d": {
+			"refSeq": {
+				"$oid": "624ab4c0f8ac0187ed22b563"
+			},
+			"allIds": [],
+			"assemblyName": "changeme",
+			"refName": "ctgA",
+			"type": "CDS",
+			"start": 15000,
+			"end": 15500,
+			"discontinuousLocations": [],
+			"strand": 1,
+			"phase": 1,
+			"attributes": {
+				"source": [
+					"predicted"
+				]
+			},
+			"_id": {
+				"$oid": "63124b59f3968c745774593d"
+			}
+		},
+		"63124b59f3968c745774593e": {
+			"refSeq": {
+				"$oid": "624ab4c0f8ac0187ed22b563"
+			},
+			"allIds": [],
+			"assemblyName": "changeme",
+			"refName": "ctgA",
+			"type": "CDS",
+			"start": 16500,
+			"end": 17000,
+			"discontinuousLocations": [],
+			"strand": 1,
+			"phase": 2,
+			"attributes": {
+				"source": [
+					"predicted"
+				]
+			},
+			"_id": {
+				"$oid": "63124b59f3968c745774593e"
+			}
+		}
+	},
+	"__v": 0
+},
+{
+	"_id": {
+		"$oid": "63124b59f3968c745774593f"
+	},
+	"refSeq": {
+		"$oid": "624ab4c0f8ac0187ed22b563"
+	},
+	"allIds": [
+		"63124b59f3968c745774593f",
+		"63124b59f3968c7457745940",
+		"63124b59f3968c7457745941",
+		"63124b59f3968c7457745942",
+		"63124b59f3968c7457745943",
+		"63124b59f3968c7457745944"
+	],
+	"assemblyName": "changeme",
+	"refName": "ctgA",
+	"type": "mRNA",
+	"start": 17400,
+	"end": 23000,
+	"discontinuousLocations": [],
+	"strand": 1,
+	"attributes": {
+		"source": [
+			"exonerate"
+		],
+		"id": [
+			"rna-Apple3"
+		],
+		"name": [
+			"Apple3"
+		],
+		"note": [
+			"mRNA with both CDSs and UTRs"
+		]
+	},
+	"children": {
+		"63124b59f3968c7457745940": {
+			"refSeq": {
+				"$oid": "624ab4c0f8ac0187ed22b563"
+			},
+			"allIds": [],
+			"assemblyName": "changeme",
+			"refName": "ctgA",
+			"type": "UTR",
+			"start": 17400,
+			"end": 17999,
+			"discontinuousLocations": [],
+			"strand": 1,
+			"attributes": {
+				"source": [
+					"exonerate"
+				]
+			},
+			"_id": {
+				"$oid": "63124b59f3968c7457745940"
+			}
+		},
+		"63124b59f3968c7457745941": {
+			"refSeq": {
+				"$oid": "624ab4c0f8ac0187ed22b563"
+			},
+			"allIds": [],
+			"assemblyName": "changeme",
+			"refName": "ctgA",
+			"type": "CDS",
+			"start": 18000,
+			"end": 18800,
+			"discontinuousLocations": [],
+			"strand": 1,
+			"phase": 0,
+			"attributes": {
+				"source": [
+					"exonerate"
+				]
+			},
+			"_id": {
+				"$oid": "63124b59f3968c7457745941"
+			}
+		},
+		"63124b59f3968c7457745942": {
+			"refSeq": {
+				"$oid": "624ab4c0f8ac0187ed22b563"
+			},
+			"allIds": [],
+			"assemblyName": "changeme",
+			"refName": "ctgA",
+			"type": "CDS",
+			"start": 19000,
+			"end": 19500,
+			"discontinuousLocations": [],
+			"strand": 1,
+			"phase": 1,
+			"attributes": {
+				"source": [
+					"exonerate"
+				]
+			},
+			"_id": {
+				"$oid": "63124b59f3968c7457745942"
+			}
+		},
+		"63124b59f3968c7457745943": {
+			"refSeq": {
+				"$oid": "624ab4c0f8ac0187ed22b563"
+			},
+			"allIds": [],
+			"assemblyName": "changeme",
+			"refName": "ctgA",
+			"type": "CDS",
+			"start": 21000,
+			"end": 21200,
+			"discontinuousLocations": [],
+			"strand": 1,
+			"phase": 2,
+			"attributes": {
+				"source": [
+					"exonerate"
+				]
+			},
+			"_id": {
+				"$oid": "63124b59f3968c7457745943"
+			}
+		},
+		"63124b59f3968c7457745944": {
+			"refSeq": {
+				"$oid": "624ab4c0f8ac0187ed22b563"
+			},
+			"allIds": [],
+			"assemblyName": "changeme",
+			"refName": "ctgA",
+			"type": "UTR",
+			"start": 21201,
+			"end": 23000,
+			"discontinuousLocations": [],
+			"strand": 1,
+			"attributes": {
+				"source": [
+					"exonerate"
+				]
+			},
+			"_id": {
+				"$oid": "63124b59f3968c7457745944"
+			}
+		}
+	},
+	"__v": 0
 }]
+

--- a/packages/apollo-mst/README.md
+++ b/packages/apollo-mst/README.md
@@ -1,0 +1,1 @@
+# apollo-mst

--- a/packages/apollo-mst/package.json
+++ b/packages/apollo-mst/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "apollo-mst",
+  "main": "./dist/index.js",
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@jbrowse/core": "^2.0.1",
+    "mobx": "^6.6.1",
+    "mobx-state-tree": "^5.1.5",
+    "rxjs": "^6.0.0",
+    "tslib": "^2.3.1"
+  },
+  "devDependencies": {
+    "typescript": "^4.7.4"
+  },
+  "packageManager": "yarn@3.2.2.",
+  "private": true
+}

--- a/packages/apollo-mst/src/AnnotationFeature.ts
+++ b/packages/apollo-mst/src/AnnotationFeature.ts
@@ -2,6 +2,7 @@ import { findParentThatIs } from '@jbrowse/core/util'
 import {
   IAnyType,
   Instance,
+  SnapshotIn,
   SnapshotOrInstance,
   cast,
   types,
@@ -465,9 +466,15 @@ export const AnnotationFeature = types
   }))
 
 export type AnnotationFeatureI = Instance<typeof AnnotationFeature>
+export type AnnotationFeatureSnapshot = SnapshotIn<typeof AnnotationFeature>
 export type AnnotationFeatureLocationI = Instance<
+  typeof AnnotationFeatureLocation
+>
+export type AnnotationFeatureLocationSnapshot = SnapshotIn<
   typeof AnnotationFeatureLocation
 >
 
 export const FeatureMap = types.map(AnnotationFeatureLocation)
 export const FeaturesForRefName = types.map(FeatureMap)
+export type FeaturesForRefNameI = Instance<typeof FeaturesForRefName>
+export type FeaturesForRefNameSnapshot = SnapshotIn<typeof FeaturesForRefName>

--- a/packages/apollo-mst/src/AnnotationFeature.ts
+++ b/packages/apollo-mst/src/AnnotationFeature.ts
@@ -1,6 +1,6 @@
 import { findParentThatIs } from '@jbrowse/core/util'
 import {
-  IAnyType,
+  IAnyModelType,
   Instance,
   SnapshotIn,
   SnapshotOrInstance,
@@ -8,36 +8,59 @@ import {
   types,
 } from 'mobx-state-tree'
 
-export function isAnnotationFeatureLocationModel(
+export function isAnnotationFeatureModel(
   thing: unknown,
-): thing is AnnotationFeatureLocationI {
+): thing is AnnotationFeatureI {
   return (
     typeof thing === 'object' &&
     thing !== null &&
     'type' in thing &&
-    (thing as AnnotationFeatureLocationI).type === 'AnnotationFeatureLocation'
+    (thing as AnnotationFeatureI).type === 'AnnotationFeatureLocation'
   )
 }
 
 export const LateAnnotationFeature = types.late(
-  (): IAnyType => AnnotationFeature,
+  (): IAnyModelType => AnnotationFeature,
 )
 
-export const AnnotationFeatureLocation = types
-  .model('AnnotationFeatureLocation', {
-    id: types.identifier,
-    type: types.optional(
-      types.literal('AnnotationFeatureLocation'),
-      'AnnotationFeatureLocation',
-    ),
-    assemblyName: types.string,
+export const AnnotationFeature = types
+  .model('AnnotationFeature', {
+    _id: types.identifier,
+    /** Reference sequence name */
     refName: types.string,
+    /** Feature type */
+    type: types.string,
+    /** Feature location start coordinate */
     start: types.number,
+    /** Feature location end coordinate */
     end: types.number,
-    strand: types.maybe(types.enumeration('Strand', ['+', '-'])),
-    children: types.maybe(types.map(LateAnnotationFeature)),
-    name: types.maybe(types.string),
-    featureType: types.maybe(types.string),
+    /**
+     * If the feature exists in multiple places, e.g. a CDS in a canonical SO
+     * gene, this gives the coordinates of the individual starts and ends. The
+     * start of the first location and the end of the last location should match
+     * the feature's start and end.
+     */
+    discontinuousLocations: types.maybe(
+      types.array(types.model({ start: types.number, end: types.number })),
+    ),
+    /** The strand on which the feature is located */
+    strand: types.maybe(types.union(types.literal(1), types.literal(-1))),
+    /** The feature's score */
+    score: types.maybe(types.number),
+    /**
+     * The feature's phase, which is required for certain features, e.g. CDS in a
+     * canonical SO gene
+     */
+    phase: types.maybe(
+      types.union(types.literal(0), types.literal(1), types.literal(2)),
+    ),
+    /** Child features of this feature */
+    children: types.maybe(types.map(types.maybe(LateAnnotationFeature))),
+    /**
+     * Additional attributes of the feature. This could include name, source,
+     * note, dbxref, etc.
+     */
+    attributes: types.map(types.array(types.string)),
   })
   .views((self) => ({
     get length() {
@@ -51,9 +74,7 @@ export const AnnotationFeatureLocation = types
     get min() {
       let min = self.start
       self.children?.forEach((child: AnnotationFeatureI) => {
-        child.locations.forEach((childLocation) => {
-          min = Math.min(min, childLocation.min)
-        })
+        min = Math.min(min, child.min)
       })
       return min
     },
@@ -65,16 +86,14 @@ export const AnnotationFeatureLocation = types
     get max() {
       let max = self.end
       self.children?.forEach((child: AnnotationFeatureI) => {
-        child.locations.forEach((childLocation) => {
-          max = Math.max(max, childLocation.max)
-        })
+        max = Math.max(max, child.max)
       })
       return max
     },
-    get featuresForRow() {
+    get featuresForRow(): typeof self[][] {
       const features = [[self]]
       if (self.children) {
-        self.children?.forEach((child) => {
+        self.children?.forEach((child: AnnotationFeatureI) => {
           features.push(...child.featuresForRow)
         })
       }
@@ -115,8 +134,8 @@ export const AnnotationFeatureLocation = types
     },
   }))
   .actions((self) => ({
-    setFeatureType(featureType: string) {
-      self.featureType = featureType
+    setType(type: string) {
+      self.type = type
     },
     setRefName(refName: string) {
       self.refName = refName
@@ -137,7 +156,7 @@ export const AnnotationFeatureLocation = types
         self.end = end
       }
     },
-    setStrand(strand?: '+' | '-') {
+    setStrand(strand?: 1 | -1) {
       self.strand = strand
     },
   }))
@@ -152,7 +171,7 @@ export const AnnotationFeatureLocation = types
       refName: string
       start: number
       end: number
-      strand?: '+' | '-'
+      strand?: 1 | -1
       children?: SnapshotOrInstance<typeof LateAnnotationFeature>
     }) {
       self.setRefName(refName)
@@ -165,9 +184,6 @@ export const AnnotationFeatureLocation = types
     },
     addChild(childFeature: SnapshotOrInstance<typeof LateAnnotationFeature>) {
       self.children?.set(childFeature.id, childFeature)
-    },
-    setFeatureType(featureType: string) {
-      self.featureType = featureType
     },
     draw(
       ctx: CanvasRenderingContext2D,
@@ -194,7 +210,7 @@ export const AnnotationFeatureLocation = types
         const width = feature.end - feature.start
         const startPx = (feature.start - self.start) / bpPerPx
         const widthPx = width / bpPerPx
-        const { rowCount } = feature as AnnotationFeatureLocationI
+        const { rowCount } = feature as AnnotationFeatureI
         if (rowCount > 1) {
           const featureHeight = rowCount * rowHeight
           ctx.fillStyle = 'rgba(255,0,0,0.25)'
@@ -217,9 +233,9 @@ export const AnnotationFeatureLocation = types
             rowHeight - 2,
           )
           ctx.fillStyle = 'black'
-          feature.featureType &&
+          feature.type &&
             ctx.fillText(
-              feature.featureType,
+              feature.type,
               xOffset + startPx + 1,
               yOffset + 11,
               widthPx - 2,
@@ -407,74 +423,25 @@ export const AnnotationFeatureLocation = types
   }))
   .views((self) => ({
     parentId() {
-      let parent: AnnotationFeatureLocationI | undefined = undefined
+      let parent: AnnotationFeatureI | undefined = undefined
       try {
-        parent = findParentThatIs(self, isAnnotationFeatureLocationModel)
+        parent = findParentThatIs(self, isAnnotationFeatureModel)
       } catch (error) {
         // pass
       }
-      return parent?.id
-    },
-  }))
-
-export const AnnotationFeature = types
-  .model('AnnotationFeature', {
-    id: types.identifier,
-    type: types.optional(
-      types.literal('AnnotationFeature'),
-      'AnnotationFeature',
-    ),
-    locations: types.map(AnnotationFeatureLocation),
-  })
-  .views((self) => ({
-    get min(): number {
-      let min: number | undefined = undefined
-      self.locations.forEach((location) => {
-        min = min === undefined ? location.min : Math.min(min, location.min)
-      })
-      if (min === undefined) {
-        throw new Error(
-          `AnnotationFeature does not have any locations: "${self.id}"`,
-        )
-      }
-      return min
-    },
-    get max(): number {
-      let max: number | undefined = undefined
-      self.locations.forEach((location) => {
-        max = max === undefined ? location.max : Math.max(max, location.max)
-      })
-      if (max === undefined) {
-        throw new Error(
-          `AnnotationFeature does not have any locations: "${self.id}"`,
-        )
-      }
-      return max
-    },
-    get featuresForRow() {
-      const features: AnnotationFeatureLocationI[][] = []
-      self.locations.forEach((location) => {
-        location.featuresForRow.forEach((row, idx) => {
-          if (idx > features.length - 1) {
-            features[idx] = []
-          }
-          features[idx].push(...(row as AnnotationFeatureLocationI[]))
-        })
-      })
-      return features
+      return parent?._id
     },
   }))
 
 export type AnnotationFeatureI = Instance<typeof AnnotationFeature>
-export type AnnotationFeatureSnapshot = SnapshotIn<typeof AnnotationFeature>
-export type AnnotationFeatureLocationI = Instance<
-  typeof AnnotationFeatureLocation
->
-export type AnnotationFeatureLocationSnapshot = SnapshotIn<
-  typeof AnnotationFeatureLocation
->
+type AnnotationFeatureSnapshotRaw = SnapshotIn<typeof AnnotationFeature>
+export interface AnnotationFeatureSnapshot
+  extends AnnotationFeatureSnapshotRaw {
+  /** Child features of this feature */
+  children?: Record<string, AnnotationFeatureSnapshot>
+}
 
-export const FeatureMap = types.map(AnnotationFeatureLocation)
+export const FeatureMap = types.map(AnnotationFeature)
 export const FeaturesForRefName = types.map(FeatureMap)
 export type FeaturesForRefNameI = Instance<typeof FeaturesForRefName>
 export type FeaturesForRefNameSnapshot = SnapshotIn<typeof FeaturesForRefName>

--- a/packages/apollo-mst/src/index.ts
+++ b/packages/apollo-mst/src/index.ts
@@ -1,0 +1,1 @@
+export * from './AnnotationFeature'

--- a/packages/apollo-mst/tsconfig.json
+++ b/packages/apollo-mst/tsconfig.json
@@ -9,10 +9,9 @@
     "lib": ["ES2020", "DOM"],
     "module": "CommonJS",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "strictPropertyInitialization": false,
   },
   "include": ["./src"],
-  "references": [
-    { "path": "../apollo-mst"},
-    { "path": "../apollo-schemas"},
-  ]
 }

--- a/packages/apollo-schemas/package.json
+++ b/packages/apollo-schemas/package.json
@@ -5,10 +5,10 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@gmod/gff": "^1.2.0",
     "@nestjs/common": "^9.0.4",
     "@nestjs/core": "^9.0.4",
     "@nestjs/mongoose": "^9.0.2",
+    "apollo-mst": "workspace:^",
     "mongoose": "^6.2.6",
     "reflect-metadata": "^0.1.13",
     "regenerator-runtime": "^0.13.9",

--- a/packages/apollo-shared/package.json
+++ b/packages/apollo-shared/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@gmod/gff": "^1.2.0",
     "@jbrowse/core": "^2.0.1",
+    "apollo-mst": "workspace:^",
     "apollo-schemas": "workspace:^",
     "bson-objectid": "^2.0.3",
     "regenerator-runtime": "^0.13.9",

--- a/packages/apollo-shared/package.json
+++ b/packages/apollo-shared/package.json
@@ -13,14 +13,12 @@
     "apollo-schemas": "workspace:^",
     "bson-objectid": "^2.0.3",
     "regenerator-runtime": "^0.13.9",
-    "tslib": "^2.3.1",
-    "uuid": "^8.3.2"
+    "tslib": "^2.3.1"
   },
   "devDependencies": {
     "@nestjs/common": "^9.0.4",
     "@types/node": "^16.0.0",
     "@types/rimraf": "^3",
-    "@types/uuid": "^8",
     "mobx-state-tree": "^5.1.5",
     "mongoose": "^6.2.10",
     "rimraf": "^3.0.2",

--- a/packages/apollo-shared/src/BackendDrivers/BackendDriver.ts
+++ b/packages/apollo-shared/src/BackendDrivers/BackendDriver.ts
@@ -1,5 +1,5 @@
 import { Region } from '@jbrowse/core/util'
-import { AnnotationFeatureLocationSnapshot } from 'apollo-mst'
+import { AnnotationFeatureSnapshot } from 'apollo-mst'
 
 import { Change, ClientDataStore } from '../ChangeManager/Change'
 import { ValidationResultSet } from '../Validations/ValidationSet'
@@ -8,7 +8,7 @@ import { ValidationResultSet } from '../Validations/ValidationSet'
 // resolves to `any`, so this offers better typechecking.
 export type FeaturesForRefNameSnapshot = Record<
   string,
-  Record<string, AnnotationFeatureLocationSnapshot | undefined> | undefined
+  Record<string, AnnotationFeatureSnapshot | undefined> | undefined
 >
 
 export abstract class BackendDriver {

--- a/packages/apollo-shared/src/BackendDrivers/BackendDriver.ts
+++ b/packages/apollo-shared/src/BackendDrivers/BackendDriver.ts
@@ -1,16 +1,14 @@
 import { Region } from '@jbrowse/core/util'
-import { SnapshotIn } from 'mobx-state-tree'
+import { AnnotationFeatureLocationSnapshot } from 'apollo-mst'
 
 import { Change, ClientDataStore } from '../ChangeManager/Change'
 import { ValidationResultSet } from '../Validations/ValidationSet'
-import { AnnotationFeatureLocation } from './AnnotationFeature'
 
 // Doing this because `SnapshotIn<typeof FeaturesForRefName>` for some reason
 // resolves to `any`, so this offers better typechecking.
 export type FeaturesForRefNameSnapshot = Record<
   string,
-  | Record<string, SnapshotIn<typeof AnnotationFeatureLocation> | undefined>
-  | undefined
+  Record<string, AnnotationFeatureLocationSnapshot | undefined> | undefined
 >
 
 export abstract class BackendDriver {

--- a/packages/apollo-shared/src/BackendDrivers/index.ts
+++ b/packages/apollo-shared/src/BackendDrivers/index.ts
@@ -1,3 +1,2 @@
-export * from './AnnotationFeature'
 export * from './BackendDriver'
 export * from './CollaborationServerDriver'

--- a/packages/apollo-shared/src/ChangeManager/Change.ts
+++ b/packages/apollo-shared/src/ChangeManager/Change.ts
@@ -2,7 +2,7 @@ import { ReadStream } from 'fs'
 
 import { AppRootModel } from '@jbrowse/core/util'
 import {
-  AnnotationFeatureLocationI,
+  AnnotationFeatureI,
   FeaturesForRefNameI,
   FeaturesForRefNameSnapshot,
 } from 'apollo-mst'
@@ -25,7 +25,7 @@ export interface ClientDataStore extends IAnyStateTreeNode {
   backendDriver?: BackendDriver
   internetAccountConfigId?: string
   internetAccounts: AppRootModel['internetAccounts']
-  getFeature(featureId: string): AnnotationFeatureLocationI | undefined
+  getFeature(featureId: string): AnnotationFeatureI | undefined
 }
 export interface LocalGFF3DataStore {
   typeName: 'LocalGFF3'

--- a/packages/apollo-shared/src/ChangeManager/Change.ts
+++ b/packages/apollo-shared/src/ChangeManager/Change.ts
@@ -1,5 +1,11 @@
 import { ReadStream } from 'fs'
 
+import { AppRootModel } from '@jbrowse/core/util'
+import {
+  AnnotationFeatureLocationI,
+  FeaturesForRefNameI,
+  FeaturesForRefNameSnapshot,
+} from 'apollo-mst'
 import {
   AssemblyDocument,
   FeatureDocument,
@@ -7,18 +13,19 @@ import {
   RefSeqChunkDocument,
   RefSeqDocument,
 } from 'apollo-schemas'
-import { IAnyStateTreeNode, Instance, SnapshotIn } from 'mobx-state-tree'
+import { IAnyStateTreeNode } from 'mobx-state-tree'
 
-import { FeaturesForRefName } from '../BackendDrivers/AnnotationFeature'
 import { BackendDriver } from '../BackendDrivers/BackendDriver'
 import { changeRegistry } from './ChangeTypes'
 
 export interface ClientDataStore extends IAnyStateTreeNode {
   typeName: 'Client'
-  features: Instance<typeof FeaturesForRefName>
-  load(features: SnapshotIn<typeof FeaturesForRefName>): void
+  features: FeaturesForRefNameI
+  load(features: FeaturesForRefNameSnapshot): void
   backendDriver?: BackendDriver
   internetAccountConfigId?: string
+  internetAccounts: AppRootModel['internetAccounts']
+  getFeature(featureId: string): AnnotationFeatureLocationI | undefined
 }
 export interface LocalGFF3DataStore {
   typeName: 'LocalGFF3'

--- a/packages/apollo-shared/src/ChangeManager/CopyFeatureChange.ts
+++ b/packages/apollo-shared/src/ChangeManager/CopyFeatureChange.ts
@@ -1,8 +1,6 @@
 import ObjectID from 'bson-objectid'
-import { resolveIdentifier } from 'mobx-state-tree'
 import { v4 as uuidv4 } from 'uuid'
 
-import { AnnotationFeatureLocation } from '../BackendDrivers/AnnotationFeature'
 import {
   ChangeOptions,
   ClientDataStore,
@@ -154,11 +152,7 @@ export class CopyFeatureChange extends FeatureChange {
       throw new Error('No data store')
     }
     this.changedIds.forEach((changedId, idx) => {
-      const feature = resolveIdentifier(
-        AnnotationFeatureLocation,
-        dataStore.features,
-        changedId,
-      )
+      const feature = dataStore.getFeature(changedId)
       if (!feature) {
         throw new Error(`Could not find feature with identifier "${changedId}"`)
       }

--- a/packages/apollo-shared/src/ChangeManager/LocationEndChange.ts
+++ b/packages/apollo-shared/src/ChangeManager/LocationEndChange.ts
@@ -1,7 +1,5 @@
 import { FeatureDocument } from 'apollo-schemas'
-import { resolveIdentifier } from 'mobx-state-tree'
 
-import { AnnotationFeatureLocation } from '../BackendDrivers/AnnotationFeature'
 import {
   ChangeOptions,
   ClientDataStore,
@@ -150,11 +148,7 @@ export class LocationEndChange extends FeatureChange {
       throw new Error('No data store')
     }
     this.changedIds.forEach((changedId, idx) => {
-      const feature = resolveIdentifier(
-        AnnotationFeatureLocation,
-        dataStore.features,
-        changedId,
-      )
+      const feature = dataStore.getFeature(changedId)
       if (!feature) {
         throw new Error(`Could not find feature with identifier "${changedId}"`)
       }

--- a/packages/apollo-shared/src/ChangeManager/LocationStartChange.ts
+++ b/packages/apollo-shared/src/ChangeManager/LocationStartChange.ts
@@ -1,7 +1,5 @@
 import { FeatureDocument } from 'apollo-schemas'
-import { resolveIdentifier } from 'mobx-state-tree'
 
-import { AnnotationFeatureLocation } from '../BackendDrivers/AnnotationFeature'
 import {
   ChangeOptions,
   ClientDataStore,
@@ -150,11 +148,7 @@ export class LocationStartChange extends FeatureChange {
       throw new Error('No data store')
     }
     this.changedIds.forEach((changedId, idx) => {
-      const feature = resolveIdentifier(
-        AnnotationFeatureLocation,
-        dataStore.features,
-        changedId,
-      )
+      const feature = dataStore.getFeature(changedId)
       if (!feature) {
         throw new Error(`Could not find feature with identifier "${changedId}"`)
       }

--- a/packages/apollo-shared/src/ChangeManager/LocationStartChange.ts
+++ b/packages/apollo-shared/src/ChangeManager/LocationStartChange.ts
@@ -1,4 +1,5 @@
 import { FeatureDocument } from 'apollo-schemas'
+import { Feature } from 'apollo-schemas'
 
 import {
   ChangeOptions,
@@ -7,10 +8,7 @@ import {
   SerializedChange,
   ServerDataStore,
 } from './Change'
-import {
-  FeatureChange,
-  GFF3FeatureLineWithFeatureIdAndOptionalRefs,
-} from './FeatureChange'
+import { FeatureChange } from './FeatureChange'
 
 interface SerializedLocationStartChangeBase extends SerializedChange {
   typeName: 'LocationStartChange'
@@ -73,7 +71,7 @@ export class LocationStartChange extends FeatureChange {
     const { featureModel, session } = backend
     const { changes } = this
     const featuresForChanges: {
-      feature: GFF3FeatureLineWithFeatureIdAndOptionalRefs
+      feature: Feature
       topLevelFeature: FeatureDocument
     }[] = []
     // Let's first check that all features are found and those old values match with expected ones. We do this just to be sure that all changes can be done.
@@ -82,7 +80,7 @@ export class LocationStartChange extends FeatureChange {
 
       // Search correct feature
       const topLevelFeature = await featureModel
-        .findOne({ featureIds: featureId })
+        .findOne({ allIds: featureId })
         .session(session)
         .exec()
 
@@ -96,7 +94,7 @@ export class LocationStartChange extends FeatureChange {
         `*** Feature found: ${JSON.stringify(topLevelFeature)}`,
       )
 
-      const foundFeature = this.getObjectByFeatureId(topLevelFeature, featureId)
+      const foundFeature = this.getFeatureFromId(topLevelFeature, featureId)
       if (!foundFeature) {
         const errMsg = `ERROR when searching feature by featureId`
         this.logger.error(errMsg)
@@ -119,10 +117,10 @@ export class LocationStartChange extends FeatureChange {
       const { newStart } = change
       const { feature, topLevelFeature } = featuresForChanges[idx]
       feature.start = newStart
-      if (topLevelFeature.featureId === feature.featureId) {
+      if (topLevelFeature._id.equals(feature._id)) {
         topLevelFeature.markModified('start') // Mark as modified. Without this save() -method is not updating data in database
       } else {
-        topLevelFeature.markModified('child_features') // Mark as modified. Without this save() -method is not updating data in database
+        topLevelFeature.markModified('children') // Mark as modified. Without this save() -method is not updating data in database
       }
 
       try {

--- a/packages/apollo-shared/src/ChangeManager/TypeChange.ts
+++ b/packages/apollo-shared/src/ChangeManager/TypeChange.ts
@@ -1,7 +1,5 @@
 import { FeatureDocument } from 'apollo-schemas'
-import { resolveIdentifier } from 'mobx-state-tree'
 
-import { AnnotationFeatureLocation } from '../BackendDrivers/AnnotationFeature'
 import {
   ChangeOptions,
   ClientDataStore,
@@ -149,11 +147,7 @@ export class TypeChange extends FeatureChange {
       throw new Error('No data store')
     }
     this.changedIds.forEach((changedId, idx) => {
-      const feature = resolveIdentifier(
-        AnnotationFeatureLocation,
-        dataStore.features,
-        changedId,
-      )
+      const feature = dataStore.getFeature(changedId)
       if (!feature) {
         throw new Error(`Could not find feature with identifier "${changedId}"`)
       }

--- a/packages/jbrowse-plugin-apollo/package.json
+++ b/packages/jbrowse-plugin-apollo/package.json
@@ -50,7 +50,6 @@
   "dependencies": {
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
-    "@gmod/gff": "^1.2.0",
     "@jbrowse/plugin-linear-genome-view": "^2.0.1",
     "@mui/icons-material": "^5.8.4",
     "apollo-mst": "workspace:^",

--- a/packages/jbrowse-plugin-apollo/package.json
+++ b/packages/jbrowse-plugin-apollo/package.json
@@ -53,6 +53,7 @@
     "@gmod/gff": "^1.2.0",
     "@jbrowse/plugin-linear-genome-view": "^2.0.1",
     "@mui/icons-material": "^5.8.4",
+    "apollo-mst": "workspace:^",
     "apollo-shared": "workspace:^",
     "bson-objectid": "^2.0.3",
     "clsx": "^1.1.1",

--- a/packages/jbrowse-plugin-apollo/src/ApolloDetailsView/components/ApolloDetailsView.tsx
+++ b/packages/jbrowse-plugin-apollo/src/ApolloDetailsView/components/ApolloDetailsView.tsx
@@ -24,7 +24,7 @@ import { ApolloDetailsViewModel } from '../stateModel'
 const featureColums: GridColumns = [
   { field: 'id', headerName: 'ID', width: 250 },
   {
-    field: 'featureType',
+    field: 'type',
     headerName: 'Type',
     width: 250,
     editable: true,
@@ -107,28 +107,20 @@ export const ApolloDetailsView = observer(
       return <div>click on a feature to see details</div>
     }
     // const sequenceTypes = changeManager?.validations.getPossibleValues('type')
-    const { id, featureType, assemblyName, refName, start, end } =
-      selectedFeature
-    const selectedFeatureRows = [
-      { id, featureType, assemblyName, refName, start, end, model },
-    ]
+    const { _id: id, type, refName, start, end } = selectedFeature
+    const assemblyId = getAssemblyId(selectedFeature)
+    const selectedFeatureRows = [{ id, type, refName, start, end, model }]
     function addChildFeatures(f: typeof selectedFeature) {
       f?.children?.forEach((child: AnnotationFeatureI, childId: string) => {
-        child.locations.forEach((childLocation) => {
-          if (!childLocation) {
-            throw new Error(`No child with id ${childId}`)
-          }
-          selectedFeatureRows.push({
-            id: childLocation.id,
-            featureType: childLocation.featureType,
-            assemblyName: childLocation.assemblyName,
-            refName: childLocation.refName,
-            start: childLocation.start,
-            end: childLocation.end,
-            model,
-          })
-          addChildFeatures(childLocation)
+        selectedFeatureRows.push({
+          id: child._id,
+          type: child.type,
+          refName: child.refName,
+          start: child.start,
+          end: child.end,
+          model,
         })
+        addChildFeatures(child)
       })
     }
     addChildFeatures(selectedFeature)
@@ -138,13 +130,8 @@ export const ApolloDetailsView = observer(
     ) {
       let change: Change | undefined = undefined
       if (newRow.start !== oldRow.start) {
-        const {
-          start: oldStart,
-          id: featureId,
-          assemblyName: rowAssemblyName,
-        } = oldRow
+        const { start: oldStart, id: featureId } = oldRow
         const { start: newStart } = newRow
-        const assemblyId = getAssemblyId(rowAssemblyName)
         change = new LocationStartChange({
           typeName: 'LocationStartChange',
           changedIds: [featureId],
@@ -154,13 +141,8 @@ export const ApolloDetailsView = observer(
           assemblyId,
         })
       } else if (newRow.start !== oldRow.start) {
-        const {
-          end: oldEnd,
-          id: featureId,
-          assemblyName: rowAssemblyName,
-        } = oldRow
+        const { end: oldEnd, id: featureId } = oldRow
         const { end: newEnd } = newRow
-        const assemblyId = getAssemblyId(rowAssemblyName)
         change = new LocationEndChange({
           typeName: 'LocationEndChange',
           changedIds: [featureId],
@@ -169,14 +151,9 @@ export const ApolloDetailsView = observer(
           newEnd: Number(newEnd),
           assemblyId,
         })
-      } else if (newRow.featureType !== oldRow.featureType) {
-        const {
-          featureType: oldType,
-          id: featureId,
-          assemblyName: rowAssemblyName,
-        } = oldRow
-        const { featureType: newType } = newRow
-        const assemblyId = getAssemblyId(rowAssemblyName)
+      } else if (newRow.type !== oldRow.type) {
+        const { type: oldType, id: featureId } = oldRow
+        const { type: newType } = newRow
         change = new TypeChange({
           typeName: 'TypeChange',
           changedIds: [featureId],

--- a/packages/jbrowse-plugin-apollo/src/ApolloDetailsView/components/ApolloDetailsView.tsx
+++ b/packages/jbrowse-plugin-apollo/src/ApolloDetailsView/components/ApolloDetailsView.tsx
@@ -8,8 +8,8 @@ import {
   MuiBaseEvent,
   useGridApiContext,
 } from '@mui/x-data-grid'
+import { AnnotationFeatureI } from 'apollo-mst'
 import {
-  AnnotationFeatureI,
   Change,
   ChangeManager,
   LocationEndChange,

--- a/packages/jbrowse-plugin-apollo/src/ApolloDetailsView/stateModel.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloDetailsView/stateModel.ts
@@ -1,7 +1,8 @@
 import PluginManager from '@jbrowse/core/PluginManager'
 import { getContainingView, getSession } from '@jbrowse/core/util'
 import { ElementId } from '@jbrowse/core/util/types/mst'
-import { AnnotationFeatureLocationI, ChangeManager } from 'apollo-shared'
+import { AnnotationFeatureLocationI } from 'apollo-mst'
+import { ChangeManager } from 'apollo-shared'
 import { Instance, getParent, types } from 'mobx-state-tree'
 
 import { ApolloViewModel } from '../ApolloView/stateModel'

--- a/packages/jbrowse-plugin-apollo/src/ApolloDetailsView/stateModel.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloDetailsView/stateModel.ts
@@ -1,11 +1,11 @@
 import PluginManager from '@jbrowse/core/PluginManager'
-import { getContainingView, getSession } from '@jbrowse/core/util'
+import { findParentThatIs, getContainingView } from '@jbrowse/core/util'
 import { ElementId } from '@jbrowse/core/util/types/mst'
-import { AnnotationFeatureLocationI } from 'apollo-mst'
+import { AnnotationFeatureI } from 'apollo-mst'
 import { ChangeManager } from 'apollo-shared'
 import { Instance, getParent, types } from 'mobx-state-tree'
 
-import { ApolloViewModel } from '../ApolloView/stateModel'
+import { ApolloViewModel, isClientDataStore } from '../ApolloView/stateModel'
 
 export function stateModelFactory(pluginManager: PluginManager) {
   return types
@@ -14,16 +14,11 @@ export function stateModelFactory(pluginManager: PluginManager) {
       type: types.literal('ApolloDetailsView'),
     })
     .views((self) => ({
-      get selectedFeature(): AnnotationFeatureLocationI | undefined {
+      get selectedFeature(): AnnotationFeatureI | undefined {
         return getParent<ApolloViewModel>(self).selectedFeature
       },
-      getAssemblyId(assemblyName: string) {
-        const { assemblyManager } = getSession(self)
-        const assembly = assemblyManager.get(assemblyName)
-        if (!assembly) {
-          throw new Error(`Could not find assembly named ${assemblyName}`)
-        }
-        return assembly.name
+      getAssemblyId(feature: AnnotationFeatureI) {
+        return findParentThatIs(feature, isClientDataStore).assemblyId
       },
       get changeManager() {
         const apolloView = getContainingView(self)
@@ -34,7 +29,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
       },
     }))
     .actions((self) => ({
-      setSelectedFeature(feature?: AnnotationFeatureLocationI) {
+      setSelectedFeature(feature?: AnnotationFeatureI) {
         getParent<ApolloViewModel>(self).setSelectedFeature(feature)
       },
     }))

--- a/packages/jbrowse-plugin-apollo/src/ApolloRenderer/components/ApolloRendering.tsx
+++ b/packages/jbrowse-plugin-apollo/src/ApolloRenderer/components/ApolloRendering.tsx
@@ -1,11 +1,7 @@
 import { Region, getSession } from '@jbrowse/core/util'
 import { Menu, MenuItem } from '@mui/material'
-import {
-  AnnotationFeatureLocationI,
-  Change,
-  LocationEndChange,
-  LocationStartChange,
-} from 'apollo-shared'
+import { AnnotationFeatureLocationI } from 'apollo-mst'
+import { Change, LocationEndChange, LocationStartChange } from 'apollo-shared'
 import { observer } from 'mobx-react'
 import { getSnapshot } from 'mobx-state-tree'
 import React, { useEffect, useRef, useState } from 'react'

--- a/packages/jbrowse-plugin-apollo/src/ApolloRenderer/components/ApolloRendering.tsx
+++ b/packages/jbrowse-plugin-apollo/src/ApolloRenderer/components/ApolloRendering.tsx
@@ -1,6 +1,6 @@
 import { Region, getSession } from '@jbrowse/core/util'
 import { Menu, MenuItem } from '@mui/material'
-import { AnnotationFeatureLocationI } from 'apollo-mst'
+import { AnnotationFeatureI } from 'apollo-mst'
 import { Change, LocationEndChange, LocationStartChange } from 'apollo-shared'
 import { observer } from 'mobx-react'
 import { getSnapshot } from 'mobx-state-tree'
@@ -28,7 +28,7 @@ function ApolloRendering(props: ApolloRenderingProps) {
   const [overEdge, setOverEdge] = useState<'start' | 'end'>()
   const [dragging, setDragging] = useState<{
     edge: 'start' | 'end'
-    feature: AnnotationFeatureLocationI
+    feature: AnnotationFeatureI
     row: number
     bp: number
     px: number
@@ -176,7 +176,7 @@ function ApolloRendering(props: ApolloRenderingProps) {
     const bp = region.start + bpPerPx * x
     const [featureRow, feat] =
       layoutRow.find((f) => bp >= f[1].min && bp <= f[1].max) || []
-    let feature: AnnotationFeatureLocationI | undefined = feat
+    let feature: AnnotationFeatureI | undefined = feat
     if (feature && featureRow) {
       const topRow = row - featureRow
       const startPx = (feature.start - region.start) / bpPerPx
@@ -186,7 +186,7 @@ function ApolloRendering(props: ApolloRenderingProps) {
         y - topRow * height,
         bpPerPx,
         height,
-      ) as AnnotationFeatureLocationI
+      ) as AnnotationFeatureI
     }
     if (feature) {
       // TODO: check reversed
@@ -232,7 +232,7 @@ function ApolloRendering(props: ApolloRenderingProps) {
       const { feature, bp, edge } = dragging
       let change: Change
       if (edge === 'end') {
-        const featureId = feature.id
+        const featureId = feature._id
         const oldEnd = feature.end
         const newEnd = Math.round(bp)
         change = new LocationEndChange({
@@ -244,7 +244,7 @@ function ApolloRendering(props: ApolloRenderingProps) {
           assemblyId,
         })
       } else {
-        const featureId = feature.id
+        const featureId = feature._id
         const oldStart = feature.start
         const newStart = Math.round(bp)
         change = new LocationStartChange({
@@ -263,7 +263,7 @@ function ApolloRendering(props: ApolloRenderingProps) {
   }
   function onContextMenu(event: React.MouseEvent) {
     event.preventDefault()
-    setContextMenuFeatureId(apolloFeatureUnderMouse?.id)
+    setContextMenuFeatureId(apolloFeatureUnderMouse?._id)
     setContextCoord([event.pageX, event.pageY])
   }
 

--- a/packages/jbrowse-plugin-apollo/src/ApolloView/stateModel.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloView/stateModel.ts
@@ -4,8 +4,8 @@ import { MenuItem } from '@jbrowse/core/ui'
 import { AppRootModel } from '@jbrowse/core/util'
 import { LinearGenomeViewStateModel } from '@jbrowse/plugin-linear-genome-view'
 import {
-  AnnotationFeatureLocation,
-  AnnotationFeatureLocationI,
+  AnnotationFeature,
+  AnnotationFeatureI,
   FeaturesForRefName,
 } from 'apollo-mst'
 import {
@@ -25,6 +25,12 @@ import {
 
 import { ApolloDetailsViewStateModel } from '../ApolloDetailsView/stateModel'
 import { ApolloInternetAccountModel } from '../ApolloInternetAccount/model'
+
+export function isClientDataStore(
+  thing: unknown,
+): thing is Instance<typeof ClientDataStore> {
+  return (thing as Instance<typeof ClientDataStore>).typeName === 'Client'
+}
 
 export const ClientDataStore = types
   .model('ClientDataStore', {
@@ -46,11 +52,7 @@ export const ClientDataStore = types
       self.features = cast(features)
     },
     getFeature(featureId: string) {
-      return resolveIdentifier(
-        AnnotationFeatureLocation,
-        self.features,
-        featureId,
-      )
+      return resolveIdentifier(AnnotationFeature, self.features, featureId)
     },
   }))
   .volatile((self) => {
@@ -82,7 +84,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
           .stateModel as ApolloDetailsViewStateModel,
         { type: 'ApolloDetailsView' },
       ),
-      selectedFeature: types.maybe(types.reference(AnnotationFeatureLocation)),
+      selectedFeature: types.maybe(types.reference(AnnotationFeature)),
       dataStore: types.maybe(ClientDataStore),
       displayName: 'Apollo',
     })
@@ -145,7 +147,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
       setDisplayName(displayName: string) {
         self.displayName = displayName
       },
-      setSelectedFeature(feature?: AnnotationFeatureLocationI) {
+      setSelectedFeature(feature?: AnnotationFeatureI) {
         self.selectedFeature = feature
       },
     }))

--- a/packages/jbrowse-plugin-apollo/src/ApolloView/stateModel.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloView/stateModel.ts
@@ -6,13 +6,22 @@ import { LinearGenomeViewStateModel } from '@jbrowse/plugin-linear-genome-view'
 import {
   AnnotationFeatureLocation,
   AnnotationFeatureLocationI,
+  FeaturesForRefName,
+} from 'apollo-mst'
+import {
   ChangeManager,
   CollaborationServerDriver,
   CoreValidation,
-  FeaturesForRefName,
   ValidationSet,
 } from 'apollo-shared'
-import { Instance, SnapshotIn, cast, getRoot, types } from 'mobx-state-tree'
+import {
+  Instance,
+  SnapshotIn,
+  cast,
+  getRoot,
+  resolveIdentifier,
+  types,
+} from 'mobx-state-tree'
 
 import { ApolloDetailsViewStateModel } from '../ApolloDetailsView/stateModel'
 import { ApolloInternetAccountModel } from '../ApolloInternetAccount/model'
@@ -27,9 +36,21 @@ export const ClientDataStore = types
     internetAccountConfigId: types.maybe(types.string),
     assemblyId: types.string,
   })
+  .views((self) => ({
+    get internetAccounts() {
+      return (getRoot(self) as AppRootModel).internetAccounts
+    },
+  }))
   .actions((self) => ({
     load(features: SnapshotIn<typeof FeaturesForRefName>) {
       self.features = cast(features)
+    },
+    getFeature(featureId: string) {
+      return resolveIdentifier(
+        AnnotationFeatureLocation,
+        self.features,
+        featureId,
+      )
     },
   }))
   .volatile((self) => {

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel.ts
@@ -4,7 +4,7 @@ import PluginManager from '@jbrowse/core/PluginManager'
 import { getContainingView, getSession } from '@jbrowse/core/util'
 import { getParentRenderProps } from '@jbrowse/core/util/tracks'
 import { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
-import { AnnotationFeatureLocationI } from 'apollo-shared'
+import { AnnotationFeatureLocationI } from 'apollo-mst'
 import { autorun } from 'mobx'
 import { Instance, addDisposer, types } from 'mobx-state-tree'
 

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel.ts
@@ -4,7 +4,7 @@ import PluginManager from '@jbrowse/core/PluginManager'
 import { getContainingView, getSession } from '@jbrowse/core/util'
 import { getParentRenderProps } from '@jbrowse/core/util/tracks'
 import { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
-import { AnnotationFeatureLocationI } from 'apollo-mst'
+import { AnnotationFeatureI } from 'apollo-mst'
 import { autorun } from 'mobx'
 import { Instance, addDisposer, types } from 'mobx-state-tree'
 
@@ -29,9 +29,7 @@ export function stateModelFactory(
       }),
     )
     .volatile(() => ({
-      apolloFeatureUnderMouse: undefined as
-        | AnnotationFeatureLocationI
-        | undefined,
+      apolloFeatureUnderMouse: undefined as AnnotationFeatureI | undefined,
       apolloRowUnderMouse: undefined as number | undefined,
     }))
     .views((self) => {
@@ -82,7 +80,7 @@ export function stateModelFactory(
           }),
         )
       },
-      setApolloFeatureUnderMouse(feature?: AnnotationFeatureLocationI) {
+      setApolloFeatureUnderMouse(feature?: AnnotationFeatureI) {
         self.apolloFeatureUnderMouse = feature
       },
       setApolloRowUnderMouse(row?: number) {
@@ -126,15 +124,19 @@ export function stateModelFactory(
         return minMax
       },
       get featureLayout() {
-        const featureLayout: Map<
-          number,
-          [number, AnnotationFeatureLocationI][]
-        > = new Map()
+        const featureLayout: Map<number, [number, AnnotationFeatureI][]> =
+          new Map()
         for (const [refName, featuresForRefName] of this.features || []) {
           if (!featuresForRefName) {
             continue
           }
-          const [min, max] = this.featuresMinMax[refName]
+          const [min, max] = this.featuresMinMax[refName] || [
+            undefined,
+            undefined,
+          ]
+          if (min === undefined || max === undefined) {
+            continue
+          }
           const rows: boolean[][] = []
           Array.from(featuresForRefName.values())
             .sort((f1, f2) => {
@@ -142,8 +144,8 @@ export function stateModelFactory(
               const { min: start2, max: end2 } = f2
               return start1 - start2 || end1 - end2
             })
-            .forEach((featureLocation) => {
-              const { rowCount } = featureLocation
+            .forEach((feature) => {
+              const { rowCount } = feature
               let startingRow = 0
               let placed = false
               while (!placed) {
@@ -166,10 +168,7 @@ export function stateModelFactory(
                   rowsForFeature
                     .map((rowForFeature) =>
                       rowForFeature
-                        .slice(
-                          featureLocation.min - min,
-                          featureLocation.max - min,
-                        )
+                        .slice(feature.min - min, feature.max - min)
                         .some(Boolean),
                     )
                     .some(Boolean)
@@ -183,13 +182,9 @@ export function stateModelFactory(
                   rowNum++
                 ) {
                   const row = rows[rowNum]
-                  row.fill(
-                    true,
-                    featureLocation.min - min,
-                    featureLocation.max - min,
-                  )
+                  row.fill(true, feature.min - min, feature.max - min)
                   const layoutRow = featureLayout.get(rowNum)
-                  layoutRow?.push([rowNum - startingRow, featureLocation])
+                  layoutRow?.push([rowNum - startingRow, feature])
                 }
                 placed = true
               }
@@ -205,7 +200,7 @@ export function stateModelFactory(
         }
         return assembly.name
       },
-      get selectedFeature(): AnnotationFeatureLocationI | undefined {
+      get selectedFeature(): AnnotationFeatureI | undefined {
         return self.apolloView.selectedFeature
       },
       get setSelectedFeature() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4098,6 +4098,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"apollo-mst@workspace:^, apollo-mst@workspace:packages/apollo-mst":
+  version: 0.0.0-use.local
+  resolution: "apollo-mst@workspace:packages/apollo-mst"
+  dependencies:
+    "@jbrowse/core": ^2.0.1
+    mobx: ^6.6.1
+    mobx-state-tree: ^5.1.5
+    rxjs: ^6.0.0
+    tslib: ^2.3.1
+    typescript: ^4.7.4
+  languageName: unknown
+  linkType: soft
+
 "apollo-schemas@workspace:^, apollo-schemas@workspace:packages/apollo-schemas":
   version: 0.0.0-use.local
   resolution: "apollo-schemas@workspace:packages/apollo-schemas"
@@ -4126,6 +4139,7 @@ __metadata:
     "@types/node": ^16.0.0
     "@types/rimraf": ^3
     "@types/uuid": ^8
+    apollo-mst: "workspace:^"
     apollo-schemas: "workspace:^"
     bson-objectid: ^2.0.3
     mobx-state-tree: ^5.1.5
@@ -8887,6 +8901,7 @@ __metadata:
     "@types/cypress": ^1.1.3
     "@types/node": ^16.11.6
     "@types/react": ^17.0.34
+    apollo-mst: "workspace:^"
     apollo-shared: "workspace:^"
     bson-objectid: ^2.0.3
     clsx: ^1.1.1
@@ -12444,7 +12459,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:6.6.7, rxjs@npm:^6.6.0":
+"rxjs@npm:6.6.7, rxjs@npm:^6.0.0, rxjs@npm:^6.6.0":
   version: 6.6.7
   resolution: "rxjs@npm:6.6.7"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3384,13 +3384,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/uuid@npm:^8":
-  version: 8.3.4
-  resolution: "@types/uuid@npm:8.3.4"
-  checksum: 6f11f3ff70f30210edaa8071422d405e9c1d4e53abbe50fdce365150d3c698fe7bbff65c1e71ae080cbfb8fded860dbb5e174da96fdbbdfcaa3fb3daa474d20f
-  languageName: node
-  linkType: hard
-
 "@types/webidl-conversions@npm:*":
   version: 6.1.1
   resolution: "@types/webidl-conversions@npm:6.1.1"
@@ -4066,7 +4059,7 @@ __metadata:
     "@types/passport-jwt": ^3.0.6
     "@types/passport-local": ^1.0.34
     "@types/supertest": ^2.0.11
-    "@types/uuid": ^8
+    apollo-mst: "workspace:^"
     apollo-schemas: "workspace:^"
     apollo-shared: "workspace:^"
     jest: ^27.0.6
@@ -4094,7 +4087,6 @@ __metadata:
     tsconfig-paths: ^3.11.0
     tslib: ^2.3.1
     typescript: ^4.7.4
-    uuid: ^8.3.2
   languageName: unknown
   linkType: soft
 
@@ -4115,11 +4107,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "apollo-schemas@workspace:packages/apollo-schemas"
   dependencies:
-    "@gmod/gff": ^1.2.0
     "@nestjs/common": ^9.0.4
     "@nestjs/core": ^9.0.4
     "@nestjs/mongoose": ^9.0.2
     "@types/node": ^16.0.0
+    apollo-mst: "workspace:^"
     mongoose: ^6.2.6
     reflect-metadata: ^0.1.13
     regenerator-runtime: ^0.13.9
@@ -4138,7 +4130,6 @@ __metadata:
     "@nestjs/common": ^9.0.4
     "@types/node": ^16.0.0
     "@types/rimraf": ^3
-    "@types/uuid": ^8
     apollo-mst: "workspace:^"
     apollo-schemas: "workspace:^"
     bson-objectid: ^2.0.3
@@ -4148,7 +4139,6 @@ __metadata:
     rimraf: ^3.0.2
     tslib: ^2.3.1
     typescript: ^4.7.4
-    uuid: ^8.3.2
   peerDependencies:
     "@mui/material": ^5.9.1
     "@mui/x-data-grid": ^4.0.0
@@ -8890,7 +8880,6 @@ __metadata:
   dependencies:
     "@emotion/react": ^11.9.3
     "@emotion/styled": ^11.9.3
-    "@gmod/gff": ^1.2.0
     "@jbrowse/cli": ^2.0.1
     "@jbrowse/core": ^2.0.1
     "@jbrowse/development-tools": ^2.1.1


### PR DESCRIPTION
This splits some mobx-state-tree code from the `apollo-shared` package to a new `apollo-mst` package. It then makes the features in mobx-state-tree and the Mongoose schemas have the same structure so that a snapshot from MST can be loaded in to MongoDB.