### PR TITLE
Use submitChange instead of calling change endpoint

### DIFF
--- a/packages/apollo-shared/src/BackendDrivers/BackendDriver.ts
+++ b/packages/apollo-shared/src/BackendDrivers/BackendDriver.ts
@@ -1,6 +1,7 @@
 import { Region } from '@jbrowse/core/util'
 import { AnnotationFeatureSnapshot } from 'apollo-mst'
 
+import { SubmitOpts } from '../ChangeManager'
 import { Change, ClientDataStore } from '../ChangeManager/Change'
 import { ValidationResultSet } from '../Validations/ValidationSet'
 
@@ -13,5 +14,8 @@ export abstract class BackendDriver {
 
   abstract getRefSeqs(): Promise<string[]>
 
-  abstract submitChange(change: Change): Promise<ValidationResultSet>
+  abstract submitChange(
+    change: Change,
+    opts: SubmitOpts,
+  ): Promise<ValidationResultSet>
 }

--- a/packages/apollo-shared/src/ChangeManager/AddAssemblyAndFeaturesFromFileChange.ts
+++ b/packages/apollo-shared/src/ChangeManager/AddAssemblyAndFeaturesFromFileChange.ts
@@ -44,6 +44,10 @@ export class AddAssemblyAndFeaturesFromFileChange extends FeatureChange {
     this.changes = 'changes' in json ? json.changes : [json]
   }
 
+  get notification(): string {
+    return `Assembly "${this.changes[0].assemblyName}" added successfully. To use it, please refresh the page.`
+  }
+
   toJSON() {
     if (this.changes.length === 1) {
       const [{ fileId }] = this.changes

--- a/packages/apollo-shared/src/ChangeManager/AddAssemblyAndFeaturesFromFileChange.ts
+++ b/packages/apollo-shared/src/ChangeManager/AddAssemblyAndFeaturesFromFileChange.ts
@@ -48,13 +48,14 @@ export class AddAssemblyAndFeaturesFromFileChange extends FeatureChange {
     return `Assembly "${this.changes[0].assemblyName}" added successfully. To use it, please refresh the page.`
   }
 
-  toJSON() {
+  toJSON(): SerializedAddAssemblyAndFeaturesFromFileChange {
     if (this.changes.length === 1) {
-      const [{ fileId }] = this.changes
+      const [{ fileId, assemblyName }] = this.changes
       return {
         typeName: this.typeName,
         changedIds: this.changedIds,
         assemblyId: this.assemblyId,
+        assemblyName,
         fileId,
       }
     }

--- a/packages/apollo-shared/src/ChangeManager/AddAssemblyFromFileChange.ts
+++ b/packages/apollo-shared/src/ChangeManager/AddAssemblyFromFileChange.ts
@@ -46,13 +46,14 @@ export class AddAssemblyFromFileChange extends FeatureChange {
     return `Assembly "${this.changes[0].assemblyName}" added successfully. To use it, please refresh the page.`
   }
 
-  toJSON() {
+  toJSON(): SerializedAddAssemblyFromFileChange {
     if (this.changes.length === 1) {
-      const [{ fileId }] = this.changes
+      const [{ fileId, assemblyName }] = this.changes
       return {
         typeName: this.typeName,
         changedIds: this.changedIds,
         assemblyId: this.assemblyId,
+        assemblyName,
         fileId,
       }
     }

--- a/packages/apollo-shared/src/ChangeManager/AddAssemblyFromFileChange.ts
+++ b/packages/apollo-shared/src/ChangeManager/AddAssemblyFromFileChange.ts
@@ -42,6 +42,10 @@ export class AddAssemblyFromFileChange extends FeatureChange {
     this.changes = 'changes' in json ? json.changes : [json]
   }
 
+  get notification(): string {
+    return `Assembly "${this.changes[0].assemblyName}" added successfully. To use it, please refresh the page.`
+  }
+
   toJSON() {
     if (this.changes.length === 1) {
       const [{ fileId }] = this.changes

--- a/packages/apollo-shared/src/ChangeManager/AddFeaturesFromFileChange.ts
+++ b/packages/apollo-shared/src/ChangeManager/AddFeaturesFromFileChange.ts
@@ -43,6 +43,10 @@ export class AddFeaturesFromFileChange extends FeatureChange {
     this.changes = 'changes' in json ? json.changes : [json]
   }
 
+  get notification(): string {
+    return `Features have been added. To see them, please refresh the page.`
+  }
+
   toJSON(): SerializedAddFeaturesFromFileChange {
     if (this.changes.length === 1) {
       const [{ fileId }] = this.changes

--- a/packages/apollo-shared/src/ChangeManager/Change.ts
+++ b/packages/apollo-shared/src/ChangeManager/Change.ts
@@ -73,6 +73,14 @@ export abstract class Change implements SerializedChange {
     this.logger = options?.logger || console
   }
 
+  /**
+   * If a non-empty string, a snackbar will display in JBrowse with this message
+   * when a successful response is received from the server.
+   */
+  get notification() {
+    return ''
+  }
+
   static fromJSON(json: SerializedChange, options?: ChangeOptions): Change {
     const ChangeType = changeRegistry.getChangeType(json.typeName)
     return new ChangeType(json, options?.logger && { logger: options.logger })

--- a/packages/apollo-shared/src/ChangeManager/ChangeManager.ts
+++ b/packages/apollo-shared/src/ChangeManager/ChangeManager.ts
@@ -40,8 +40,14 @@ export class ChangeManager {
       return
     }
 
-    // submit to client data store
-    await change.apply(this.dataStore)
+    try {
+      // submit to client data store
+      await change.apply(this.dataStore)
+    } catch (error) {
+      console.error(error)
+      session.notify(String(error), 'error')
+      return
+    }
 
     // post-validate
     const results2 = await this.validations.frontendPostValidate(
@@ -61,7 +67,7 @@ export class ChangeManager {
       }
       let backendResult: ValidationResultSet
       try {
-        backendResult = await backendDriver.submitChange(change)
+        backendResult = await backendDriver.submitChange(change, opts)
       } catch (error) {
         console.error(error)
         session.notify(String(error), 'error')

--- a/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
@@ -6,15 +6,11 @@ import { ApolloLoginForm } from './components/ApolloLoginForm'
 import { ApolloInternetAccountConfigModel } from './configSchema'
 
 const stateModelFactory = (configSchema: ApolloInternetAccountConfigModel) => {
-  return types
-    .compose(
-      'ApolloInternetAccount',
-      InternetAccount,
-      types.model({
-        type: types.literal('ApolloInternetAccount'),
-        configuration: ConfigurationReference(configSchema),
-      }),
-    )
+  return InternetAccount.named('ApolloInternetAccount')
+    .props({
+      type: types.literal('ApolloInternetAccount'),
+      configuration: ConfigurationReference(configSchema),
+    })
     .views((self) => ({
       get internetAccountType() {
         return 'ApolloInternetAccount'

--- a/packages/jbrowse-plugin-apollo/src/ApolloRenderer/components/ApolloRendering.tsx
+++ b/packages/jbrowse-plugin-apollo/src/ApolloRenderer/components/ApolloRendering.tsx
@@ -304,16 +304,16 @@ function ApolloRendering(props: ApolloRenderingProps) {
                 session,
                 handleClose: () => {
                   doneCallback()
+                  setContextMenuFeature(undefined)
                 },
                 changeManager,
                 sourceFeature: contextMenuFeature,
                 sourceAssemblyId: currentAssemblyId,
               },
             ])
-            setContextMenuFeature(undefined)
           }}
         >
-          {'Add child feature'}
+          Add child feature
         </MenuItem>
         <MenuItem
           key={2}
@@ -326,16 +326,16 @@ function ApolloRendering(props: ApolloRenderingProps) {
                 session,
                 handleClose: () => {
                   doneCallback()
+                  setContextMenuFeature(undefined)
                 },
                 changeManager,
-                sourceFeature: contextMenuFeature,
+                sourceFeatureId: contextMenuFeature?._id,
                 sourceAssemblyId: currentAssemblyId,
               },
             ])
-            setContextMenuFeature(undefined)
           }}
         >
-          {'Copy features and annotations'}
+          Copy features and annotations
         </MenuItem>
         <MenuItem
           key={3}
@@ -348,6 +348,7 @@ function ApolloRendering(props: ApolloRenderingProps) {
                 session,
                 handleClose: () => {
                   doneCallback()
+                  setContextMenuFeature(undefined)
                 },
                 changeManager,
                 sourceFeature: contextMenuFeature,
@@ -356,10 +357,9 @@ function ApolloRendering(props: ApolloRenderingProps) {
                 setSelectedFeature,
               },
             ])
-            setContextMenuFeature(undefined)
           }}
         >
-          {'Delete feature'}
+          Delete feature
         </MenuItem>
       </Menu>
       <canvas

--- a/packages/jbrowse-plugin-apollo/src/components/CopyFeature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/CopyFeature.tsx
@@ -10,7 +10,7 @@ import {
   Select,
   SelectChangeEvent,
 } from '@mui/material'
-import { ChangeManager } from 'apollo-shared'
+import { ChangeManager, CopyFeatureChange } from 'apollo-shared'
 import { getRoot } from 'mobx-state-tree'
 import React, { useEffect, useState } from 'react'
 
@@ -37,7 +37,6 @@ export function CopyFeature({
   changeManager,
 }: CopyFeatureProps) {
   const { internetAccounts } = getRoot(session) as AppRootModel
-  const { notify } = session
   const apolloInternetAccount = internetAccounts.find(
     (ia) => ia.type === 'ApolloInternetAccount',
   ) as ApolloInternetAccountModel | undefined
@@ -45,16 +44,12 @@ export function CopyFeature({
     throw new Error('No Apollo internet account found')
   }
   const { baseURL } = apolloInternetAccount
-  const [assemblyName, setAssemblyName] = useState('')
   const [collection, setCollection] = useState<Collection[]>([])
   const [assemblyId, setAssemblyId] = useState('')
   const [errorMessage, setErrorMessage] = useState('')
 
   function handleChangeAssembly(e: SelectChangeEvent<string>) {
     setAssemblyId(e.target.value as string)
-    setAssemblyName(
-      collection.find((i) => i._id === e.target.value)?.name as string,
-    )
   }
 
   useEffect(() => {
@@ -106,44 +101,14 @@ export function CopyFeature({
   async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
     setErrorMessage('')
-    let msg
-
-    // Add features
-    const uri = new URL('changes', baseURL).href
-    const apolloFetch = apolloInternetAccount?.getFetcher({
-      locationType: 'UriLocation',
-      uri,
+    const change = new CopyFeatureChange({
+      changedIds: ['1'],
+      typeName: 'CopyFeatureChange',
+      assemblyId: sourceAssemblyId,
+      featureId: sourceFeatureId,
+      targetAssemblyId: assemblyId,
     })
-    if (apolloFetch) {
-      const res = await apolloFetch(uri, {
-        method: 'POST',
-        body: JSON.stringify({
-          changedIds: ['1'],
-          typeName: 'CopyFeatureChange',
-          assemblyId: sourceAssemblyId,
-          featureId: sourceFeatureId,
-          targetAssemblyId: assemblyId,
-        }),
-        headers: new Headers({ 'Content-Type': 'application/json' }),
-      })
-      if (!res.ok) {
-        try {
-          msg = await res.text()
-        } catch (e) {
-          msg = ''
-        }
-        setErrorMessage(
-          `Error when copying features — ${res.status} (${res.statusText})${
-            msg ? ` (${msg})` : ''
-          }`,
-        )
-        return
-      }
-    }
-    notify(
-      `Features copied to assembly "${assemblyName}" successfully`,
-      'success',
-    )
+    await changeManager.submit(change)
     handleClose()
     event.preventDefault()
   }

--- a/packages/jbrowse-plugin-apollo/src/components/CopyFeature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/CopyFeature.tsx
@@ -11,6 +11,7 @@ import {
   SelectChangeEvent,
 } from '@mui/material'
 import { ChangeManager, CopyFeatureChange } from 'apollo-shared'
+import ObjectID from 'bson-objectid'
 import { getRoot } from 'mobx-state-tree'
 import React, { useEffect, useState } from 'react'
 
@@ -101,16 +102,17 @@ export function CopyFeature({
   async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
     setErrorMessage('')
+    const newFeatureId = new ObjectID().toHexString()
     const change = new CopyFeatureChange({
-      changedIds: ['1'],
+      changedIds: [newFeatureId],
       typeName: 'CopyFeatureChange',
       assemblyId: sourceAssemblyId,
       featureId: sourceFeatureId,
+      newFeatureId,
       targetAssemblyId: assemblyId,
     })
-    await changeManager.submit(change)
+    changeManager.submit(change)
     handleClose()
-    event.preventDefault()
   }
 
   return (

--- a/packages/jbrowse-plugin-apollo/src/components/ImportFeatures.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/ImportFeatures.tsx
@@ -152,7 +152,7 @@ export function ImportFeatures({
             {submitted ? 'Submitting...' : 'Submit'}
           </Button>
           <Button
-            disabled={!(assemblyName && file) || submitted}
+            disabled={submitted}
             variant="outlined"
             type="submit"
             onClick={() => {

--- a/packages/jbrowse-plugin-apollo/src/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/index.ts
@@ -111,6 +111,8 @@ export default class ApolloPlugin extends Plugin {
               handleClose: () => {
                 doneCallback()
               },
+              changeManager: (session as ApolloSessionModel).apolloDataStore
+                .changeManager,
             },
           ])
         },
@@ -125,6 +127,8 @@ export default class ApolloPlugin extends Plugin {
               handleClose: () => {
                 doneCallback()
               },
+              changeManager: (session as ApolloSessionModel).apolloDataStore
+                .changeManager,
             },
           ])
         },

--- a/packages/jbrowse-plugin-apollo/src/session.ts
+++ b/packages/jbrowse-plugin-apollo/src/session.ts
@@ -58,7 +58,6 @@ const ClientDataStore = types
       types.enumeration('backendDriverType', ['CollaborationServerDriver']),
       'CollaborationServerDriver',
     ),
-    internetAccountConfigId: types.maybe(types.string),
   })
   .views((self) => ({
     get internetAccounts() {


### PR DESCRIPTION
This uses `changeManager.submitChange` instead of calling the `/change` API endpoint directly, so it goes through all the verifications and has better type checking on the change object. It also adds a way to select a particular collaboration server if multiple are configured when adding an assembly.