### PR TITLE
Add sequence adapter for viewing and retrieving sequences

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,3 +19,5 @@ jobs:
           install-command: yarn --immutable
       - name: Lint codebase
         run: yarn eslint --report-unused-disable-directives --max-warnings 0 --ext .js,.ts,.jsx,.tsx .
+      - name: Test codebase
+        run: yarn test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   build:
-    name: Strict lint
+    name: Strict lint and test
     runs-on: ubuntu-latest
     steps:
       - name: Check out

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "start:shared": "yarn workspace apollo-shared run start",
     "start:server": "yarn workspace apollo-collaboration-server run start",
     "start:plugin": "yarn workspace jbrowse-plugin-apollo run start",
-    "start": "npm-run-all --print-label --parallel start:shared start:server start:plugin"
+    "start": "npm-run-all --print-label --parallel start:shared start:server start:plugin",
+    "test": "yarn workspace jbrowse-plugin-apollo run test"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.14.7",

--- a/packages/apollo-mst/package.json
+++ b/packages/apollo-mst/package.json
@@ -5,7 +5,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@jbrowse/core": "^2.0.1",
+    "@jbrowse/core": "^2.1.4",
     "mobx": "^6.6.1",
     "mobx-state-tree": "^5.1.5",
     "rxjs": "^6.0.0",

--- a/packages/apollo-shared/package.json
+++ b/packages/apollo-shared/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@gmod/gff": "^1.2.0",
-    "@jbrowse/core": "^2.0.1",
+    "@jbrowse/core": "^2.1.4",
     "apollo-mst": "workspace:^",
     "apollo-schemas": "workspace:^",
     "bson-objectid": "^2.0.3",

--- a/packages/jbrowse-plugin-apollo/jest.config.js
+++ b/packages/jbrowse-plugin-apollo/jest.config.js
@@ -1,0 +1,8 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testPathIgnorePatterns: ['<rootDir>/cypress/'],
+  automock: false,
+  setupFiles: ['./jestSetup.js'],
+}

--- a/packages/jbrowse-plugin-apollo/jestSetup.js
+++ b/packages/jbrowse-plugin-apollo/jestSetup.js
@@ -1,0 +1,2 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+require('jest-fetch-mock').enableMocks()

--- a/packages/jbrowse-plugin-apollo/package.json
+++ b/packages/jbrowse-plugin-apollo/package.json
@@ -55,7 +55,7 @@
     "tslib": "^2.0.3"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.1",
+    "@jbrowse/core": "^2.1.4",
     "@mui/material": "^5.9.1",
     "mobx": "^6.6.1",
     "mobx-react": "^7.2.1",
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@jbrowse/cli": "^2.0.1",
-    "@jbrowse/core": "^2.0.1",
+    "@jbrowse/core": "^2.1.4",
     "@jbrowse/development-tools": "^2.1.1",
     "@jest/globals": "^29.0.3",
     "@mui/material": "^5.9.1",

--- a/packages/jbrowse-plugin-apollo/package.json
+++ b/packages/jbrowse-plugin-apollo/package.json
@@ -42,11 +42,6 @@
   "jbrowse-plugin": {
     "name": "Apollo"
   },
-  "jest": {
-    "testPathIgnorePatterns": [
-      "<rootDir>/cypress/"
-    ]
-  },
   "dependencies": {
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
@@ -65,30 +60,41 @@
     "mobx": "^6.6.1",
     "mobx-react": "^7.2.1",
     "mobx-state-tree": "^5.1.5",
-    "react": "^17.0.2",
+    "prop-types": "^15.8.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "rxjs": "^6.5.2",
     "tss-react": "^3.7.1"
   },
   "devDependencies": {
     "@jbrowse/cli": "^2.0.1",
     "@jbrowse/core": "^2.0.1",
     "@jbrowse/development-tools": "^2.1.1",
+    "@jest/globals": "^29.0.3",
     "@mui/material": "^5.9.1",
     "@mui/x-data-grid": "^5.12.3",
     "@types/cypress": "^1.1.3",
     "@types/node": "^16.11.6",
+    "@types/prop-types": "^15",
     "@types/react": "^17.0.34",
+    "@types/react-dom": "^18",
     "cypress": "^8.7.0",
-    "jest": "^27.3.1",
+    "jest": "^29.0.3",
+    "jest-fetch-mock": "^3.0.3",
     "mobx": "^6.6.1",
     "mobx-react": "^7.2.1",
     "mobx-state-tree": "^5.1.5",
     "npm-run-all": "4.1.5",
-    "react": "^17.0.2",
+    "prop-types": "^15.8.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "rimraf": "^3.0.2",
     "rollup": "^2.59.0",
+    "rxjs": "^6.5.2",
     "serve": "^14.0.1",
     "shx": "^0.3.3",
     "start-server-and-test": "^1.11.7",
+    "ts-jest": "^29.0.0",
     "ts-node": "^10.3.0",
     "tss-react": "^3.7.1",
     "typescript": "^4.7.4"

--- a/packages/jbrowse-plugin-apollo/src/ApolloSequenceAdapter/ApolloSequenceAdapter.test.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloSequenceAdapter/ApolloSequenceAdapter.test.ts
@@ -1,0 +1,66 @@
+import { beforeAll, beforeEach, describe, expect, it } from '@jest/globals'
+import fetchMock from 'jest-fetch-mock'
+import { toArray } from 'rxjs/operators'
+
+import { ApolloSequenceAdapter, RefSeq } from './ApolloSequenceAdapter'
+import configSchema from './configSchema'
+
+const mockRefSeqs: RefSeq[] = [
+  {
+    _id: '6317dac51a89f156b2e21a70',
+    name: 'ctgA',
+    description: 'the first contig',
+    length: 10000,
+  },
+  {
+    _id: '6317dac51a89f156b2e21b7c',
+    name: 'ctgB',
+    description: 'the second contig',
+    length: 10000,
+  },
+]
+
+describe('ApolloSequenceAdapter', () => {
+  let adapter: ApolloSequenceAdapter
+  beforeAll(async () => {
+    adapter = new ApolloSequenceAdapter(
+      configSchema.create({
+        assemblyId: '6317d5436061de774b43e9d6',
+        baseURL: 'http://fake.url',
+      }),
+    )
+    // populate refSeqs cache before the tests are run
+    fetchMock.mockResponseOnce(JSON.stringify(mockRefSeqs))
+    await adapter.getRefNames({})
+  })
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+  it('can get refNames and regions', async () => {
+    const refNames = await adapter.getRefNames({})
+    expect(refNames).toEqual(mockRefSeqs.map((r) => r.name))
+    const regions = await adapter.getRegions({})
+    expect(regions).toEqual(
+      mockRefSeqs.map((r) => ({ refName: r.name, start: 0, end: r.length })),
+    )
+  })
+  it('can get features', async () => {
+    fetchMock.mockResponseOnce('GCGTGCAACAGACTTTCCATGATGCGAGCT')
+    const features = adapter.getFeatures(
+      { refName: 'ctgA', start: 0, end: 30 },
+      {},
+    )
+    const featuresArray = await features.pipe(toArray()).toPromise()
+    expect(featuresArray).toMatchInlineSnapshot(`
+      [
+        {
+          "end": 30,
+          "refName": "ctgA",
+          "seq": "GCGTGCAACAGACTTTCCATGATGCGAGCT",
+          "start": 0,
+          "uniqueId": "ctgA 0-30",
+        },
+      ]
+    `)
+  })
+})

--- a/packages/jbrowse-plugin-apollo/src/ApolloSequenceAdapter/ApolloSequenceAdapter.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloSequenceAdapter/ApolloSequenceAdapter.ts
@@ -31,7 +31,6 @@ export class ApolloSequenceAdapter extends BaseSequenceAdapter {
     const uri = new URL(`refSeqs?${searchParams.toString()}`, this.baseURL).href
     const fetch = getFetcher(
       { locationType: 'UriLocation', uri },
-      // @ts-ignore
       this.pluginManager,
     )
     const response = await fetch(uri, { signal })
@@ -95,7 +94,6 @@ export class ApolloSequenceAdapter extends BaseSequenceAdapter {
       ).href
       const fetch = getFetcher(
         { locationType: 'UriLocation', uri },
-        // @ts-ignore
         this.pluginManager,
       )
       const response = await fetch(uri, { signal: opts.signal })

--- a/packages/jbrowse-plugin-apollo/src/ApolloSequenceAdapter/ApolloSequenceAdapter.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloSequenceAdapter/ApolloSequenceAdapter.ts
@@ -1,0 +1,135 @@
+import { readConfObject } from '@jbrowse/core/configuration'
+import {
+  BaseOptions,
+  BaseSequenceAdapter,
+} from '@jbrowse/core/data_adapters/BaseAdapter'
+import { getFetcher } from '@jbrowse/core/util/io'
+import { ObservableCreate } from '@jbrowse/core/util/rxjs'
+import SimpleFeature, { Feature } from '@jbrowse/core/util/simpleFeature'
+import { NoAssemblyRegion } from '@jbrowse/core/util/types'
+
+export interface RefSeq {
+  _id: string
+  name: string
+  description: string
+  length: number
+}
+
+export class ApolloSequenceAdapter extends BaseSequenceAdapter {
+  private refSeqs: Promise<RefSeq[]> | undefined
+
+  get baseURL() {
+    return readConfObject(this.config, 'baseURL')
+  }
+
+  protected async getRefSeqs({ signal }: BaseOptions) {
+    if (this.refSeqs) {
+      return this.refSeqs
+    }
+    const assemblyId = readConfObject(this.config, 'assemblyId')
+    const searchParams = new URLSearchParams({ assembly: assemblyId })
+    const uri = new URL(`refSeqs?${searchParams.toString()}`, this.baseURL).href
+    const fetch = getFetcher(
+      { locationType: 'UriLocation', uri },
+      // @ts-ignore
+      this.pluginManager,
+    )
+    const response = await fetch(uri, { signal })
+    if (!response.ok) {
+      let errorMessage
+      try {
+        errorMessage = await response.text()
+      } catch (e) {
+        errorMessage = ''
+      }
+      throw new Error(
+        `Failed to fetch refSeqs — ${response.status} (${response.statusText})${
+          errorMessage ? ` (${errorMessage})` : ''
+        }`,
+      )
+    }
+    const refSeqs = (await response.json()) as RefSeq[]
+    this.refSeqs = Promise.resolve(refSeqs)
+    return refSeqs
+  }
+
+  public async getRefNames(opts: BaseOptions) {
+    const refSeqs = await this.getRefSeqs(opts)
+    return refSeqs.map((refSeq) => refSeq.name)
+  }
+
+  public async getRegions(opts: BaseOptions): Promise<NoAssemblyRegion[]> {
+    const refSeqs = await this.getRefSeqs(opts)
+    return refSeqs.map((refSeq) => ({
+      refName: refSeq.name,
+      start: 0,
+      end: refSeq.length,
+    }))
+  }
+
+  /**
+   * Fetch features for a certain region
+   * @param param -
+   * @returns Observable of Feature objects in the region
+   */
+  public getFeatures(
+    { refName, start, end }: NoAssemblyRegion,
+    opts: BaseOptions,
+  ) {
+    return ObservableCreate<Feature>(async (observer) => {
+      const refSeqs = await this.getRefSeqs(opts)
+      const refSeq = refSeqs.find((rs) => rs.name === refName)
+      if (!refSeq) {
+        return observer.error(
+          `Could not find refSeq that matched refName "${refName}"`,
+        )
+      }
+      const searchParams = new URLSearchParams({
+        refSeq: refSeq._id,
+        start: String(start),
+        end: String(end),
+      })
+      const uri = new URL(
+        `refSeqs/getSequence?${searchParams.toString()}`,
+        this.baseURL,
+      ).href
+      const fetch = getFetcher(
+        { locationType: 'UriLocation', uri },
+        // @ts-ignore
+        this.pluginManager,
+      )
+      const response = await fetch(uri, { signal: opts.signal })
+      if (!response.ok) {
+        let errorMessage
+        try {
+          errorMessage = await response.text()
+        } catch (e) {
+          errorMessage = ''
+        }
+        throw new Error(
+          `Failed to fetch refSeqs — ${response.status} (${
+            response.statusText
+          })${errorMessage ? ` (${errorMessage})` : ''}`,
+        )
+      }
+      const seq = (await response.text()) as string
+      if (seq) {
+        observer.next(
+          new SimpleFeature({
+            id: `${refName} ${start}-${end}`,
+            data: { refName, start, end, seq },
+          }),
+        )
+      }
+      observer.complete()
+    })
+  }
+
+  /**
+   * called to provide a hint that data tied to a certain region
+   * will not be needed for the forseeable future and can be purged
+   * from caches, etc
+   */
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  public freeResources(/* { region } */): void {}
+}

--- a/packages/jbrowse-plugin-apollo/src/ApolloSequenceAdapter/configSchema.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloSequenceAdapter/configSchema.ts
@@ -1,0 +1,16 @@
+import { ConfigurationSchema } from '@jbrowse/core/configuration'
+
+export default ConfigurationSchema(
+  'ApolloSequenceAdapter',
+  {
+    assemblyId: {
+      type: 'string',
+      defaultValue: '',
+    },
+    baseURL: {
+      type: 'string',
+      defaultValue: '',
+    },
+  },
+  { explicitlyTyped: true },
+)

--- a/packages/jbrowse-plugin-apollo/src/ApolloSequenceAdapter/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloSequenceAdapter/index.ts
@@ -1,0 +1,22 @@
+import AdapterType from '@jbrowse/core/pluggableElementTypes/AdapterType'
+import PluginManager from '@jbrowse/core/PluginManager'
+
+import { ApolloSequenceAdapter } from './ApolloSequenceAdapter'
+import configSchema from './configSchema'
+
+export function installApolloSequenceAdapter(pluginManager: PluginManager) {
+  pluginManager.addAdapterType(
+    () =>
+      new AdapterType({
+        name: 'ApolloSequenceAdapter',
+        configSchema,
+        adapterMetadata: {
+          category: null,
+          hiddenFromGUI: true,
+          displayName: null,
+          description: null,
+        },
+        AdapterClass: ApolloSequenceAdapter,
+      }),
+  )
+}

--- a/packages/jbrowse-plugin-apollo/src/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/index.ts
@@ -21,6 +21,7 @@ import {
   ReactComponent as ApolloRendererReactComponent,
   configSchema as apolloRendererConfigSchema,
 } from './ApolloRenderer'
+import { installApolloSequenceAdapter } from './ApolloSequenceAdapter'
 import { AddAssembly, ImportFeatures, ViewChangeLog } from './components'
 import { DownloadGFF3 } from './components/DownloadGFF3'
 import {
@@ -39,6 +40,7 @@ export default class ApolloPlugin extends Plugin {
   version = version
 
   install(pluginManager: PluginManager) {
+    installApolloSequenceAdapter(pluginManager)
     pluginManager.addTrackType(() => {
       const configSchema = ConfigurationSchema(
         'ApolloTrack',

--- a/packages/jbrowse-plugin-apollo/src/session.ts
+++ b/packages/jbrowse-plugin-apollo/src/session.ts
@@ -235,26 +235,20 @@ export function extendSession(sessionModel: IAnyModelType) {
             const response2 = (yield fetch2(uri2, {
               signal,
             })) as unknown as Response
-            if (!response.ok) {
+            if (!response2.ok) {
               let errorMessage
               try {
-                errorMessage = yield response.text()
+                errorMessage = yield response2.text()
               } catch (e) {
                 errorMessage = ''
               }
               throw new Error(
-                `Failed to fetch fasta info — ${response.status} (${
-                  response.statusText
+                `Failed to fetch fasta info — ${response2.status} (${
+                  response2.statusText
                 })${errorMessage ? ` (${errorMessage})` : ''}`,
               )
             }
             const f = (yield response2.json()) as ApolloRefSeqResponse[]
-            const features = f.map((contig) => ({
-              refName: contig.name,
-              uniqueId: contig._id,
-              start: 0,
-              end: contig.length,
-            }))
             const refNameAliasesFeatures = f.map((contig) => ({
               refName: contig.name,
               aliases: [contig._id],
@@ -267,7 +261,11 @@ export function extendSession(sessionModel: IAnyModelType) {
               sequence: {
                 trackId: `sequenceConfigId-${assembly.name}`,
                 type: 'ReferenceSequenceTrack',
-                adapter: { type: 'FromConfigRegionsAdapter', features },
+                adapter: {
+                  type: 'ApolloSequenceAdapter',
+                  assemblyId: assembly._id,
+                  baseURL,
+                },
                 metadata: {
                   internetAccountConfigId:
                     internetAccount.configuration.internetAccountId,

--- a/packages/jbrowse-plugin-apollo/tsconfig.json
+++ b/packages/jbrowse-plugin-apollo/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "target": "ES6",
     "rootDir": "./src",
     "noEmit": true,
     "noEmitOnError": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1902,9 +1902,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jbrowse/core@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@jbrowse/core@npm:2.0.1"
+"@jbrowse/core@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "@jbrowse/core@npm:2.1.4"
   dependencies:
     "@babel/runtime": ^7.17.9
     "@mui/icons-material": ^5.0.1
@@ -1920,7 +1920,7 @@ __metadata:
     dompurify: ^2.3.4
     escape-html: ^1.0.3
     fast-deep-equal: ^3.1.3
-    generic-filehandle: ^2.2.2
+    generic-filehandle: ^3.0.0
     http-range-fetcher: ^1.4.0
     is-object: ^1.0.1
     jexl: ^2.3.0
@@ -1945,7 +1945,7 @@ __metadata:
     react-dom: ">=16.8.0"
     rxjs: ^6.0.0
     tss-react: ^3.0.0
-  checksum: e239f628b86a372f9525eaa68b918ffb26b151f2440ca2d2fcffb551ee244f11b6d07e76e74f17c570c7645067d4f3631462ef0df17fbde9086e3e8ff0003755
+  checksum: b306e1c1b524127a32ee4f6e2627505f31b2b690dacac5c76b1fbdef2a6ffe277f56ef2be9f8322dabb5785646b9b71339f8a5be25ee3ba2b0811d2498da3b44
   languageName: node
   linkType: hard
 
@@ -4517,7 +4517,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "apollo-mst@workspace:packages/apollo-mst"
   dependencies:
-    "@jbrowse/core": ^2.0.1
+    "@jbrowse/core": ^2.1.4
     mobx: ^6.6.1
     mobx-state-tree: ^5.1.5
     rxjs: ^6.0.0
@@ -4549,7 +4549,7 @@ __metadata:
   resolution: "apollo-shared@workspace:packages/apollo-shared"
   dependencies:
     "@gmod/gff": ^1.2.0
-    "@jbrowse/core": ^2.0.1
+    "@jbrowse/core": ^2.1.4
     "@nestjs/common": ^9.0.4
     "@types/node": ^16.0.0
     "@types/rimraf": ^3
@@ -7885,7 +7885,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"file-uri-to-path@npm:2, file-uri-to-path@npm:^2.0.0":
+"file-uri-to-path@npm:2":
   version: 2.0.0
   resolution: "file-uri-to-path@npm:2.0.0"
   checksum: 4a71a99ddaa6ae7ae7bffe2948c34da59982ed465d930a0af9cb59fcc10fcd93366cc356ec3337c18373fde5df7ac52afda4558f155febd1799d135552207edb
@@ -8238,13 +8238,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"generic-filehandle@npm:^2.2.2":
-  version: 2.2.3
-  resolution: "generic-filehandle@npm:2.2.3"
+"generic-filehandle@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "generic-filehandle@npm:3.0.0"
   dependencies:
     es6-promisify: ^6.1.1
-    file-uri-to-path: ^2.0.0
-  checksum: 9f04c7c078c1d2a674fcac77507630a91f66dbd9e84eaf74cee47e71012cde19e9051c9b3653d4f631adc3574860a5c3637b2e29734444edaf23120c4f0419a8
+  checksum: cd2a193e0783e105c8301d70b00098051b5e8f5b181cfe644e9417f3f849e7d72f8e72aaeec192377c18b95a7d9c715812c2aff7782b8297478551f38d5bb8e4
   languageName: node
   linkType: hard
 
@@ -9381,7 +9380,7 @@ __metadata:
     "@emotion/react": ^11.9.3
     "@emotion/styled": ^11.9.3
     "@jbrowse/cli": ^2.0.1
-    "@jbrowse/core": ^2.0.1
+    "@jbrowse/core": ^2.1.4
     "@jbrowse/development-tools": ^2.1.1
     "@jbrowse/plugin-linear-genome-view": ^2.0.1
     "@jest/globals": ^29.0.3
@@ -9420,7 +9419,7 @@ __metadata:
     tss-react: ^3.7.1
     typescript: ^4.7.4
   peerDependencies:
-    "@jbrowse/core": ^2.0.1
+    "@jbrowse/core": ^2.1.4
     "@mui/material": ^5.9.1
     mobx: ^6.6.1
     mobx-react: ^7.2.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -134,6 +134,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/compat-data@npm:^7.19.0":
+  version: 7.19.0
+  resolution: "@babel/compat-data@npm:7.19.0"
+  checksum: f90d25a3779578c230ad0632e12ffd5ee1033614dee2786f7f1567823a78923da7185638eedd7166f31e4771a3398ae6a28ab8e680b96cc25bafb38a3b66ff11
+  languageName: node
+  linkType: hard
+
 "@babel/core@npm:^7.1.0, @babel/core@npm:^7.12.3, @babel/core@npm:^7.16.0, @babel/core@npm:^7.2.2, @babel/core@npm:^7.7.2, @babel/core@npm:^7.8.0":
   version: 7.18.9
   resolution: "@babel/core@npm:7.18.9"
@@ -154,6 +161,29 @@ __metadata:
     json5: ^2.2.1
     semver: ^6.3.0
   checksum: 64b9088b03fdf659b334864ef93bed85d60c17b27fcbd72970f8eb9e0d3266ffa5a1926960f648f2db36b0bafec615f947ea5117d200599a0661b9f0a9cdf323
+  languageName: node
+  linkType: hard
+
+"@babel/core@npm:^7.11.6":
+  version: 7.19.0
+  resolution: "@babel/core@npm:7.19.0"
+  dependencies:
+    "@ampproject/remapping": ^2.1.0
+    "@babel/code-frame": ^7.18.6
+    "@babel/generator": ^7.19.0
+    "@babel/helper-compilation-targets": ^7.19.0
+    "@babel/helper-module-transforms": ^7.19.0
+    "@babel/helpers": ^7.19.0
+    "@babel/parser": ^7.19.0
+    "@babel/template": ^7.18.10
+    "@babel/traverse": ^7.19.0
+    "@babel/types": ^7.19.0
+    convert-source-map: ^1.7.0
+    debug: ^4.1.0
+    gensync: ^1.0.0-beta.2
+    json5: ^2.2.1
+    semver: ^6.3.0
+  checksum: 0d5b52b552e215802d2fd7b266611c390d90b28dece09db8a142666c32928c5d404eb72a95630b4cb726c4d80a53fcdc2d6464cd7ad28bb26087475f1b2205e2
   languageName: node
   linkType: hard
 
@@ -179,6 +209,17 @@ __metadata:
     "@jridgewell/gen-mapping": ^0.3.2
     jsesc: ^2.5.1
   checksum: 1c271e0c6f33e59f7845d88a1b0b9b0dce88164e80dec9274a716efa54c260e405e9462b160843e73f45382bf5b24d8e160e0121207e480c29b30e2ed0eb16d4
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:^7.19.0":
+  version: 7.19.0
+  resolution: "@babel/generator@npm:7.19.0"
+  dependencies:
+    "@babel/types": ^7.19.0
+    "@jridgewell/gen-mapping": ^0.3.2
+    jsesc: ^2.5.1
+  checksum: aa3d5785cf8f8e81672dcc61aef351188efeadb20d9f66d79113d82cbcf3bbbdeb829989fa14582108572ddbc4e4027bdceb06ccaf5ec40fa93c2dda8fbcd4aa
   languageName: node
   linkType: hard
 
@@ -212,6 +253,20 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 2a9d71e124e098a9f45de4527ddd1982349d231827d341e00da9dfb967e260ecc7662c8b62abee4a010fb34d5f07a8d2155c974e0bc1928144cee5644910621d
+  languageName: node
+  linkType: hard
+
+"@babel/helper-compilation-targets@npm:^7.19.0":
+  version: 7.19.0
+  resolution: "@babel/helper-compilation-targets@npm:7.19.0"
+  dependencies:
+    "@babel/compat-data": ^7.19.0
+    "@babel/helper-validator-option": ^7.18.6
+    browserslist: ^4.20.2
+    semver: ^6.3.0
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 5f1be9811d53a5e43eb4b9b402517dec79bfa3a55e9fbc131a106914a78b435bc08a4b35591e424665c36c2c1eceb864ec2ca2c2f3dcf240a1551a28530428f9
   languageName: node
   linkType: hard
 
@@ -306,6 +361,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-function-name@npm:^7.19.0":
+  version: 7.19.0
+  resolution: "@babel/helper-function-name@npm:7.19.0"
+  dependencies:
+    "@babel/template": ^7.18.10
+    "@babel/types": ^7.19.0
+  checksum: eac1f5db428ba546270c2b8d750c24eb528b8fcfe50c81de2e0bdebf0e20f24bec688d4331533b782e4a907fad435244621ca2193cfcf80a86731299840e0f6e
+  languageName: node
+  linkType: hard
+
 "@babel/helper-hoist-variables@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/helper-hoist-variables@npm:7.18.6"
@@ -346,6 +411,22 @@ __metadata:
     "@babel/traverse": ^7.18.9
     "@babel/types": ^7.18.9
   checksum: af08c60ea239ff3d40eda542fceaab69de17e713f131e80ead08c975ba7a47dd55d439cb48cfb14ae7ec96704a10c989ff5a5240e52a39101cb44a49467ce058
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-transforms@npm:^7.19.0":
+  version: 7.19.0
+  resolution: "@babel/helper-module-transforms@npm:7.19.0"
+  dependencies:
+    "@babel/helper-environment-visitor": ^7.18.9
+    "@babel/helper-module-imports": ^7.18.6
+    "@babel/helper-simple-access": ^7.18.6
+    "@babel/helper-split-export-declaration": ^7.18.6
+    "@babel/helper-validator-identifier": ^7.18.6
+    "@babel/template": ^7.18.10
+    "@babel/traverse": ^7.19.0
+    "@babel/types": ^7.19.0
+  checksum: 4483276c66f56cf3b5b063634092ad9438c2593725de5c143ba277dda82f1501e6d73b311c1b28036f181dbe36eaeff29f24726cde37a599d4e735af294e5359
   languageName: node
   linkType: hard
 
@@ -419,6 +500,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-string-parser@npm:^7.18.10":
+  version: 7.18.10
+  resolution: "@babel/helper-string-parser@npm:7.18.10"
+  checksum: d554a4393365b624916b5c00a4cc21c990c6617e7f3fe30be7d9731f107f12c33229a7a3db9d829bfa110d2eb9f04790745d421640e3bd245bb412dc0ea123c1
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/helper-validator-identifier@npm:7.18.6"
@@ -456,6 +544,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helpers@npm:^7.19.0":
+  version: 7.19.0
+  resolution: "@babel/helpers@npm:7.19.0"
+  dependencies:
+    "@babel/template": ^7.18.10
+    "@babel/traverse": ^7.19.0
+    "@babel/types": ^7.19.0
+  checksum: e50e78e0dbb0435075fa3f85021a6bcae529589800bca0292721afd7f7c874bea54508d6dc57eca16e5b8224f8142c6b0e32e3b0140029dc09865da747da4623
+  languageName: node
+  linkType: hard
+
 "@babel/highlight@npm:^7.10.4, @babel/highlight@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/highlight@npm:7.18.6"
@@ -473,6 +572,15 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 81a966b334e3ef397e883c64026265a5ae0ad435a86f52a84f60a5ee1efc0738c1f42c55e0dc5f191cc6a83ba0c61350433eee417bf1dff160ca5f3cfde244c6
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.18.10, @babel/parser@npm:^7.19.0":
+  version: 7.19.0
+  resolution: "@babel/parser@npm:7.19.0"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: af86d829bfeb60e0dcf54a43489c2514674b6c8d9bb24cf112706772125752fcd517877ad30501d533fa85f70a439d02eebeec3be9c2e95499853367184e0da7
   languageName: node
   linkType: hard
 
@@ -788,7 +896,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-jsx@npm:^7.12.13":
+"@babel/plugin-syntax-jsx@npm:^7.12.13, @babel/plugin-syntax-jsx@npm:^7.7.2":
   version: 7.18.6
   resolution: "@babel/plugin-syntax-jsx@npm:7.18.6"
   dependencies:
@@ -1397,6 +1505,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/template@npm:^7.18.10":
+  version: 7.18.10
+  resolution: "@babel/template@npm:7.18.10"
+  dependencies:
+    "@babel/code-frame": ^7.18.6
+    "@babel/parser": ^7.18.10
+    "@babel/types": ^7.18.10
+  checksum: 93a6aa094af5f355a72bd55f67fa1828a046c70e46f01b1606e6118fa1802b6df535ca06be83cc5a5e834022be95c7b714f0a268b5f20af984465a71e28f1473
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.18.6, @babel/template@npm:^7.3.3":
   version: 7.18.6
   resolution: "@babel/template@npm:7.18.6"
@@ -1426,6 +1545,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.19.0":
+  version: 7.19.0
+  resolution: "@babel/traverse@npm:7.19.0"
+  dependencies:
+    "@babel/code-frame": ^7.18.6
+    "@babel/generator": ^7.19.0
+    "@babel/helper-environment-visitor": ^7.18.9
+    "@babel/helper-function-name": ^7.19.0
+    "@babel/helper-hoist-variables": ^7.18.6
+    "@babel/helper-split-export-declaration": ^7.18.6
+    "@babel/parser": ^7.19.0
+    "@babel/types": ^7.19.0
+    debug: ^4.1.0
+    globals: ^11.1.0
+  checksum: dcbd1316c9f4bf3cefee45b6f5194590563aa5d123500a60d3c8d714bef279205014c8e599ebafc469967199a7622e1444cd0235c16d4243da437e3f1281771e
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.0.0, @babel/types@npm:^7.0.0-beta.54, @babel/types@npm:^7.18.6, @babel/types@npm:^7.18.9, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
   version: 7.18.9
   resolution: "@babel/types@npm:7.18.9"
@@ -1433,6 +1570,17 @@ __metadata:
     "@babel/helper-validator-identifier": ^7.18.6
     to-fast-properties: ^2.0.0
   checksum: f0e0147267895fd8a5b82133e711ce7ce99941f3ce63647e0e3b00656a7afe48a8aa48edbae27543b701794d2b29a562a08f51f88f41df401abce7c3acc5e13a
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.18.10, @babel/types@npm:^7.19.0":
+  version: 7.19.0
+  resolution: "@babel/types@npm:7.19.0"
+  dependencies:
+    "@babel/helper-string-parser": ^7.18.10
+    "@babel/helper-validator-identifier": ^7.18.6
+    to-fast-properties: ^2.0.0
+  checksum: 9b346715a68aeede70ba9c685a144b0b26c53bcd595d448e24c8fa8df4d5956a5712e56ebadb7c85dcc32f218ee42788e37b93d50d3295c992072224cb3ef3fe
   languageName: node
   linkType: hard
 
@@ -1878,6 +2026,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/console@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "@jest/console@npm:29.0.3"
+  dependencies:
+    "@jest/types": ^29.0.3
+    "@types/node": "*"
+    chalk: ^4.0.0
+    jest-message-util: ^29.0.3
+    jest-util: ^29.0.3
+    slash: ^3.0.0
+  checksum: 1c5f092082c45c5c35ea51e7c75f4ce06a9b4350e44e0d3aa6c586c469a687fb095ab2601f196f147cccd1c4b5cbf4adc885ae83c8af42dfeee5aa518fa0968e
+  languageName: node
+  linkType: hard
+
 "@jest/core@npm:^27.5.1":
   version: 27.5.1
   resolution: "@jest/core@npm:27.5.1"
@@ -1919,6 +2081,47 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/core@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "@jest/core@npm:29.0.3"
+  dependencies:
+    "@jest/console": ^29.0.3
+    "@jest/reporters": ^29.0.3
+    "@jest/test-result": ^29.0.3
+    "@jest/transform": ^29.0.3
+    "@jest/types": ^29.0.3
+    "@types/node": "*"
+    ansi-escapes: ^4.2.1
+    chalk: ^4.0.0
+    ci-info: ^3.2.0
+    exit: ^0.1.2
+    graceful-fs: ^4.2.9
+    jest-changed-files: ^29.0.0
+    jest-config: ^29.0.3
+    jest-haste-map: ^29.0.3
+    jest-message-util: ^29.0.3
+    jest-regex-util: ^29.0.0
+    jest-resolve: ^29.0.3
+    jest-resolve-dependencies: ^29.0.3
+    jest-runner: ^29.0.3
+    jest-runtime: ^29.0.3
+    jest-snapshot: ^29.0.3
+    jest-util: ^29.0.3
+    jest-validate: ^29.0.3
+    jest-watcher: ^29.0.3
+    micromatch: ^4.0.4
+    pretty-format: ^29.0.3
+    slash: ^3.0.0
+    strip-ansi: ^6.0.0
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  checksum: 411a994ae0df96262c911c894b231a3148280ae39cf0a5d1132c126e708925a3aa89d3f75be628260916a5c38c6ee1ce27979cf78171a393f3c3bbac019149d9
+  languageName: node
+  linkType: hard
+
 "@jest/environment@npm:^27.5.1":
   version: 27.5.1
   resolution: "@jest/environment@npm:27.5.1"
@@ -1928,6 +2131,37 @@ __metadata:
     "@types/node": "*"
     jest-mock: ^27.5.1
   checksum: 2a9e18c35a015508dbec5b90b21c150230fa6c1c8cb8fabe029d46ee2ca4c40eb832fb636157da14c66590d0a4c8a2c053226b041f54a44507d6f6a89abefd66
+  languageName: node
+  linkType: hard
+
+"@jest/environment@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "@jest/environment@npm:29.0.3"
+  dependencies:
+    "@jest/fake-timers": ^29.0.3
+    "@jest/types": ^29.0.3
+    "@types/node": "*"
+    jest-mock: ^29.0.3
+  checksum: 3cf9a6c18d1175f9d9dc353ad26a8482cef3aae8d68574d2c2feaf149e4d6f5c83e145aeefffdc0c614e9b770d26251e476cb1bd86f140c9d19b6adf8f1a2681
+  languageName: node
+  linkType: hard
+
+"@jest/expect-utils@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "@jest/expect-utils@npm:29.0.3"
+  dependencies:
+    jest-get-type: ^29.0.0
+  checksum: af6fa6e0b9cdf42f5778ff0b70c2049ec768598f720ea473773e0c0bebd2416a32ecbede94cfdc95572a021eda5302a9295a5c416ad5ce155c4ec277c40129da
+  languageName: node
+  linkType: hard
+
+"@jest/expect@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "@jest/expect@npm:29.0.3"
+  dependencies:
+    expect: ^29.0.3
+    jest-snapshot: ^29.0.3
+  checksum: 8f969cce260b84edc105a73b8314accd305f2ad012031c00a6a4ba8b3db864237719e95a167702badada274bd764c306e561326bef86d950f72b94f5c9c69c7e
   languageName: node
   linkType: hard
 
@@ -1945,6 +2179,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/fake-timers@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "@jest/fake-timers@npm:29.0.3"
+  dependencies:
+    "@jest/types": ^29.0.3
+    "@sinonjs/fake-timers": ^9.1.2
+    "@types/node": "*"
+    jest-message-util: ^29.0.3
+    jest-mock: ^29.0.3
+    jest-util: ^29.0.3
+  checksum: c0a641fe239044a766eb27e6e4e085acdc8f53d34813aa883a8da8fcce555d8b6ce06716b94c72b44e60c0ca8088b1f1a1d3b05c7f41ed39fc0f6cf23dead7c4
+  languageName: node
+  linkType: hard
+
 "@jest/globals@npm:^27.5.1":
   version: 27.5.1
   resolution: "@jest/globals@npm:27.5.1"
@@ -1953,6 +2201,18 @@ __metadata:
     "@jest/types": ^27.5.1
     expect: ^27.5.1
   checksum: 087f97047e9dcf555f76fe2ce54aee681e005eaa837a0c0c2d251df6b6412c892c9df54cb871b180342114389a5ff895a4e52e6e6d3d0015bf83c02a54f64c3c
+  languageName: node
+  linkType: hard
+
+"@jest/globals@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "@jest/globals@npm:29.0.3"
+  dependencies:
+    "@jest/environment": ^29.0.3
+    "@jest/expect": ^29.0.3
+    "@jest/types": ^29.0.3
+    jest-mock: ^29.0.3
+  checksum: ab6a3f93b98c600f6b4d57c5cf593e624847101bf037f452800d891f55612cd042f524f032f4871ff784c1814f85a4939afbd853104f50f78aada353ac124b7e
   languageName: node
   linkType: hard
 
@@ -1994,6 +2254,53 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/reporters@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "@jest/reporters@npm:29.0.3"
+  dependencies:
+    "@bcoe/v8-coverage": ^0.2.3
+    "@jest/console": ^29.0.3
+    "@jest/test-result": ^29.0.3
+    "@jest/transform": ^29.0.3
+    "@jest/types": ^29.0.3
+    "@jridgewell/trace-mapping": ^0.3.15
+    "@types/node": "*"
+    chalk: ^4.0.0
+    collect-v8-coverage: ^1.0.0
+    exit: ^0.1.2
+    glob: ^7.1.3
+    graceful-fs: ^4.2.9
+    istanbul-lib-coverage: ^3.0.0
+    istanbul-lib-instrument: ^5.1.0
+    istanbul-lib-report: ^3.0.0
+    istanbul-lib-source-maps: ^4.0.0
+    istanbul-reports: ^3.1.3
+    jest-message-util: ^29.0.3
+    jest-util: ^29.0.3
+    jest-worker: ^29.0.3
+    slash: ^3.0.0
+    string-length: ^4.0.1
+    strip-ansi: ^6.0.0
+    terminal-link: ^2.0.0
+    v8-to-istanbul: ^9.0.1
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  checksum: 43028a8823cb8d58c5219e0471990e0d7e9014ed9ef6f2853076bd9e49a490fc1bcfcf46a4d7b981725da0f31be1496725a4a0edb0149f7c7f54c5d2299dcae1
+  languageName: node
+  linkType: hard
+
+"@jest/schemas@npm:^29.0.0":
+  version: 29.0.0
+  resolution: "@jest/schemas@npm:29.0.0"
+  dependencies:
+    "@sinclair/typebox": ^0.24.1
+  checksum: 41355c78f09eb1097e57a3c5d0ca11c9099e235e01ea5fa4e3953562a79a6a9296c1d300f1ba50ca75236048829e056b00685cd2f1ff8285e56fd2ce01249acb
+  languageName: node
+  linkType: hard
+
 "@jest/source-map@npm:^27.5.1":
   version: 27.5.1
   resolution: "@jest/source-map@npm:27.5.1"
@@ -2002,6 +2309,17 @@ __metadata:
     graceful-fs: ^4.2.9
     source-map: ^0.6.0
   checksum: 4fb1e743b602841babf7e22bd84eca34676cb05d4eb3b604cae57fc59e406099f5ac759ac1a0d04d901237d143f0f4f234417306e823bde732a1d19982230862
+  languageName: node
+  linkType: hard
+
+"@jest/source-map@npm:^29.0.0":
+  version: 29.0.0
+  resolution: "@jest/source-map@npm:29.0.0"
+  dependencies:
+    "@jridgewell/trace-mapping": ^0.3.15
+    callsites: ^3.0.0
+    graceful-fs: ^4.2.9
+  checksum: dd97bc5826cf68d6eb5565383816332f800476232fd12800bd027a259cbf3ef216f1633405f3ad0861dde3b12a7886301798c078b334f6d3012044d43abcf4f6
   languageName: node
   linkType: hard
 
@@ -2017,6 +2335,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/test-result@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "@jest/test-result@npm:29.0.3"
+  dependencies:
+    "@jest/console": ^29.0.3
+    "@jest/types": ^29.0.3
+    "@types/istanbul-lib-coverage": ^2.0.0
+    collect-v8-coverage: ^1.0.0
+  checksum: 9cb76090b2b49cc19f95c51e3593085ab88b2d9539f9c15b1e7919f770aaee75376b453f30a14f2034a5cb25fa8e14f5fcc422f05954dbdb0873220576d9c9a0
+  languageName: node
+  linkType: hard
+
 "@jest/test-sequencer@npm:^27.5.1":
   version: 27.5.1
   resolution: "@jest/test-sequencer@npm:27.5.1"
@@ -2026,6 +2356,18 @@ __metadata:
     jest-haste-map: ^27.5.1
     jest-runtime: ^27.5.1
   checksum: f21f9c8bb746847f7f89accfd29d6046eec1446f0b54e4694444feaa4df379791f76ef0f5a4360aafcbc73b50bc979f68b8a7620de404019d3de166be6720cb0
+  languageName: node
+  linkType: hard
+
+"@jest/test-sequencer@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "@jest/test-sequencer@npm:29.0.3"
+  dependencies:
+    "@jest/test-result": ^29.0.3
+    graceful-fs: ^4.2.9
+    jest-haste-map: ^29.0.3
+    slash: ^3.0.0
+  checksum: c6868e29a36c2dd4f6aa71a7148fa7bf34fb845e97b29bc418cb6988245ad7f0cd820aa6dcf9389d0e5b4592b9df8a727a40b0b91eee0dad00f683c250b94a2c
   languageName: node
   linkType: hard
 
@@ -2052,6 +2394,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/transform@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "@jest/transform@npm:29.0.3"
+  dependencies:
+    "@babel/core": ^7.11.6
+    "@jest/types": ^29.0.3
+    "@jridgewell/trace-mapping": ^0.3.15
+    babel-plugin-istanbul: ^6.1.1
+    chalk: ^4.0.0
+    convert-source-map: ^1.4.0
+    fast-json-stable-stringify: ^2.1.0
+    graceful-fs: ^4.2.9
+    jest-haste-map: ^29.0.3
+    jest-regex-util: ^29.0.0
+    jest-util: ^29.0.3
+    micromatch: ^4.0.4
+    pirates: ^4.0.4
+    slash: ^3.0.0
+    write-file-atomic: ^4.0.1
+  checksum: c68ebb673a27640372c912736aa26bda5bc4dfd7a890bb10c467b81e8a66826c8b8b6826ebf25ed3c7a70b7818fcc60e3c0d7341d1595d5ce4978d53d22a7ea1
+  languageName: node
+  linkType: hard
+
 "@jest/types@npm:^27.5.1":
   version: 27.5.1
   resolution: "@jest/types@npm:27.5.1"
@@ -2062,6 +2427,20 @@ __metadata:
     "@types/yargs": ^16.0.0
     chalk: ^4.0.0
   checksum: d1f43cc946d87543ddd79d49547aab2399481d34025d5c5f2025d3d99c573e1d9832fa83cef25e9d9b07a8583500229d15bbb07b8e233d127d911d133e2f14b1
+  languageName: node
+  linkType: hard
+
+"@jest/types@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "@jest/types@npm:29.0.3"
+  dependencies:
+    "@jest/schemas": ^29.0.0
+    "@types/istanbul-lib-coverage": ^2.0.0
+    "@types/istanbul-reports": ^3.0.0
+    "@types/node": "*"
+    "@types/yargs": ^17.0.8
+    chalk: ^4.0.0
+  checksum: 3bd33e64d87a5421b860396ac7f7b9b8d5abbf0f300f4379bb20c8e3a6169fbbd078933ce0649827cd63e23330c4effeb6b222fa94e8dd0df638dfff6c1fed41
   languageName: node
   linkType: hard
 
@@ -2124,6 +2503,16 @@ __metadata:
     "@jridgewell/resolve-uri": ^3.0.3
     "@jridgewell/sourcemap-codec": ^1.4.10
   checksum: d89597752fd88d3f3480845691a05a44bd21faac18e2185b6f436c3b0fd0c5a859fbbd9aaa92050c4052caf325ad3e10e2e1d1b64327517471b7d51babc0ddef
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.15":
+  version: 0.3.15
+  resolution: "@jridgewell/trace-mapping@npm:0.3.15"
+  dependencies:
+    "@jridgewell/resolve-uri": ^3.0.3
+    "@jridgewell/sourcemap-codec": ^1.4.10
+  checksum: 38917e9c2b014d469a9f51c016ed506acbe44dd16ec2f6f99b553ebf3764d22abadbf992f2367b6d2b3511f3eae8ed3a8963f6c1030093fda23efd35ecab2bae
   languageName: node
   linkType: hard
 
@@ -2850,6 +3239,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sinclair/typebox@npm:^0.24.1":
+  version: 0.24.41
+  resolution: "@sinclair/typebox@npm:0.24.41"
+  checksum: eb9861ad7bc5a29d5a6be27732757210edfcfa73fca386e303b0363af31c7ad16ebad75cf0c3fdf6444663dda5884ba0de333fc7a8ab8680c1c01e1e91089c1d
+  languageName: node
+  linkType: hard
+
 "@sinonjs/commons@npm:^1.7.0":
   version: 1.8.3
   resolution: "@sinonjs/commons@npm:1.8.3"
@@ -2865,6 +3261,15 @@ __metadata:
   dependencies:
     "@sinonjs/commons": ^1.7.0
   checksum: 09b5a158ce013a6c37613258bad79ca4efeb99b1f59c41c73cca36cac00b258aefcf46eeea970fccf06b989414d86fe9f54c1102272c0c3bdd51a313cea80949
+  languageName: node
+  linkType: hard
+
+"@sinonjs/fake-timers@npm:^9.1.2":
+  version: 9.1.2
+  resolution: "@sinonjs/fake-timers@npm:9.1.2"
+  dependencies:
+    "@sinonjs/commons": ^1.7.0
+  checksum: 7d3aef54e17c1073101cb64d953157c19d62a40e261a30923fa1ee337b049c5f29cc47b1f0c477880f42b5659848ba9ab897607ac8ea4acd5c30ddcfac57fca6
   languageName: node
   linkType: hard
 
@@ -3060,7 +3465,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/graceful-fs@npm:^4.1.2":
+"@types/graceful-fs@npm:^4.1.2, @types/graceful-fs@npm:^4.1.3":
   version: 4.1.5
   resolution: "@types/graceful-fs@npm:4.1.5"
   dependencies:
@@ -3226,7 +3631,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prop-types@npm:*, @types/prop-types@npm:^15.7.5":
+"@types/prop-types@npm:*, @types/prop-types@npm:^15, @types/prop-types@npm:^15.7.5":
   version: 15.7.5
   resolution: "@types/prop-types@npm:15.7.5"
   checksum: 5b43b8b15415e1f298243165f1d44390403bb2bd42e662bca3b5b5633fdd39c938e91b7fce3a9483699db0f7a715d08cef220c121f723a634972fdf596aec980
@@ -3244,6 +3649,15 @@ __metadata:
   version: 1.2.4
   resolution: "@types/range-parser@npm:1.2.4"
   checksum: b7c0dfd5080a989d6c8bb0b6750fc0933d9acabeb476da6fe71d8bdf1ab65e37c136169d84148034802f48378ab94e3c37bb4ef7656b2bec2cb9c0f8d4146a95
+  languageName: node
+  linkType: hard
+
+"@types/react-dom@npm:^18":
+  version: 18.0.6
+  resolution: "@types/react-dom@npm:18.0.6"
+  dependencies:
+    "@types/react": "*"
+  checksum: db571047af1a567631758700b9f7d143e566df939cfe5fbf7535347cc0c726a1cdbb5e3f8566d076e54cf708b6c1166689de194a9ba09ee35efc9e1d45911685
   languageName: node
   linkType: hard
 
@@ -3414,6 +3828,15 @@ __metadata:
   dependencies:
     "@types/yargs-parser": "*"
   checksum: caa21d2c957592fe2184a8368c8cbe5a82a6c2e2f2893722e489f842dc5963293d2f3120bc06fe3933d60a3a0d1e2eb269649fd6b1947fe1820f8841ba611dd9
+  languageName: node
+  linkType: hard
+
+"@types/yargs@npm:^17.0.8":
+  version: 17.0.12
+  resolution: "@types/yargs@npm:17.0.12"
+  dependencies:
+    "@types/yargs-parser": "*"
+  checksum: 5b41d21d8624199f89db82209b2adab2e47867b3677e852fde65698be2ca48364b14c2e70cb0adc9bca4a2102c93dad2409cae0ad666ea36ae031ae1cb08a7b5
   languageName: node
   linkType: hard
 
@@ -4442,6 +4865,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"babel-jest@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "babel-jest@npm:29.0.3"
+  dependencies:
+    "@jest/transform": ^29.0.3
+    "@types/babel__core": ^7.1.14
+    babel-plugin-istanbul: ^6.1.1
+    babel-preset-jest: ^29.0.2
+    chalk: ^4.0.0
+    graceful-fs: ^4.2.9
+    slash: ^3.0.0
+  peerDependencies:
+    "@babel/core": ^7.8.0
+  checksum: 4670945691c204464f7694017d59148b97cdbd51ff91ef492340ef5d6bbc74c461fa698a5feb04a93515300632ed44a55e85500bb61206d8a7ff60afb5b6da48
+  languageName: node
+  linkType: hard
+
 "babel-plugin-annotate-pure-calls@npm:^0.4.0":
   version: 0.4.0
   resolution: "babel-plugin-annotate-pure-calls@npm:0.4.0"
@@ -4491,6 +4931,18 @@ __metadata:
     "@types/babel__core": ^7.0.0
     "@types/babel__traverse": ^7.0.6
   checksum: 709c17727aa8fd3be755d256fb514bf945a5c2ea6017f037d80280fc44ae5fe7dfeebf63d8412df53796455c2c216119d628d8cc90b099434fd819005943d058
+  languageName: node
+  linkType: hard
+
+"babel-plugin-jest-hoist@npm:^29.0.2":
+  version: 29.0.2
+  resolution: "babel-plugin-jest-hoist@npm:29.0.2"
+  dependencies:
+    "@babel/template": ^7.3.3
+    "@babel/types": ^7.3.3
+    "@types/babel__core": ^7.1.14
+    "@types/babel__traverse": ^7.0.6
+  checksum: e02ab2c56b471940bc147d75808f6fb5d18b81382088beb36088d2fee8c5f9699b2a814a98884539191d43871d66770928e09c268c095ec39aad5766c3337f34
   languageName: node
   linkType: hard
 
@@ -4601,6 +5053,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 251bcea11c18fd9672fec104eadb45b43f117ceeb326fa7345ced778d4c1feab29343cd7a87a1dcfae4997d6c851a8b386d7f7213792da6e23b74f4443a8976d
+  languageName: node
+  linkType: hard
+
+"babel-preset-jest@npm:^29.0.2":
+  version: 29.0.2
+  resolution: "babel-preset-jest@npm:29.0.2"
+  dependencies:
+    babel-plugin-jest-hoist: ^29.0.2
+    babel-preset-current-node-syntax: ^1.0.0
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 485db525f4cd38c02c29edcd7240dd232e8d6dbcaef88bfa4765ad3057ed733512f1b7aad06f4bf9661afefeb0ada2c4e259d130113b0289d7db574f82bbd4f8
   languageName: node
   linkType: hard
 
@@ -5804,6 +6268,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cross-fetch@npm:^3.0.4":
+  version: 3.1.5
+  resolution: "cross-fetch@npm:3.1.5"
+  dependencies:
+    node-fetch: 2.6.7
+  checksum: f6b8c6ee3ef993ace6277fd789c71b6acf1b504fd5f5c7128df4ef2f125a429e29cd62dc8c127523f04a5f2fa4771ed80e3f3d9695617f441425045f505cf3bb
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:^6.0.5":
   version: 6.0.5
   resolution: "cross-spawn@npm:6.0.5"
@@ -6269,6 +6742,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"diff-sequences@npm:^29.0.0":
+  version: 29.0.0
+  resolution: "diff-sequences@npm:29.0.0"
+  checksum: 2c084a3db03ecde26f649f6f2559974e01e174451debeb301a7e17199e73423a8e8ddeb9a35ae38638c084b4fa51296a4a20fa7f44f3db0c0ba566bdc704ed3d
+  languageName: node
+  linkType: hard
+
 "diff@npm:^4.0.1":
   version: 4.0.2
   resolution: "diff@npm:4.0.2"
@@ -6431,6 +6911,13 @@ __metadata:
     minimalistic-assert: ^1.0.1
     minimalistic-crypto-utils: ^1.0.1
   checksum: d56d21fd04e97869f7ffcc92e18903b9f67f2d4637a23c860492fbbff5a3155fd9ca0184ce0c865dd6eb2487d234ce9551335c021c376cd2d3b7cb749c7d10f4
+  languageName: node
+  linkType: hard
+
+"emittery@npm:^0.10.2":
+  version: 0.10.2
+  resolution: "emittery@npm:0.10.2"
+  checksum: ee3e21788b043b90885b18ea756ec3105c1cedc50b29709c92b01e239c7e55345d4bb6d3aef4ddbaf528eef448a40b3bb831bad9ee0fc9c25cbf1367ab1ab5ac
   languageName: node
   linkType: hard
 
@@ -7172,6 +7659,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expect@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "expect@npm:29.0.3"
+  dependencies:
+    "@jest/expect-utils": ^29.0.3
+    jest-get-type: ^29.0.0
+    jest-matcher-utils: ^29.0.3
+    jest-message-util: ^29.0.3
+    jest-util: ^29.0.3
+  checksum: 21b7fd346c47896a3de8f1103d7be32dab9409eb3dc170b7a9ff5d8d564b8499bd600b9af6251fe2f46064cf4e2f1456a6c6318da15314b7d74ed6dad723b555
+  languageName: node
+  linkType: hard
+
 "express@npm:4.18.1, express@npm:^4.17.1":
   version: 4.18.1
   resolution: "express@npm:4.18.1"
@@ -7296,7 +7796,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-json-stable-stringify@npm:2.1.0, fast-json-stable-stringify@npm:2.x, fast-json-stable-stringify@npm:^2.0.0":
+"fast-json-stable-stringify@npm:2.1.0, fast-json-stable-stringify@npm:2.x, fast-json-stable-stringify@npm:^2.0.0, fast-json-stable-stringify@npm:^2.1.0":
   version: 2.1.0
   resolution: "fast-json-stable-stringify@npm:2.1.0"
   checksum: b191531e36c607977e5b1c47811158733c34ccb3bfde92c44798929e9b4154884378536d26ad90dfecd32e1ffc09c545d23535ad91b3161a27ddbb8ebe0cbecb
@@ -8884,29 +9384,37 @@ __metadata:
     "@jbrowse/core": ^2.0.1
     "@jbrowse/development-tools": ^2.1.1
     "@jbrowse/plugin-linear-genome-view": ^2.0.1
+    "@jest/globals": ^29.0.3
     "@mui/icons-material": ^5.8.4
     "@mui/material": ^5.9.1
     "@mui/x-data-grid": ^5.12.3
     "@types/cypress": ^1.1.3
     "@types/node": ^16.11.6
+    "@types/prop-types": ^15
     "@types/react": ^17.0.34
+    "@types/react-dom": ^18
     apollo-mst: "workspace:^"
     apollo-shared: "workspace:^"
     bson-objectid: ^2.0.3
     clsx: ^1.1.1
     cypress: ^8.7.0
-    jest: ^27.3.1
+    jest: ^29.0.3
+    jest-fetch-mock: ^3.0.3
     mobx: ^6.6.1
     mobx-react: ^7.2.1
     mobx-state-tree: ^5.1.5
     npm-run-all: 4.1.5
-    react: ^17.0.2
+    prop-types: ^15.8.1
+    react: ^18.2.0
+    react-dom: ^18.2.0
     regenerator-runtime: ^0.13.9
     rimraf: ^3.0.2
     rollup: ^2.59.0
+    rxjs: ^6.5.2
     serve: ^14.0.1
     shx: ^0.3.3
     start-server-and-test: ^1.11.7
+    ts-jest: ^29.0.0
     ts-node: ^10.3.0
     tslib: ^2.0.3
     tss-react: ^3.7.1
@@ -8917,7 +9425,10 @@ __metadata:
     mobx: ^6.6.1
     mobx-react: ^7.2.1
     mobx-state-tree: ^5.1.5
-    react: ^17.0.2
+    prop-types: ^15.8.1
+    react: ^18.2.0
+    react-dom: ^18.2.0
+    rxjs: ^6.5.2
     tss-react: ^3.7.1
   languageName: unknown
   linkType: soft
@@ -8930,6 +9441,16 @@ __metadata:
     execa: ^5.0.0
     throat: ^6.0.1
   checksum: 95e9dc74c3ca688ef85cfeab270f43f8902721a6c8ade6ac2459459a77890c85977f537d6fb809056deaa6d9c3f075fa7d2699ff5f3bf7d3fda17c3760b79b15
+  languageName: node
+  linkType: hard
+
+"jest-changed-files@npm:^29.0.0":
+  version: 29.0.0
+  resolution: "jest-changed-files@npm:29.0.0"
+  dependencies:
+    execa: ^5.0.0
+    p-limit: ^3.1.0
+  checksum: 5642ace8cd1e7e4f9e3ee423b97d0b018b00ad85ea7e5864592b4657e8500ef56ec50d2189229b912223046bbf31c9196c8ef2442a917be9726a5911d40db1b2
   languageName: node
   linkType: hard
 
@@ -8960,6 +9481,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-circus@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "jest-circus@npm:29.0.3"
+  dependencies:
+    "@jest/environment": ^29.0.3
+    "@jest/expect": ^29.0.3
+    "@jest/test-result": ^29.0.3
+    "@jest/types": ^29.0.3
+    "@types/node": "*"
+    chalk: ^4.0.0
+    co: ^4.6.0
+    dedent: ^0.7.0
+    is-generator-fn: ^2.0.0
+    jest-each: ^29.0.3
+    jest-matcher-utils: ^29.0.3
+    jest-message-util: ^29.0.3
+    jest-runtime: ^29.0.3
+    jest-snapshot: ^29.0.3
+    jest-util: ^29.0.3
+    p-limit: ^3.1.0
+    pretty-format: ^29.0.3
+    slash: ^3.0.0
+    stack-utils: ^2.0.3
+  checksum: 6ba495d4fb68ebb59f269b59029837f55009793d632ba2f29300992de80f7e3a37e619ea4e88676982cf74128416265a5929b3f9b77142fbf27c1dd0d6b6f98c
+  languageName: node
+  linkType: hard
+
 "jest-cli@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-cli@npm:27.5.1"
@@ -8984,6 +9532,33 @@ __metadata:
   bin:
     jest: bin/jest.js
   checksum: 6c0a69fb48e500241409e09ff743ed72bc6578d7769e2c994724e7ef1e5587f6c1f85dc429e93b98ae38a365222993ee70f0acc2199358992120900984f349e5
+  languageName: node
+  linkType: hard
+
+"jest-cli@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "jest-cli@npm:29.0.3"
+  dependencies:
+    "@jest/core": ^29.0.3
+    "@jest/test-result": ^29.0.3
+    "@jest/types": ^29.0.3
+    chalk: ^4.0.0
+    exit: ^0.1.2
+    graceful-fs: ^4.2.9
+    import-local: ^3.0.2
+    jest-config: ^29.0.3
+    jest-util: ^29.0.3
+    jest-validate: ^29.0.3
+    prompts: ^2.0.1
+    yargs: ^17.3.1
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  bin:
+    jest: bin/jest.js
+  checksum: 4cd6ed7effcf703c3275bb07231227e32bd2de2dfc84354f0bbd25a2a8b26395570c8902c7dc87b02bed4a57c304a6b48e21a60fa26025b89c1e4e61eae1ea38
   languageName: node
   linkType: hard
 
@@ -9024,6 +9599,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-config@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "jest-config@npm:29.0.3"
+  dependencies:
+    "@babel/core": ^7.11.6
+    "@jest/test-sequencer": ^29.0.3
+    "@jest/types": ^29.0.3
+    babel-jest: ^29.0.3
+    chalk: ^4.0.0
+    ci-info: ^3.2.0
+    deepmerge: ^4.2.2
+    glob: ^7.1.3
+    graceful-fs: ^4.2.9
+    jest-circus: ^29.0.3
+    jest-environment-node: ^29.0.3
+    jest-get-type: ^29.0.0
+    jest-regex-util: ^29.0.0
+    jest-resolve: ^29.0.3
+    jest-runner: ^29.0.3
+    jest-util: ^29.0.3
+    jest-validate: ^29.0.3
+    micromatch: ^4.0.4
+    parse-json: ^5.2.0
+    pretty-format: ^29.0.3
+    slash: ^3.0.0
+    strip-json-comments: ^3.1.1
+  peerDependencies:
+    "@types/node": "*"
+    ts-node: ">=9.0.0"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    ts-node:
+      optional: true
+  checksum: b2861ebf946e8c332c0526559de7f41d79bbe27731ee4de15add1a2ac8baec160ed572d22e66fd8dae6cde38dbedc9dd0987397021499f7aa44f558da651c65a
+  languageName: node
+  linkType: hard
+
 "jest-diff@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-diff@npm:27.5.1"
@@ -9036,12 +9649,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-diff@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "jest-diff@npm:29.0.3"
+  dependencies:
+    chalk: ^4.0.0
+    diff-sequences: ^29.0.0
+    jest-get-type: ^29.0.0
+    pretty-format: ^29.0.3
+  checksum: 1e12b63ea6254ea25146b6fb19f8b2d1ba334e1b8b635a007767c17dc272728afbdf41ccccce26c2a40cd9c7f3176bcfed53be2572927a3fc7b1ee5fff43eb26
+  languageName: node
+  linkType: hard
+
 "jest-docblock@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-docblock@npm:27.5.1"
   dependencies:
     detect-newline: ^3.0.0
   checksum: c0fed6d55b229d8bffdd8d03f121dd1a3be77c88f50552d374f9e1ea3bde57bf6bea017a0add04628d98abcb1bfb48b456438eeca8a74ef0053f4dae3b95d29c
+  languageName: node
+  linkType: hard
+
+"jest-docblock@npm:^29.0.0":
+  version: 29.0.0
+  resolution: "jest-docblock@npm:29.0.0"
+  dependencies:
+    detect-newline: ^3.0.0
+  checksum: b4f81426cc0dffb05b873d3cc373a1643040be62d72cce4dfed499fbcb57c55ac02c44af7aba5e7753915ff5e85b8d6030456981156eaea20be1cb57d2719904
   languageName: node
   linkType: hard
 
@@ -9055,6 +9689,19 @@ __metadata:
     jest-util: ^27.5.1
     pretty-format: ^27.5.1
   checksum: b5a6d8730fd938982569c9e0b42bdf3c242f97b957ed8155a6473b5f7b540970f8685524e7f53963dc1805319f4b6602abfc56605590ca19d55bd7a87e467e63
+  languageName: node
+  linkType: hard
+
+"jest-each@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "jest-each@npm:29.0.3"
+  dependencies:
+    "@jest/types": ^29.0.3
+    chalk: ^4.0.0
+    jest-get-type: ^29.0.0
+    jest-util: ^29.0.3
+    pretty-format: ^29.0.3
+  checksum: 80c1912eb573a2972e29d9731cfbfa773b010c1416998eca28a90bda4f50de393c60860a2cb1531a4d3e0a0d23698c561a64e8942d48a75023b683136de519cc
   languageName: node
   linkType: hard
 
@@ -9087,10 +9734,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-environment-node@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "jest-environment-node@npm:29.0.3"
+  dependencies:
+    "@jest/environment": ^29.0.3
+    "@jest/fake-timers": ^29.0.3
+    "@jest/types": ^29.0.3
+    "@types/node": "*"
+    jest-mock: ^29.0.3
+    jest-util: ^29.0.3
+  checksum: 76cd5759cdb08d3a4619004a23cc45fb8d103004b4d3e95451a36b981540c5d56e4f2a5b3cafb8ecf144bf874633ea86118a202e08aec1f445a25caf4081d8bc
+  languageName: node
+  linkType: hard
+
+"jest-fetch-mock@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "jest-fetch-mock@npm:3.0.3"
+  dependencies:
+    cross-fetch: ^3.0.4
+    promise-polyfill: ^8.1.3
+  checksum: fb052f7e0ef1c8192a9c15efdd1b18d281ab68fc6b1648b30bff8880fe24418bdf12190ea79b1996932dc15417c3c01f5b2d77ef7104a7e7943e7cbe8d61071d
+  languageName: node
+  linkType: hard
+
 "jest-get-type@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-get-type@npm:27.5.1"
   checksum: 63064ab70195c21007d897c1157bf88ff94a790824a10f8c890392e7d17eda9c3900513cb291ca1c8d5722cad79169764e9a1279f7c8a9c4cd6e9109ff04bbc0
+  languageName: node
+  linkType: hard
+
+"jest-get-type@npm:^29.0.0":
+  version: 29.0.0
+  resolution: "jest-get-type@npm:29.0.0"
+  checksum: 9abdd11d69788963a92fb9d813a7b887654ecc8f3a3c8bf83166d33aaf4d57ed380e74ab8ef106f57565dd235446ca6ebc607679f0c516c4633e6d09f0540a2b
   languageName: node
   linkType: hard
 
@@ -9115,6 +9793,29 @@ __metadata:
     fsevents:
       optional: true
   checksum: e092a1412829a9254b4725531ee72926de530f77fda7b0d9ea18008fb7623c16f72e772d8e93be71cac9e591b2c6843a669610887dd2c89bd9eb528856e3ab47
+  languageName: node
+  linkType: hard
+
+"jest-haste-map@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "jest-haste-map@npm:29.0.3"
+  dependencies:
+    "@jest/types": ^29.0.3
+    "@types/graceful-fs": ^4.1.3
+    "@types/node": "*"
+    anymatch: ^3.0.3
+    fb-watchman: ^2.0.0
+    fsevents: ^2.3.2
+    graceful-fs: ^4.2.9
+    jest-regex-util: ^29.0.0
+    jest-util: ^29.0.3
+    jest-worker: ^29.0.3
+    micromatch: ^4.0.4
+    walker: ^1.0.8
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: fb766e0d8174e7e3a43a63b28e23bd35db61a5939d6c5c1335d7f3d642d1c608e16fef8a105289b78795e308ab3176a62bc45acfa3fa14087e7635cb008795c3
   languageName: node
   linkType: hard
 
@@ -9153,6 +9854,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-leak-detector@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "jest-leak-detector@npm:29.0.3"
+  dependencies:
+    jest-get-type: ^29.0.0
+    pretty-format: ^29.0.3
+  checksum: a1657dbb72f2c3b4a8af148daec491d42eabdadc4e27eb8ec325d5267c21ac958e82e5c8ee679861c2131afd2bdfed4139b806511de7624d93b9838c6fcf5b2e
+  languageName: node
+  linkType: hard
+
 "jest-matcher-utils@npm:^27.0.0, jest-matcher-utils@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-matcher-utils@npm:27.5.1"
@@ -9162,6 +9873,18 @@ __metadata:
     jest-get-type: ^27.5.1
     pretty-format: ^27.5.1
   checksum: bb2135fc48889ff3fe73888f6cc7168ddab9de28b51b3148f820c89fdfd2effdcad005f18be67d0b9be80eda208ad47290f62f03d0a33f848db2dd0273c8217a
+  languageName: node
+  linkType: hard
+
+"jest-matcher-utils@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "jest-matcher-utils@npm:29.0.3"
+  dependencies:
+    chalk: ^4.0.0
+    jest-diff: ^29.0.3
+    jest-get-type: ^29.0.0
+    pretty-format: ^29.0.3
+  checksum: e39ab74a046ada8fbd75a275bfe54bd5f8ec14a98f77e1162a49d4e1ea82e68c5a4575691767cea0f60dd0b74cb481275012bf3467cd91fdb014311c670b8a83
   languageName: node
   linkType: hard
 
@@ -9182,6 +9905,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-message-util@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "jest-message-util@npm:29.0.3"
+  dependencies:
+    "@babel/code-frame": ^7.12.13
+    "@jest/types": ^29.0.3
+    "@types/stack-utils": ^2.0.0
+    chalk: ^4.0.0
+    graceful-fs: ^4.2.9
+    micromatch: ^4.0.4
+    pretty-format: ^29.0.3
+    slash: ^3.0.0
+    stack-utils: ^2.0.3
+  checksum: 04bee1fee10106f4eb875092e5d06187930d44050a4f99e7aa1d1e42768b18d6d9e5439623d9242202942deb8a1eec08359e0cd19a43ae505d96aeaf243a3f8d
+  languageName: node
+  linkType: hard
+
 "jest-mock@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-mock@npm:27.5.1"
@@ -9189,6 +9929,16 @@ __metadata:
     "@jest/types": ^27.5.1
     "@types/node": "*"
   checksum: f5b5904bb1741b4a1687a5f492535b7b1758dc26534c72a5423305f8711292e96a601dec966df81bb313269fb52d47227e29f9c2e08324d79529172f67311be0
+  languageName: node
+  linkType: hard
+
+"jest-mock@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "jest-mock@npm:29.0.3"
+  dependencies:
+    "@jest/types": ^29.0.3
+    "@types/node": "*"
+  checksum: 8a04823334216f5fca9733a200cbb4cca207bdd74c523321a4170cbec3b2086b44eb1744a9faef808d2853593f132dda90d17e4bce59678fc373e1bab666ad0f
   languageName: node
   linkType: hard
 
@@ -9211,6 +9961,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-regex-util@npm:^29.0.0":
+  version: 29.0.0
+  resolution: "jest-regex-util@npm:29.0.0"
+  checksum: dce16394c357213008e6f84f2288f77c64bba59b7cb48ea614e85c5aae036a7e46dbfd1f45aa08180b7e7c576102bf4f8f0ff8bc60fb9721fb80874adc3ae0ea
+  languageName: node
+  linkType: hard
+
 "jest-resolve-dependencies@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-resolve-dependencies@npm:27.5.1"
@@ -9219,6 +9976,16 @@ __metadata:
     jest-regex-util: ^27.5.1
     jest-snapshot: ^27.5.1
   checksum: c67af97afad1da88f5530317c732bbd1262d1225f6cd7f4e4740a5db48f90ab0bd8564738ac70d1a43934894f9aef62205c1b8f8ee89e5c7a737e6a121ee4c25
+  languageName: node
+  linkType: hard
+
+"jest-resolve-dependencies@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "jest-resolve-dependencies@npm:29.0.3"
+  dependencies:
+    jest-regex-util: ^29.0.0
+    jest-snapshot: ^29.0.3
+  checksum: 43980c0c03a7f00459209315832f03c28d8289ca30ccd8bb6652c87a2c03275aacdba8789177cefc162ceb05218ba3db8bf5a1968920aa4e510cbbefd54f9793
   languageName: node
   linkType: hard
 
@@ -9237,6 +10004,23 @@ __metadata:
     resolve.exports: ^1.1.0
     slash: ^3.0.0
   checksum: 735830e7265b20a348029738680bb2f6e37f80ecea86cda869a4c318ba3a45d39c7a3a873a22f7f746d86258c50ead6e7f501de043e201c095d7ba628a1c440f
+  languageName: node
+  linkType: hard
+
+"jest-resolve@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "jest-resolve@npm:29.0.3"
+  dependencies:
+    chalk: ^4.0.0
+    graceful-fs: ^4.2.9
+    jest-haste-map: ^29.0.3
+    jest-pnp-resolver: ^1.2.2
+    jest-util: ^29.0.3
+    jest-validate: ^29.0.3
+    resolve: ^1.20.0
+    resolve.exports: ^1.1.0
+    slash: ^3.0.0
+  checksum: 9a774f78decbd9caa863e8c539d439aac76a780ea7acc54e90f2ad9c2000c03294e7f4f38816d16a8aa020ae0e3358845cc8f96fbab5f3e186b00e6e0462bf9b
   languageName: node
   linkType: hard
 
@@ -9269,6 +10053,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-runner@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "jest-runner@npm:29.0.3"
+  dependencies:
+    "@jest/console": ^29.0.3
+    "@jest/environment": ^29.0.3
+    "@jest/test-result": ^29.0.3
+    "@jest/transform": ^29.0.3
+    "@jest/types": ^29.0.3
+    "@types/node": "*"
+    chalk: ^4.0.0
+    emittery: ^0.10.2
+    graceful-fs: ^4.2.9
+    jest-docblock: ^29.0.0
+    jest-environment-node: ^29.0.3
+    jest-haste-map: ^29.0.3
+    jest-leak-detector: ^29.0.3
+    jest-message-util: ^29.0.3
+    jest-resolve: ^29.0.3
+    jest-runtime: ^29.0.3
+    jest-util: ^29.0.3
+    jest-watcher: ^29.0.3
+    jest-worker: ^29.0.3
+    p-limit: ^3.1.0
+    source-map-support: 0.5.13
+  checksum: db62830d1635be5e376fd261e38d37a4855146c9a586ec616cfb64257ef6f79697bd947bbb9751377dc2302626e73d1b77036eafd78ef6f93e1e53ca89c23e3e
+  languageName: node
+  linkType: hard
+
 "jest-runtime@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-runtime@npm:27.5.1"
@@ -9296,6 +10109,36 @@ __metadata:
     slash: ^3.0.0
     strip-bom: ^4.0.0
   checksum: 929e3df0c53dab43f831f2af4e2996b22aa8cb2d6d483919d6b0426cbc100098fd5b777b998c6568b77f8c4d860b2e83127514292ff61416064f5ef926492386
+  languageName: node
+  linkType: hard
+
+"jest-runtime@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "jest-runtime@npm:29.0.3"
+  dependencies:
+    "@jest/environment": ^29.0.3
+    "@jest/fake-timers": ^29.0.3
+    "@jest/globals": ^29.0.3
+    "@jest/source-map": ^29.0.0
+    "@jest/test-result": ^29.0.3
+    "@jest/transform": ^29.0.3
+    "@jest/types": ^29.0.3
+    "@types/node": "*"
+    chalk: ^4.0.0
+    cjs-module-lexer: ^1.0.0
+    collect-v8-coverage: ^1.0.0
+    glob: ^7.1.3
+    graceful-fs: ^4.2.9
+    jest-haste-map: ^29.0.3
+    jest-message-util: ^29.0.3
+    jest-mock: ^29.0.3
+    jest-regex-util: ^29.0.0
+    jest-resolve: ^29.0.3
+    jest-snapshot: ^29.0.3
+    jest-util: ^29.0.3
+    slash: ^3.0.0
+    strip-bom: ^4.0.0
+  checksum: e13bfadfe225e9c06a95809d34e209e1769723c0c3d5913d86e4e748a22777e2bec11a352f2d12ca790e04203a6defc6556f77a3050518ebf6600a454a56fd36
   languageName: node
   linkType: hard
 
@@ -9339,6 +10182,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-snapshot@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "jest-snapshot@npm:29.0.3"
+  dependencies:
+    "@babel/core": ^7.11.6
+    "@babel/generator": ^7.7.2
+    "@babel/plugin-syntax-jsx": ^7.7.2
+    "@babel/plugin-syntax-typescript": ^7.7.2
+    "@babel/traverse": ^7.7.2
+    "@babel/types": ^7.3.3
+    "@jest/expect-utils": ^29.0.3
+    "@jest/transform": ^29.0.3
+    "@jest/types": ^29.0.3
+    "@types/babel__traverse": ^7.0.6
+    "@types/prettier": ^2.1.5
+    babel-preset-current-node-syntax: ^1.0.0
+    chalk: ^4.0.0
+    expect: ^29.0.3
+    graceful-fs: ^4.2.9
+    jest-diff: ^29.0.3
+    jest-get-type: ^29.0.0
+    jest-haste-map: ^29.0.3
+    jest-matcher-utils: ^29.0.3
+    jest-message-util: ^29.0.3
+    jest-util: ^29.0.3
+    natural-compare: ^1.4.0
+    pretty-format: ^29.0.3
+    semver: ^7.3.5
+  checksum: 412c0fc4c12c14470aa33beeddfeb04fa0d5724235321e8284b52097c74c97ada40ea52f5ac52a8e01e6d42dd5894b9a0260577d30c8c723ca84fcc7a60bd40c
+  languageName: node
+  linkType: hard
+
 "jest-util@npm:^27.0.0, jest-util@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-util@npm:27.5.1"
@@ -9350,6 +10225,20 @@ __metadata:
     graceful-fs: ^4.2.9
     picomatch: ^2.2.3
   checksum: ac8d122f6daf7a035dcea156641fd3701aeba245417c40836a77e35b3341b9c02ddc5d904cfcd4ddbaa00ab854da76d3b911870cafdcdbaff90ea471de26c7d7
+  languageName: node
+  linkType: hard
+
+"jest-util@npm:^29.0.0, jest-util@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "jest-util@npm:29.0.3"
+  dependencies:
+    "@jest/types": ^29.0.3
+    "@types/node": "*"
+    chalk: ^4.0.0
+    ci-info: ^3.2.0
+    graceful-fs: ^4.2.9
+    picomatch: ^2.2.3
+  checksum: 39c31e75ba5bcb4c3ccdf0895f9fdbb83f839c432e7c6639a688beb414d681b5d50282da017c723ea1f2a7033e74a4938fd33dcff231c3e90f903173919991d5
   languageName: node
   linkType: hard
 
@@ -9367,6 +10256,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-validate@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "jest-validate@npm:29.0.3"
+  dependencies:
+    "@jest/types": ^29.0.3
+    camelcase: ^6.2.0
+    chalk: ^4.0.0
+    jest-get-type: ^29.0.0
+    leven: ^3.1.0
+    pretty-format: ^29.0.3
+  checksum: 096df6a77837155d9b65cd7ff9198489317c53903eb74a7f207e053c0b56204c18b6a8047e168eced291eb550b792ef4ab322b05c7da348af76cd78ea3556b4e
+  languageName: node
+  linkType: hard
+
 "jest-watcher@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-watcher@npm:27.5.1"
@@ -9379,6 +10282,22 @@ __metadata:
     jest-util: ^27.5.1
     string-length: ^4.0.1
   checksum: 191c4e9c278c0902ade1a8a80883ac244963ba3e6e78607a3d5f729ccca9c6e71fb3b316f87883658132641c5d818aa84202585c76752e03c539e6cbecb820bd
+  languageName: node
+  linkType: hard
+
+"jest-watcher@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "jest-watcher@npm:29.0.3"
+  dependencies:
+    "@jest/test-result": ^29.0.3
+    "@jest/types": ^29.0.3
+    "@types/node": "*"
+    ansi-escapes: ^4.2.1
+    chalk: ^4.0.0
+    emittery: ^0.10.2
+    jest-util: ^29.0.3
+    string-length: ^4.0.1
+  checksum: d585b9dda467d08946357c8ed1f971f15a302f958ccd3f6e2e59df5da245edca91cd4a72329d0126de8ac5793567965e4be1e555c4e40ecadb4f8f14306441bb
   languageName: node
   linkType: hard
 
@@ -9404,6 +10323,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-worker@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "jest-worker@npm:29.0.3"
+  dependencies:
+    "@types/node": "*"
+    merge-stream: ^2.0.0
+    supports-color: ^8.0.0
+  checksum: cdae4a58f6ab1ec3c384b42f1106004d434e65febcb34ba14a1e7d8538f7a5a5c2ebb0cf29cecfe8c71882c526ee02c4aa338a9ce0abcf11fcec9b8fa662189b
+  languageName: node
+  linkType: hard
+
 "jest@npm:^27.0.6, jest@npm:^27.3.1":
   version: 27.5.1
   resolution: "jest@npm:27.5.1"
@@ -9419,6 +10349,25 @@ __metadata:
   bin:
     jest: bin/jest.js
   checksum: 96f1d69042b3c6dfc695f2a4e4b0db38af6fb78582ad1a02beaa57cfcd77cbd31567d7d865c1c85709b7c3e176eefa3b2035ffecd646005f15d8ef528eccf205
+  languageName: node
+  linkType: hard
+
+"jest@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "jest@npm:29.0.3"
+  dependencies:
+    "@jest/core": ^29.0.3
+    "@jest/types": ^29.0.3
+    import-local: ^3.0.2
+    jest-cli: ^29.0.3
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  bin:
+    jest: bin/jest.js
+  checksum: 6bffa1ec703dbf64ce79aa7ef2887b586fdc96881cf2b83c8e86569237124a17aa001ddd4e7be7877202abe530ee5c04e9f0dd54e7320533b05b90709aca2607
   languageName: node
   linkType: hard
 
@@ -10741,7 +11690,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7":
+"node-fetch@npm:2.6.7, node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7":
   version: 2.6.7
   resolution: "node-fetch@npm:2.6.7"
   dependencies:
@@ -11108,6 +12057,15 @@ __metadata:
   dependencies:
     p-try: ^2.0.0
   checksum: 84ff17f1a38126c3314e91ecfe56aecbf36430940e2873dadaa773ffe072dc23b7af8e46d4b6485d302a11673fe94c6b67ca2cfbb60c989848b02100d0594ac1
+  languageName: node
+  linkType: hard
+
+"p-limit@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "p-limit@npm:3.1.0"
+  dependencies:
+    yocto-queue: ^0.1.0
+  checksum: 7c3690c4dbf62ef625671e20b7bdf1cbc9534e83352a2780f165b0d3ceba21907e77ad63401708145ca4e25bfc51636588d89a8c0aeb715e6c37d1c066430360
   languageName: node
   linkType: hard
 
@@ -11527,6 +12485,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pretty-format@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "pretty-format@npm:29.0.3"
+  dependencies:
+    "@jest/schemas": ^29.0.0
+    ansi-styles: ^5.0.0
+    react-is: ^18.0.0
+  checksum: 239aa73b09919b195353e62530908b43883af66e3ba8ecb5fda77578b20f297fd774fcf53abbedcb6cfff72521e8a220052a49e6a0e29418082d06386da27bac
+  languageName: node
+  linkType: hard
+
 "process-es6@npm:^0.11.2, process-es6@npm:^0.11.6":
   version: 0.11.6
   resolution: "process-es6@npm:0.11.6"
@@ -11552,6 +12521,13 @@ __metadata:
   version: 1.0.1
   resolution: "promise-inflight@npm:1.0.1"
   checksum: 22749483091d2c594261517f4f80e05226d4d5ecc1fc917e1886929da56e22b5718b7f2a75f3807e7a7d471bc3be2907fe92e6e8f373ddf5c64bae35b5af3981
+  languageName: node
+  linkType: hard
+
+"promise-polyfill@npm:^8.1.3":
+  version: 8.2.3
+  resolution: "promise-polyfill@npm:8.2.3"
+  checksum: f320278bab8b8ce32f0e2f377d75aabe35c90a79f92b3e001db084d635da1fb8740ba8a26b5c1c2b4cdca5a4c988f9b6b3eb30f0b151d0362d3d9c1675024a8f
   languageName: node
   linkType: hard
 
@@ -11851,6 +12827,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-dom@npm:^18.2.0":
+  version: 18.2.0
+  resolution: "react-dom@npm:18.2.0"
+  dependencies:
+    loose-envify: ^1.1.0
+    scheduler: ^0.23.0
+  peerDependencies:
+    react: ^18.2.0
+  checksum: 7d323310bea3a91be2965f9468d552f201b1c27891e45ddc2d6b8f717680c95a75ae0bc1e3f5cf41472446a2589a75aed4483aee8169287909fcd59ad149e8cc
+  languageName: node
+  linkType: hard
+
 "react-error-boundary@npm:^3.0.0":
   version: 3.1.4
   resolution: "react-error-boundary@npm:3.1.4"
@@ -11892,7 +12880,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^18.2.0":
+"react-is@npm:^18.0.0, react-is@npm:^18.2.0":
   version: 18.2.0
   resolution: "react-is@npm:18.2.0"
   checksum: e72d0ba81b5922759e4aff17e0252bd29988f9642ed817f56b25a3e217e13eea8a7f2322af99a06edb779da12d5d636e9fda473d620df9a3da0df2a74141d53e
@@ -11947,6 +12935,15 @@ __metadata:
     loose-envify: ^1.1.0
     object-assign: ^4.1.1
   checksum: b254cc17ce3011788330f7bbf383ab653c6848902d7936a87b09d835d091e3f295f7e9dd1597c6daac5dc80f90e778c8230218ba8ad599f74adcc11e33b9d61b
+  languageName: node
+  linkType: hard
+
+"react@npm:^18.2.0":
+  version: 18.2.0
+  resolution: "react@npm:18.2.0"
+  dependencies:
+    loose-envify: ^1.1.0
+  checksum: 88e38092da8839b830cda6feef2e8505dec8ace60579e46aa5490fc3dc9bba0bd50336507dc166f43e3afc1c42939c09fe33b25fae889d6f402721dcd78fca1b
   languageName: node
   linkType: hard
 
@@ -12448,7 +13445,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:6.6.7, rxjs@npm:^6.0.0, rxjs@npm:^6.6.0":
+"rxjs@npm:6.6.7, rxjs@npm:^6.0.0, rxjs@npm:^6.5.2, rxjs@npm:^6.6.0":
   version: 6.6.7
   resolution: "rxjs@npm:6.6.7"
   dependencies:
@@ -12512,6 +13509,15 @@ __metadata:
     loose-envify: ^1.1.0
     object-assign: ^4.1.1
   checksum: c4b35cf967c8f0d3e65753252d0f260271f81a81e427241295c5a7b783abf4ea9e905f22f815ab66676f5313be0a25f47be582254db8f9241b259213e999b8fc
+  languageName: node
+  linkType: hard
+
+"scheduler@npm:^0.23.0":
+  version: 0.23.0
+  resolution: "scheduler@npm:0.23.0"
+  dependencies:
+    loose-envify: ^1.1.0
+  checksum: d79192eeaa12abef860c195ea45d37cbf2bbf5f66e3c4dcd16f54a7da53b17788a70d109ee3d3dde1a0fd50e6a8fc171f4300356c5aee4fc0171de526bf35f8a
   languageName: node
   linkType: hard
 
@@ -12892,6 +13898,16 @@ __metadata:
     atob: ^2.1.2
     decode-uri-component: ^0.2.0
   checksum: fe503b9e5dac1c54be835282fcfec10879434e7b3ee08a9774f230299c724a8d403484d9531276d1670c87390e0e4d1d3f92b14cca6e4a2445ea3016b786ecd4
+  languageName: node
+  linkType: hard
+
+"source-map-support@npm:0.5.13":
+  version: 0.5.13
+  resolution: "source-map-support@npm:0.5.13"
+  dependencies:
+    buffer-from: ^1.0.0
+    source-map: ^0.6.0
+  checksum: 933550047b6c1a2328599a21d8b7666507427c0f5ef5eaadd56b5da0fd9505e239053c66fe181bf1df469a3b7af9d775778eee283cbb7ae16b902ddc09e93a97
   languageName: node
   linkType: hard
 
@@ -13651,6 +14667,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-jest@npm:^29.0.0":
+  version: 29.0.0
+  resolution: "ts-jest@npm:29.0.0"
+  dependencies:
+    bs-logger: 0.x
+    fast-json-stable-stringify: 2.x
+    jest-util: ^29.0.0
+    json5: ^2.2.1
+    lodash.memoize: 4.x
+    make-error: 1.x
+    semver: 7.x
+    yargs-parser: ^21.0.1
+  peerDependencies:
+    "@babel/core": ">=7.0.0-beta.0 <8"
+    "@jest/types": ^29.0.0
+    babel-jest: ^29.0.0
+    jest: ^29.0.0
+    typescript: ">=4.3"
+  peerDependenciesMeta:
+    "@babel/core":
+      optional: true
+    "@jest/types":
+      optional: true
+    babel-jest:
+      optional: true
+    esbuild:
+      optional: true
+  bin:
+    ts-jest: cli.js
+  checksum: f4e811aa910b7cd2ef6a9269700dda17ccf253ebdb6ba9e596982d238292d6482973e670e7a6875209e7d246cdf575d79590fc503e12e9368e9105d1d74f09fc
+  languageName: node
+  linkType: hard
+
 "ts-loader@npm:^9.2.3":
   version: 9.3.1
   resolution: "ts-loader@npm:9.3.1"
@@ -14150,6 +15199,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"v8-to-istanbul@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "v8-to-istanbul@npm:9.0.1"
+  dependencies:
+    "@jridgewell/trace-mapping": ^0.3.12
+    "@types/istanbul-lib-coverage": ^2.0.1
+    convert-source-map: ^1.6.0
+  checksum: a49c34bf0a3af0c11041a3952a2600913904a983bd1bc87148b5c033bc5c1d02d5a13620fcdbfa2c60bc582a2e2970185780f0c844b4c3a220abf405f8af6311
+  languageName: node
+  linkType: hard
+
 "validate-npm-package-license@npm:^3.0.1":
   version: 3.0.4
   resolution: "validate-npm-package-license@npm:3.0.4"
@@ -14230,7 +15290,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"walker@npm:^1.0.7":
+"walker@npm:^1.0.7, walker@npm:^1.0.8":
   version: 1.0.8
   resolution: "walker@npm:1.0.8"
   dependencies:
@@ -14530,6 +15590,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"write-file-atomic@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "write-file-atomic@npm:4.0.2"
+  dependencies:
+    imurmurhash: ^0.1.4
+    signal-exit: ^3.0.7
+  checksum: 5da60bd4eeeb935eec97ead3df6e28e5917a6bd317478e4a85a5285e8480b8ed96032bbcc6ecd07b236142a24f3ca871c924ec4a6575e623ec1b11bf8c1c253c
+  languageName: node
+  linkType: hard
+
 "ws@npm:^7.4.6":
   version: 7.5.9
   resolution: "ws@npm:7.5.9"
@@ -14641,6 +15711,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yargs-parser@npm:^21.0.0, yargs-parser@npm:^21.0.1":
+  version: 21.1.1
+  resolution: "yargs-parser@npm:21.1.1"
+  checksum: ed2d96a616a9e3e1cc7d204c62ecc61f7aaab633dcbfab2c6df50f7f87b393993fe6640d017759fe112d0cb1e0119f2b4150a87305cc873fd90831c6a58ccf1c
+  languageName: node
+  linkType: hard
+
 "yargs@npm:^16.2.0":
   version: 16.2.0
   resolution: "yargs@npm:16.2.0"
@@ -14653,6 +15730,21 @@ __metadata:
     y18n: ^5.0.5
     yargs-parser: ^20.2.2
   checksum: b14afbb51e3251a204d81937c86a7e9d4bdbf9a2bcee38226c900d00f522969ab675703bee2a6f99f8e20103f608382936034e64d921b74df82b63c07c5e8f59
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^17.3.1":
+  version: 17.5.1
+  resolution: "yargs@npm:17.5.1"
+  dependencies:
+    cliui: ^7.0.2
+    escalade: ^3.1.1
+    get-caller-file: ^2.0.5
+    require-directory: ^2.1.1
+    string-width: ^4.2.3
+    y18n: ^5.0.5
+    yargs-parser: ^21.0.0
+  checksum: 00d58a2c052937fa044834313f07910fd0a115dec5ee35919e857eeee3736b21a4eafa8264535800ba8bac312991ce785ecb8a51f4d2cc8c4676d865af1cfbde
   languageName: node
   linkType: hard
 
@@ -14670,5 +15762,12 @@ __metadata:
   version: 3.1.1
   resolution: "yn@npm:3.1.1"
   checksum: 2c487b0e149e746ef48cda9f8bad10fc83693cd69d7f9dcd8be4214e985de33a29c9e24f3c0d6bcf2288427040a8947406ab27f7af67ee9456e6b84854f02dd6
+  languageName: node
+  linkType: hard
+
+"yocto-queue@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "yocto-queue@npm:0.1.0"
+  checksum: f77b3d8d00310def622123df93d4ee654fc6a0096182af8bd60679ddcdfb3474c56c6c7190817c84a2785648cdee9d721c0154eb45698c62176c322fb46fc700
   languageName: node
   linkType: hard


### PR DESCRIPTION
Resolves #44 

With this, the sequence track shows the sequence for an Apollo assembly, and the "Get sequence" from the rubber band menu works.

Draft until https://github.com/GMOD/jbrowse-components/pull/3183 is merged.

Also includes some updates to the plugin test config, a test for the adapter, and a new CI step that runs the tests on PRs.