### PR TITLE
Validation registry

### DIFF
--- a/packages/apollo-collaboration-server/src/changes/changes.service.ts
+++ b/packages/apollo-collaboration-server/src/changes/changes.service.ts
@@ -21,7 +21,6 @@ import {
 import {
   SerializedChange,
   changeRegistry,
-  changes,
   validationRegistry,
 } from 'apollo-shared'
 import { FilterQuery, Model } from 'mongoose'
@@ -45,11 +44,7 @@ export class ChangesService {
     @InjectModel(Change.name)
     private readonly changeModel: Model<ChangeDocument>,
     private readonly filesService: FilesService,
-  ) {
-    Object.entries(changes).forEach(([changeName, change]) => {
-      changeRegistry.registerChange(changeName, change)
-    })
-  }
+  ) {}
 
   private readonly logger = new Logger(ChangesService.name)
 

--- a/packages/apollo-collaboration-server/src/changes/changes.service.ts
+++ b/packages/apollo-collaboration-server/src/changes/changes.service.ts
@@ -19,12 +19,10 @@ import {
   RefSeqDocument,
 } from 'apollo-schemas'
 import {
-  CoreValidation,
-  ParentChildValidation,
   SerializedChange,
-  ValidationSet,
   changeRegistry,
   changes,
+  validationRegistry,
 } from 'apollo-shared'
 import { FilterQuery, Model } from 'mongoose'
 
@@ -54,17 +52,13 @@ export class ChangesService {
   }
 
   private readonly logger = new Logger(ChangesService.name)
-  private readonly validations = new ValidationSet([
-    new CoreValidation(),
-    new ParentChildValidation(),
-  ])
 
   async create(serializedChange: SerializedChange) {
     const ChangeType = changeRegistry.getChangeType(serializedChange.typeName)
     const change = new ChangeType(serializedChange, { logger: this.logger })
     this.logger.debug(`Requested change: ${JSON.stringify(change)}`)
 
-    const validationResult = await this.validations.backendPreValidate(change)
+    const validationResult = await validationRegistry.backendPreValidate(change)
     if (!validationResult.ok) {
       const errorMessage = validationResult.results
         .map((r) => r.error?.message)
@@ -106,7 +100,7 @@ export class ChangesService {
         { session },
       )
       changeDoc = savedChangedLogDoc
-      const validationResult2 = await this.validations.backendPostValidate(
+      const validationResult2 = await validationRegistry.backendPostValidate(
         change,
         { featureModel: this.featureModel, session },
       )

--- a/packages/apollo-collaboration-server/src/main.ts
+++ b/packages/apollo-collaboration-server/src/main.ts
@@ -1,4 +1,9 @@
 import { HttpAdapterHost, NestFactory } from '@nestjs/core'
+import {
+  CoreValidation,
+  ParentChildValidation,
+  validationRegistry,
+} from 'apollo-shared'
 
 import { AppModule } from './app.module'
 import { GlobalExceptionsFilter } from './global-exceptions.filter'
@@ -14,6 +19,10 @@ async function bootstrap() {
   if (!APPLICATION_PORT) {
     throw new Error('No APPLICATION_PORT found in .env file')
   }
+
+  validationRegistry.registerValidation(new CoreValidation())
+  validationRegistry.registerValidation(new ParentChildValidation())
+
   const cors = convertToBoolean(CORS)
   const loggerOpions = JSON.parse(LOGGER_OPTIONS)
   const app = await NestFactory.create(AppModule, {

--- a/packages/apollo-collaboration-server/src/main.ts
+++ b/packages/apollo-collaboration-server/src/main.ts
@@ -2,6 +2,8 @@ import { HttpAdapterHost, NestFactory } from '@nestjs/core'
 import {
   CoreValidation,
   ParentChildValidation,
+  changeRegistry,
+  changes,
   validationRegistry,
 } from 'apollo-shared'
 
@@ -19,6 +21,10 @@ async function bootstrap() {
   if (!APPLICATION_PORT) {
     throw new Error('No APPLICATION_PORT found in .env file')
   }
+
+  Object.entries(changes).forEach(([changeName, change]) => {
+    changeRegistry.registerChange(changeName, change)
+  })
 
   validationRegistry.registerValidation(new CoreValidation())
   validationRegistry.registerValidation(new ParentChildValidation())

--- a/packages/apollo-shared/src/ChangeManager/ChangeManager.ts
+++ b/packages/apollo-shared/src/ChangeManager/ChangeManager.ts
@@ -3,7 +3,7 @@ import { IAnyStateTreeNode } from 'mobx-state-tree'
 
 import {
   ValidationResultSet,
-  ValidationSet,
+  validationRegistry,
 } from '../Validations/ValidationSet'
 import { Change, ClientDataStore } from './Change'
 
@@ -17,10 +17,7 @@ export interface SubmitOpts {
 }
 
 export class ChangeManager {
-  constructor(
-    private dataStore: ClientDataStore & IAnyStateTreeNode,
-    public validations: ValidationSet,
-  ) {}
+  constructor(private dataStore: ClientDataStore & IAnyStateTreeNode) {}
 
   recentChanges: Change[] = []
 
@@ -28,7 +25,7 @@ export class ChangeManager {
     const { submitToBackend = true, addToRecents = true } = opts
     // pre-validate
     const session = getSession(this.dataStore)
-    const result = await this.validations.frontendPreValidate(change)
+    const result = await validationRegistry.frontendPreValidate(change)
     if (!result.ok) {
       session.notify(
         `Pre-validation failed: "${result.results
@@ -50,7 +47,7 @@ export class ChangeManager {
     }
 
     // post-validate
-    const results2 = await this.validations.frontendPostValidate(
+    const results2 = await validationRegistry.frontendPostValidate(
       change,
       this.dataStore,
     )

--- a/packages/apollo-shared/src/Validations/ValidationSet.ts
+++ b/packages/apollo-shared/src/Validations/ValidationSet.ts
@@ -16,10 +16,10 @@ export class ValidationResultSet {
 }
 
 export class ValidationSet {
-  validations: Set<Validation>
+  validations: Set<Validation> = new Set()
 
-  constructor(v: Validation[]) {
-    this.validations = new Set(v)
+  registerValidation(validation: Validation): void {
+    this.validations.add(validation)
   }
 
   async frontendPreValidate(change: Change): Promise<ValidationResultSet> {
@@ -92,3 +92,6 @@ export class ValidationSet {
     return undefined
   }
 }
+
+/** global singleton of all known types of changes */
+export const validationRegistry = new ValidationSet()

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/ApolloDetails.tsx
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/ApolloDetails.tsx
@@ -11,10 +11,10 @@ import {
 import { AnnotationFeatureI } from 'apollo-mst'
 import {
   Change,
-  ChangeManager,
   LocationEndChange,
   LocationStartChange,
   TypeChange,
+  validationRegistry,
 } from 'apollo-shared'
 import { observer } from 'mobx-react'
 import React, { useEffect, useState } from 'react'
@@ -38,29 +38,21 @@ const featureColums: GridColumns = [
 ]
 
 function AutocompleteInputCell(props: GridRenderEditCellParams) {
-  const {
-    id,
-    value,
-    field,
-    row: { model },
-  } = props
-  const { changeManager } = model as { changeManager?: ChangeManager }
+  const { id, value, field } = props
   const [soSequenceTerms, setSOSequenceTerms] = useState<string[]>([])
   const apiRef = useGridApiContext()
 
   useEffect(() => {
     async function getSOSequenceTerms() {
-      if (!changeManager) {
-        return
-      }
-      const { validations } = changeManager
-      const soTerms = (await validations.possibleValues('type')) as string[]
+      const soTerms = (await validationRegistry.possibleValues(
+        'type',
+      )) as string[]
       if (soTerms) {
         setSOSequenceTerms(soTerms)
       }
     }
     getSOSequenceTerms()
-  }, [changeManager])
+  }, [])
 
   const handleChange = async (
     event: MuiBaseEvent,

--- a/packages/jbrowse-plugin-apollo/src/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/index.ts
@@ -9,7 +9,13 @@ import {
 import Plugin from '@jbrowse/core/Plugin'
 import PluginManager from '@jbrowse/core/PluginManager'
 import { AbstractSessionModel, isAbstractMenuManager } from '@jbrowse/core/util'
-import { changeRegistry, changes } from 'apollo-shared'
+import {
+  CoreValidation,
+  ParentChildValidation,
+  changeRegistry,
+  changes,
+  validationRegistry,
+} from 'apollo-shared'
 
 import { version } from '../package.json'
 import {
@@ -34,6 +40,9 @@ import { ApolloSessionModel, extendSession } from './session'
 Object.entries(changes).forEach(([changeName, change]) => {
   changeRegistry.registerChange(changeName, change)
 })
+
+validationRegistry.registerValidation(new CoreValidation())
+validationRegistry.registerValidation(new ParentChildValidation())
 
 export default class ApolloPlugin extends Plugin {
   name = 'ApolloPlugin'

--- a/packages/jbrowse-plugin-apollo/src/session.ts
+++ b/packages/jbrowse-plugin-apollo/src/session.ts
@@ -13,8 +13,6 @@ import {
   ChangeManager,
   ClientDataStore as ClientDataStoreType,
   CollaborationServerDriver,
-  CoreValidation,
-  ValidationSet,
 } from 'apollo-shared'
 import {
   IAnyModelType,
@@ -127,10 +125,7 @@ const ClientDataStore = types
     },
   }))
   .volatile((self) => ({
-    changeManager: new ChangeManager(
-      self as unknown as ClientDataStoreType,
-      new ValidationSet([new CoreValidation()]),
-    ),
+    changeManager: new ChangeManager(self as unknown as ClientDataStoreType),
   }))
   .volatile((self) => {
     if (self.backendDriverType !== 'CollaborationServerDriver') {


### PR DESCRIPTION
This creates a `validationRegistry` that's analogous to the `changeRegistry`, a global singleton where all validations are registered. The validations get registered in the initial app bootstrap. This PR also moves the registration of the changes to that same bootstrap step as well.

This addresses part of #136 