### PR TITLE
Add six frame feature display

### DIFF
--- a/packages/apollo-common/src/Change.ts
+++ b/packages/apollo-common/src/Change.ts
@@ -19,6 +19,7 @@ export interface ClientDataStore {
   assemblies: Map<string, ApolloAssemblyI>
   internetAccounts: AppRootModel['internetAccounts']
   loadFeatures(regions: Region[]): void
+  loadRefSeq(regions: Region[]): void
   getFeature(featureId: string): AnnotationFeatureI | undefined
   addAssembly(_id: string, assemblyName: string): void
   addFeature(assemblyId: string, feature: AnnotationFeatureSnapshot): void

--- a/packages/apollo-mst/src/AnnotationFeature.ts
+++ b/packages/apollo-mst/src/AnnotationFeature.ts
@@ -57,6 +57,9 @@ export const AnnotationFeature = types
     get length() {
       return self.end - self.start
     },
+    get testId() {
+      return self.attributes.get('id')
+    },
     /**
      * Possibly different from `start` because "The GFF3 format does not enforce
      * a rule in which features must be wholly contained within the location of

--- a/packages/apollo-mst/src/AnnotationFeature.ts
+++ b/packages/apollo-mst/src/AnnotationFeature.ts
@@ -57,7 +57,7 @@ export const AnnotationFeature = types
     get length() {
       return self.end - self.start
     },
-    get testId() {
+    get featureId() {
       return self.attributes.get('id')
     },
     /**

--- a/packages/apollo-mst/src/index.ts
+++ b/packages/apollo-mst/src/index.ts
@@ -2,11 +2,18 @@ import { Instance, SnapshotIn, types } from 'mobx-state-tree'
 
 import { AnnotationFeature } from './AnnotationFeature'
 
+export const Sequence = types.model({
+  start: types.number,
+  stop: types.number,
+  sequence: types.string,
+})
+
 export const ApolloRefSeq = types
   .model('ApolloRefSeq', {
     _id: types.identifier,
     name: types.string,
     features: types.map(AnnotationFeature),
+    sequence: types.array(Sequence),
   })
   .actions((self) => ({
     deleteFeature(featureId: string) {

--- a/packages/apollo-mst/src/index.ts
+++ b/packages/apollo-mst/src/index.ts
@@ -37,11 +37,14 @@ export const ApolloRefSeq = types
             // adjacent/overlapping to existing sequence - modify
             const newStart = Math.min(start, seq.start)
             const newStop = Math.max(stop, seq.stop)
-            let newSeq = seq.sequence
+            // let newSeq = seq.sequence
+            let newSeq = sequence
             if (seq.start < start) {
-              newSeq = newSeq.slice(0, start - seq.start).concat(sequence)
+              // newSeq = newSeq.slice(0, start - seq.start).concat(sequence)
+              newSeq = seq.sequence.slice(0, start - seq.start).concat(newSeq)
             }
             if (seq.stop > stop) {
+              // newSeq = sequence.concat(newSeq.slice(stop - seq.start))
               newSeq = newSeq.concat(seq.sequence.slice(stop - seq.start))
             }
             self.sequence.splice(i, 1, {

--- a/packages/apollo-mst/src/index.ts
+++ b/packages/apollo-mst/src/index.ts
@@ -1,4 +1,9 @@
-import { Instance, SnapshotIn, types } from 'mobx-state-tree'
+import {
+  Instance,
+  SnapshotIn,
+  SnapshotOrInstance,
+  types,
+} from 'mobx-state-tree'
 
 import { AnnotationFeature } from './AnnotationFeature'
 
@@ -18,6 +23,57 @@ export const ApolloRefSeq = types
   .actions((self) => ({
     deleteFeature(featureId: string) {
       return self.features.delete(featureId)
+    },
+    addSequence(seq: SnapshotOrInstance<typeof Sequence>) {
+      if (self.sequence.length === 0) {
+        self.sequence.push(seq)
+      } else {
+        let found = false
+        for (const [i, { start, stop, sequence }] of self.sequence.entries()) {
+          if (seq.stop < stop && seq.start > start) {
+            // already there - do nothing
+            found = true
+          } else if (seq.start < start || seq.stop > stop) {
+            // adjacent/overlapping to existing sequence - modify
+            const newStart = Math.min(start, seq.start)
+            const newStop = Math.max(stop, seq.stop)
+            let newSeq = seq.sequence
+            if (seq.start < start) {
+              newSeq = newSeq.slice(0, start - seq.start).concat(sequence)
+            }
+            if (seq.stop > stop) {
+              newSeq = newSeq.concat(seq.sequence.slice(stop - seq.start))
+            }
+            self.sequence.splice(i, 1, {
+              start: newStart,
+              stop: newStop,
+              sequence: newSeq,
+            })
+            found = true
+          }
+        }
+        if (!found) {
+          // not adjacent - add new item to array
+          self.sequence.push(seq)
+        }
+      }
+    },
+  }))
+  .views((self) => ({
+    getSequence(start: number, stop: number): string {
+      for (const {
+        start: seqStart,
+        stop: seqStop,
+        sequence,
+      } of self.sequence) {
+        // adjacent to existing sequence - modify
+        if (start < seqStop && stop > seqStart) {
+          return sequence.slice(start - seqStart, stop - seqStart)
+        }
+      }
+      throw new Error(
+        `No sequence detected for ${start}, ${stop} of region ${self.name}`,
+      )
     },
   }))
 

--- a/packages/apollo-mst/src/index.ts
+++ b/packages/apollo-mst/src/index.ts
@@ -13,6 +13,12 @@ export const Sequence = types.model({
   sequence: types.string,
 })
 
+interface SequenceSnapshot {
+  start: number
+  stop: number
+  sequence: string
+}
+
 export const ApolloRefSeq = types
   .model('ApolloRefSeq', {
     _id: types.identifier,
@@ -27,39 +33,49 @@ export const ApolloRefSeq = types
     addSequence(seq: SnapshotOrInstance<typeof Sequence>) {
       if (self.sequence.length === 0) {
         self.sequence.push(seq)
-      } else {
-        let found = false
-        for (const [i, { start, stop, sequence }] of self.sequence.entries()) {
-          if (seq.stop < stop && seq.start > start) {
-            // already there - do nothing
-            found = true
-          } else if (seq.start < start || seq.stop > stop) {
-            // adjacent/overlapping to existing sequence - modify
-            const newStart = Math.min(start, seq.start)
-            const newStop = Math.max(stop, seq.stop)
-            // let newSeq = seq.sequence
-            let newSeq = sequence
-            if (seq.start < start) {
-              // newSeq = newSeq.slice(0, start - seq.start).concat(sequence)
-              newSeq = seq.sequence.slice(0, start - seq.start).concat(newSeq)
-            }
-            if (seq.stop > stop) {
-              // newSeq = sequence.concat(newSeq.slice(stop - seq.start))
-              newSeq = newSeq.concat(seq.sequence.slice(stop - seq.start))
-            }
-            self.sequence.splice(i, 1, {
-              start: newStart,
-              stop: newStop,
-              sequence: newSeq,
-            })
-            found = true
-          }
-        }
-        if (!found) {
-          // not adjacent - add new item to array
-          self.sequence.push(seq)
-        }
+        return
       }
+      const newSequences: SequenceSnapshot[] = self.sequence.map((s) => ({
+        start: s.start,
+        stop: s.stop,
+        sequence: s.sequence,
+      }))
+      newSequences.push({
+        start: seq.start,
+        stop: seq.stop,
+        sequence: seq.sequence,
+      })
+      newSequences.sort((s1, s2) => s1.start - s2.start)
+      const consolidatedSequences = newSequences.reduce((result, current) => {
+        if (result.length === 0) {
+          return [current]
+        }
+        const lastRange = result[result.length - 1]
+        if (lastRange.stop >= current.start) {
+          if (current.stop > lastRange.stop) {
+            lastRange.stop = current.stop
+            lastRange.sequence += current.sequence.slice(
+              current.stop - lastRange.stop,
+            )
+          }
+        } else {
+          result.push(current)
+        }
+        return result
+      }, [] as SequenceSnapshot[])
+      if (
+        self.sequence.length === consolidatedSequences.length &&
+        self.sequence.every(
+          (s, idx) =>
+            s.start === consolidatedSequences[idx].start &&
+            s.stop === consolidatedSequences[idx].stop,
+        )
+      ) {
+        // sequences was unchanged
+        return
+      }
+      self.sequence.clear()
+      self.sequence.push(...consolidatedSequences)
     },
   }))
   .views((self) => ({
@@ -70,13 +86,11 @@ export const ApolloRefSeq = types
         sequence,
       } of self.sequence) {
         // adjacent to existing sequence - modify
-        if (start < seqStop && stop > seqStart) {
+        if (start <= seqStop && stop >= seqStart) {
           return sequence.slice(start - seqStart, stop - seqStart)
         }
       }
-      throw new Error(
-        `No sequence detected for ${start}, ${stop} of region ${self.name}`,
-      )
+      return ''
     },
   }))
 

--- a/packages/apollo-shared/src/Changes/DeleteFeatureChange.ts
+++ b/packages/apollo-shared/src/Changes/DeleteFeatureChange.ts
@@ -156,7 +156,6 @@ export class DeleteFeatureChange extends FeatureChange {
     throw new Error('executeOnLocalGFF3 not implemented')
   }
 
-
   async executeOnClient(dataStore: ClientDataStore) {
     if (!dataStore) {
       throw new Error('No data store')

--- a/packages/jbrowse-plugin-apollo/src/ApolloSixFrameRenderer/ApolloSixFrameRenderer.tsx
+++ b/packages/jbrowse-plugin-apollo/src/ApolloSixFrameRenderer/ApolloSixFrameRenderer.tsx
@@ -1,0 +1,12 @@
+import { RenderProps, RendererType } from '@jbrowse/core/pluggableElementTypes'
+import RpcManager from '@jbrowse/core/rpc/RpcManager'
+
+export default class ApolloSixFrameRenderer extends RendererType {
+  async renderInClient(_rpcManager: RpcManager, args: RenderProps) {
+    return this.render(args)
+  }
+
+  async freeResourcesInClient(_rpcManager: RpcManager, _args: RenderProps) {
+    return 0
+  }
+}

--- a/packages/jbrowse-plugin-apollo/src/ApolloSixFrameRenderer/components/ApolloRendering.tsx
+++ b/packages/jbrowse-plugin-apollo/src/ApolloSixFrameRenderer/components/ApolloRendering.tsx
@@ -1,0 +1,534 @@
+import { getConf } from '@jbrowse/core/configuration'
+import {
+  AppRootModel,
+  Region,
+  defaultStops,
+  defaultCodonTable,
+  generateCodonTable,
+  getSession,
+} from '@jbrowse/core/util'
+import { Menu, MenuItem } from '@mui/material'
+import { AnnotationFeatureI } from 'apollo-mst'
+import { LocationEndChange, LocationStartChange } from 'apollo-shared'
+import { autorun, toJS } from 'mobx'
+import { observer } from 'mobx-react'
+import { getRoot, getSnapshot, isAlive } from 'mobx-state-tree'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+
+import { ApolloInternetAccountModel } from '../../ApolloInternetAccount/model'
+import { AddFeature } from '../../components/AddFeature'
+import { CopyFeature } from '../../components/CopyFeature'
+import { DeleteFeature } from '../../components/DeleteFeature'
+import { Collaborator } from '../../session'
+import { SixFrameFeatureDisplay } from '../../SixFrameFeatureDisplay/stateModel'
+
+interface ApolloRenderingProps {
+  assemblyName: string
+  regions: Region[]
+  bpPerPx: number
+  displayModel: SixFrameFeatureDisplay
+  blockKey: string
+}
+
+type Coord = [number, number]
+
+function ApolloRendering(props: ApolloRenderingProps) {
+  const [contextCoord, setContextCoord] = useState<Coord>()
+  const [contextMenuFeature, setContextMenuFeature] =
+    useState<AnnotationFeatureI>()
+
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const overlayCanvasRef = useRef<HTMLCanvasElement>(null)
+  const [isAdmin, setIsAdmin] = useState<boolean>(false)
+  const [isReadOnly, setIsReadOnly] = useState<boolean>(true)
+  const [overEdge, setOverEdge] = useState<'start' | 'end'>()
+  const [dragging, setDragging] = useState<{
+    edge: 'start' | 'end'
+    feature: AnnotationFeatureI
+    row: number
+    bp: number
+    px: number
+  }>()
+  const [movedDuringLastMouseDown, setMovedDuringLastMouseDown] =
+    useState(false)
+  const [collaborators, setCollaborators] = useState<Collaborator[]>([])
+
+  const { regions, bpPerPx, displayModel } = props
+  const session = getSession(displayModel)
+  const { collaborators: collabs } = session
+
+  // bridging mobx observability and React useEffect observability
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => autorun(() => setCollaborators(toJS(collabs))), [])
+
+  const [region] = regions
+  const totalWidth = (region.end - region.start) / bpPerPx
+  const {
+    featureLayout,
+    apolloFeatureUnderMouse,
+    setApolloFeatureUnderMouse,
+    apolloRowUnderMouse,
+    setApolloRowUnderMouse,
+    changeManager,
+    getAssemblyId,
+    selectedFeature,
+    setSelectedFeature,
+    features,
+    featuresHeight: totalHeight,
+    apolloRowHeight: height,
+    showStartCodons,
+    showStopCodons,
+  } = displayModel
+  // use this to convince useEffect that the features really did change
+  const featureSnap = Array.from(features.values()).map((a) =>
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    Array.from(a.values()).map((f) => getSnapshot(f)),
+  )
+
+  const apolloInternetAccount = useMemo(() => {
+    const { internetAccounts } = getRoot(session) as AppRootModel
+    const { assemblyName } = region
+    const { assemblyManager } = getSession(displayModel)
+    const assembly = assemblyManager.get(assemblyName)
+    if (!assembly) {
+      throw new Error(`No assembly found with name ${assemblyName}`)
+    }
+    const { internetAccountConfigId } = getConf(assembly, [
+      'sequence',
+      'metadata',
+    ]) as { internetAccountConfigId: string }
+    const matchingAccount = internetAccounts.find(
+      (ia) => getConf(ia, 'internetAccountId') === internetAccountConfigId,
+    ) as ApolloInternetAccountModel | undefined
+    if (!matchingAccount) {
+      throw new Error(
+        `No InternetAccount found with config id ${internetAccountConfigId}`,
+      )
+    }
+    return matchingAccount
+  }, [displayModel, region, session])
+
+  const { authType, getRole } = apolloInternetAccount
+
+  useEffect(() => {
+    if (!authType) {
+      return
+    }
+    if (getRole()?.includes('admin')) {
+      setIsAdmin(true)
+    }
+    if (getRole()?.includes('admin') || getRole()?.includes('user')) {
+      setIsReadOnly(false)
+    }
+  }, [authType, getRole])
+
+  useEffect(() => {
+    if (!isAlive(region)) {
+      return
+    }
+    const canvas = canvasRef.current
+    if (!canvas) {
+      return
+    }
+    const ctx = canvas.getContext('2d')
+    if (!ctx) {
+      return
+    }
+    ctx.clearRect(0, 0, totalWidth, totalHeight)
+    for (const [row, featureInfos] of featureLayout) {
+      for (const [featureRow, feature] of featureInfos) {
+        if (featureRow > 0) {
+          continue
+        }
+        const start = region.reversed
+          ? region.end - feature.end
+          : feature.start - region.start - 1
+        const startPx = start / bpPerPx
+        feature.draw(
+          ctx,
+          startPx,
+          row * height,
+          bpPerPx,
+          height,
+          region.reversed,
+        )
+      }
+    }
+  }, [
+    region,
+    bpPerPx,
+    region.start,
+    region.end,
+    region.reversed,
+    totalWidth,
+    featureLayout,
+    totalHeight,
+    features,
+    height,
+    featureSnap,
+  ])
+  useEffect(() => {
+    if (!isAlive(region)) {
+      return
+    }
+  }, [
+    showStartCodons,
+    showStopCodons,
+  ])
+
+  useEffect(() => {
+    if (!isAlive(region)) {
+      return
+    }
+    const canvas = overlayCanvasRef.current
+    if (!canvas) {
+      return
+    }
+    const ctx = canvas.getContext('2d')
+    if (!ctx) {
+      return
+    }
+    ctx.clearRect(0, 0, totalWidth, totalHeight)
+    if (dragging) {
+      const { feature, row, edge, px } = dragging
+      const featureEdge = region.reversed
+        ? region.end - feature[edge]
+        : feature[edge] - region.start
+      const featureEdgePx = featureEdge / bpPerPx
+      const startPx = Math.min(px, featureEdgePx)
+      const widthPx = Math.abs(px - featureEdgePx)
+      ctx.strokeStyle = 'red'
+      ctx.setLineDash([6])
+      ctx.strokeRect(startPx, row * height, widthPx, height * feature.rowCount)
+      ctx.fillStyle = 'rgba(255,0,0,.2)'
+      ctx.fillRect(startPx, row * height, widthPx, height * feature.rowCount)
+    }
+    const feature = dragging?.feature || apolloFeatureUnderMouse
+    const row = dragging?.row || apolloRowUnderMouse
+    if (feature && row !== undefined) {
+      const start = region.reversed
+        ? region.end - feature.end
+        : feature.start - region.start - 1
+      const width = feature.length
+      const startPx = start / bpPerPx
+      const widthPx = width / bpPerPx
+      ctx.fillStyle = 'rgba(0,0,0,0.2)'
+      ctx.fillRect(startPx, row * height, widthPx, height * feature.rowCount)
+    }
+    for (const collaborator of collaborators) {
+      const { locations } = collaborator
+      if (!locations.length) {
+        return
+      }
+      for (const location of locations) {
+        const { start, end } = location
+        const locationStart = region.reversed
+          ? region.end - start
+          : start - region.start
+        const locationStartPx = locationStart / bpPerPx
+        const locationWidthPx = (end - start) / bpPerPx
+        ctx.fillStyle = 'rgba(0,255,0,.2)'
+        ctx.fillRect(locationStartPx, 1, locationWidthPx, 100)
+        ctx.fillStyle = 'black'
+        ctx.fillText(
+          collaborator.name,
+          locationStartPx + 1,
+          11,
+          locationWidthPx - 2,
+        )
+      }
+    }
+  }, [
+    apolloFeatureUnderMouse,
+    apolloRowUnderMouse,
+    bpPerPx,
+    totalHeight,
+    totalWidth,
+    region,
+    region.start,
+    region.end,
+    region.reversed,
+    dragging,
+    height,
+    collaborators,
+  ])
+
+  function onMouseMove(event: React.MouseEvent<HTMLCanvasElement, MouseEvent>) {
+    if (!isAlive(region)) {
+      return
+    }
+    const { clientX, clientY, buttons } = event
+    if (!movedDuringLastMouseDown && buttons === 1) {
+      setMovedDuringLastMouseDown(true)
+    }
+    const { left, top } = canvasRef.current?.getBoundingClientRect() || {
+      left: 0,
+      top: 0,
+    }
+    // get pixel coordinates within the whole canvas
+    let x = clientX - left
+    x = region.reversed ? totalWidth - x : x
+    const y = clientY - top
+
+    if (dragging) {
+      const { edge, feature, row } = dragging
+      let px = region.reversed ? totalWidth - x : x
+      let bp = region.start + x * bpPerPx
+      if (edge === 'start' && bp > feature.end - 1) {
+        bp = feature.end - 1
+        px = (region.reversed ? region.end - bp : bp - region.start) / bpPerPx
+      } else if (edge === 'end' && bp < feature.start + 1) {
+        bp = feature.start + 1
+        px = (region.reversed ? region.end - bp : bp - region.start) / bpPerPx
+      }
+      setDragging({
+        edge,
+        feature,
+        row,
+        px,
+        bp,
+      })
+      return
+    }
+
+    const row = Math.floor(y / height)
+    if (row === undefined) {
+      setApolloFeatureUnderMouse(undefined)
+      setApolloRowUnderMouse(undefined)
+      return
+    }
+    const layoutRow = featureLayout.get(row)
+    if (!layoutRow) {
+      setApolloFeatureUnderMouse(undefined)
+      setApolloRowUnderMouse(undefined)
+      return
+    }
+    const bp = region.start + bpPerPx * x
+    const [featureRow, feat] =
+      layoutRow.find((f) => bp >= f[1].min && bp <= f[1].max) || []
+    let feature: AnnotationFeatureI | undefined = feat
+    if (feature && featureRow) {
+      const topRow = row - featureRow
+      const startPx = (feature.start - region.start) / bpPerPx
+      const thisX = x - startPx
+      feature = feature.getFeatureFromLayout(
+        thisX,
+        y - topRow * height,
+        bpPerPx,
+        height,
+      ) as AnnotationFeatureI
+    }
+    if (feature) {
+      // TODO: check reversed
+      // TODO: ensure feature is in interbase
+      const startPx = (feature.start - region.start) / bpPerPx
+      const endPx = (feature.end - region.start) / bpPerPx
+      if (endPx - startPx < 8) {
+        setOverEdge(undefined)
+      } else if (Math.abs(startPx - x) < 4) {
+        setOverEdge('start')
+      } else if (Math.abs(endPx - x) < 4) {
+        setOverEdge('end')
+      } else {
+        setOverEdge(undefined)
+      }
+    }
+    setApolloFeatureUnderMouse(feature)
+    setApolloRowUnderMouse(row)
+  }
+  function onMouseLeave() {
+    setApolloFeatureUnderMouse(undefined)
+    setApolloRowUnderMouse(undefined)
+  }
+  function onMouseDown(event: React.MouseEvent) {
+    if (apolloFeatureUnderMouse && overEdge) {
+      const { clientX } = event
+      const { left } = canvasRef.current?.getBoundingClientRect() || {
+        left: 0,
+        top: 0,
+      }
+      const px = clientX - left
+      event.stopPropagation()
+      setDragging({
+        edge: overEdge,
+        feature: apolloFeatureUnderMouse,
+        row: apolloRowUnderMouse || 0,
+        px,
+        bp: apolloFeatureUnderMouse[overEdge],
+      })
+    }
+  }
+  function onMouseUp() {
+    if (!movedDuringLastMouseDown) {
+      if (apolloFeatureUnderMouse) {
+        setSelectedFeature(apolloFeatureUnderMouse)
+      }
+    } else if (dragging) {
+      const assembly = getAssemblyId(region.assemblyName)
+      const { feature, bp, edge } = dragging
+      let change: LocationEndChange | LocationStartChange
+      if (edge === 'end') {
+        const featureId = feature._id
+        const oldEnd = feature.end
+        const newEnd = Math.round(bp)
+        change = new LocationEndChange({
+          typeName: 'LocationEndChange',
+          changedIds: [featureId],
+          featureId,
+          oldEnd,
+          newEnd,
+          assembly,
+        })
+      } else {
+        const featureId = feature._id
+        const oldStart = feature.start
+        const newStart = Math.round(bp)
+        change = new LocationStartChange({
+          typeName: 'LocationStartChange',
+          changedIds: [featureId],
+          featureId,
+          oldStart,
+          newStart,
+          assembly,
+        })
+      }
+      changeManager?.submit(change)
+    }
+    setDragging(undefined)
+    setMovedDuringLastMouseDown(false)
+  }
+  function onContextMenu(event: React.MouseEvent) {
+    event.preventDefault()
+    setContextMenuFeature(apolloFeatureUnderMouse)
+    setContextCoord([event.pageX, event.pageY])
+  }
+
+  return (
+    <div
+      style={{ position: 'relative', width: totalWidth, height: totalHeight }}
+    >
+      <Menu
+        open={Boolean(contextMenuFeature)}
+        anchorReference="anchorPosition"
+        anchorPosition={
+          contextCoord
+            ? { left: contextCoord[0], top: contextCoord[1] }
+            : undefined
+        }
+        data-testid="base_linear_display_context_menu"
+        onClose={() => {
+          setContextMenuFeature(undefined)
+        }}
+      >
+        <MenuItem
+          disabled={isReadOnly}
+          key={1}
+          value={1}
+          onClick={() => {
+            if (!contextMenuFeature) {
+              return
+            }
+            const currentAssemblyId = getAssemblyId(region.assemblyName)
+            session.queueDialog((doneCallback) => [
+              AddFeature,
+              {
+                session,
+                handleClose: () => {
+                  doneCallback()
+                  setContextMenuFeature(undefined)
+                },
+                changeManager,
+                sourceFeature: contextMenuFeature,
+                sourceAssemblyId: currentAssemblyId,
+              },
+            ])
+          }}
+        >
+          Add child feature
+        </MenuItem>
+        <MenuItem
+          disabled={isReadOnly}
+          key={2}
+          value={2}
+          onClick={() => {
+            if (!contextMenuFeature) {
+              return
+            }
+            const currentAssemblyId = getAssemblyId(region.assemblyName)
+            session.queueDialog((doneCallback) => [
+              CopyFeature,
+              {
+                session,
+                handleClose: () => {
+                  doneCallback()
+                  setContextMenuFeature(undefined)
+                },
+                changeManager,
+                sourceFeatureId: contextMenuFeature?._id,
+                sourceAssemblyId: currentAssemblyId,
+              },
+            ])
+          }}
+        >
+          Copy features and annotations
+        </MenuItem>
+        <MenuItem
+          disabled={!isAdmin}
+          key={3}
+          value={3}
+          onClick={() => {
+            if (!contextMenuFeature) {
+              return
+            }
+            const currentAssemblyId = getAssemblyId(region.assemblyName)
+            session.queueDialog((doneCallback) => [
+              DeleteFeature,
+              {
+                session,
+                handleClose: () => {
+                  doneCallback()
+                  setContextMenuFeature(undefined)
+                },
+                changeManager,
+                sourceFeature: contextMenuFeature,
+                sourceAssemblyId: currentAssemblyId,
+                selectedFeature,
+                setSelectedFeature,
+              },
+            ])
+          }}
+        >
+          Delete feature
+        </MenuItem>
+      </Menu>
+      <canvas
+        ref={canvasRef}
+        width={totalWidth}
+        height={totalHeight}
+        style={{ position: 'absolute', left: 0, top: 0 }}
+      />
+      <canvas
+        ref={overlayCanvasRef}
+        width={totalWidth}
+        height={totalHeight}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+        onMouseDown={onMouseDown}
+        onMouseUp={onMouseUp}
+        onContextMenu={onContextMenu}
+        style={{
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          cursor:
+            dragging || (apolloFeatureUnderMouse && overEdge)
+              ? 'col-resize'
+              : 'default',
+        }}
+      />
+    </div>
+  )
+}
+
+export default observer(ApolloRendering)

--- a/packages/jbrowse-plugin-apollo/src/ApolloSixFrameRenderer/components/ApolloRendering.tsx
+++ b/packages/jbrowse-plugin-apollo/src/ApolloSixFrameRenderer/components/ApolloRendering.tsx
@@ -2,19 +2,17 @@ import { getConf } from '@jbrowse/core/configuration'
 import {
   AppRootModel,
   Region,
-  // defaultStops,
-  defaultCodonTable,
-  generateCodonTable,
+  defaultStarts,
+  defaultStops,
   getSession,
-  reverse
+  reverse,
 } from '@jbrowse/core/util'
-import { xdescribe } from '@jest/globals'
 import { Menu, MenuItem } from '@mui/material'
 import { AnnotationFeatureI } from 'apollo-mst'
 import { LocationEndChange, LocationStartChange } from 'apollo-shared'
 import { autorun, toJS } from 'mobx'
 import { observer } from 'mobx-react'
-import { getRoot, getSnapshot, isAlive } from 'mobx-state-tree'
+import { getRoot, getSnapshot } from 'mobx-state-tree'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 
 import { ApolloInternetAccountModel } from '../../ApolloInternetAccount/model'
@@ -187,115 +185,49 @@ function ApolloRendering(props: ApolloRenderingProps) {
 
     ctx.clearRect(0, 0, totalWidth, totalHeight)
     for (const [row, translated] of codonLayout) {
-      // for (const start of codon.starts) {
-      //   const startPx = start / bpPerPx
-      //   ctx.fillStyle = 'rgba(255,0,255,1)'
-      //   if (showStarts) {
-      //     ctx.fillRect(startPx, row * height, 1, height)
-      //   } else {
-      //     ctx.clearRect(startPx, row * height, 1, height)
-      //   }
-      // }
-      // for (const stop of codon.stops) {
-      //   const stopPx = stop / bpPerPx
-      //   ctx.fillStyle = 'black'
-      //   if (showStops) {
-      //     ctx.fillRect(stopPx, row * height, 1, height)
-      //   } else {
-      //     ctx.clearRect(stopPx, row * height, 1, height)
-      //   }
-      // }
-      const defaultStarts = ['ATG']
-      const defaultStops = ['TAA', 'TAG', 'TGA']
       const scale = bpPerPx
-      // const w = (1 / scale) * 3
-      // const drop = region.start === 0 ? 0 : w
-      // const render = 1 / bpPerPx >= 12
-      // const width = (region.end - region.start) / bpPerPx
-
       for (const element of translated) {
-        const { letter, codon, reversed, start } = element
-        // const x = reversed
-        //   ? width - (w * (start + 1) + effectiveFrame / scale - drop)
-        //   : w * start + effectiveFrame / scale - drop
-        const x = reversed
-          // ? width - (w * (start + 1) + effectiveFrame / scale - drop)
-          // ? width - start * (1 / scale)
-          ? region.end / scale - start * (1 / scale)
-          : start * (1 / scale)
+        const { codon, reversed, start } = element
+        const x = start / scale
         if (region.start / scale <= x && x <= region.end / scale) {
           const normalizedCodon = reversed ? reverse(codon) : codon
           if (defaultStarts.includes(normalizedCodon.toUpperCase())) {
             ctx.fillStyle = 'rgba(255,0,255,1)'
             if (showStarts) {
               ctx.fillRect(
-                reversed
-                  ? region.end / scale - (x - 0.5 - region.start / scale)
-                  : x - 0.5 - region.start / scale,
+                Math.round(x - 0.5 - region.start / scale),
                 row * height,
                 1,
                 height,
               )
-              // ctx.fillRect(x + 2, row * height, 2, height)
             } else {
               ctx.clearRect(
-                reversed
-                  ? region.end / scale - (x - 0.5 - region.start / scale)
-                  : x - 0.5 - region.start / scale,
+                Math.round(x - 0.5 - region.start / scale),
                 row * height,
                 1,
                 height,
               )
-              // ctx.clearRect(x + 2, row * height, 2, height)
             }
           } else if (defaultStops.includes(normalizedCodon.toUpperCase())) {
             ctx.fillStyle = 'black'
             if (showStops) {
               ctx.fillRect(
-                reversed
-                  ? region.end / scale - (x - 0.5 - region.start / scale)
-                  : x - 0.5 - region.start / scale,
+                Math.round(x - 0.5 - region.start / scale),
                 row * height,
                 1,
                 height,
               )
-              // ctx.fillRect(x + 2, row * height, 2, height)
             } else {
               ctx.clearRect(
-                reversed
-                  ? region.end / scale - (x - 0.5 - region.start / scale)
-                  : x - 0.5 - region.start / scale,
+                Math.round(x - 0.5 - region.start / scale),
                 row * height,
                 1,
                 height,
               )
-              // ctx.clearRect(x + 2, row * height, 2, height)
             }
           }
         }
       }
-      // translated.map((element) => {
-      //   const { letter, codon, effectiveFrame, reversed, start } = element
-      //   const x = reversed
-      //     ? width - (w * (start + 1) + effectiveFrame / scale - drop)
-      //     : w * start + effectiveFrame / scale - drop
-      //   const normalizedCodon = reversed ? reverse(codon) : codon
-      //   if (defaultStarts.includes(normalizedCodon.toUpperCase())) {
-      //     ctx.fillStyle = 'rgba(255,0,255,1)'
-      //     if (showStarts) {
-      //       ctx.fillRect(x, row * height, 1, height)
-      //     } else {
-      //       ctx.clearRect(x, row * height, 1, height)
-      //     }
-      //   } else if (defaultStops.includes(normalizedCodon.toUpperCase())) {
-      //     ctx.fillStyle = 'black'
-      //     if (showStops) {
-      //       ctx.fillRect(x, row * height, 1, height)
-      //     } else {
-      //       ctx.clearRect(x, row * height, 1, height)
-      //     }
-      //   }
-      // })
     }
   }, [
     showStarts,

--- a/packages/jbrowse-plugin-apollo/src/ApolloSixFrameRenderer/components/ApolloRendering.tsx
+++ b/packages/jbrowse-plugin-apollo/src/ApolloSixFrameRenderer/components/ApolloRendering.tsx
@@ -588,6 +588,7 @@ function ApolloRendering(props: ApolloRenderingProps) {
                 changeManager,
                 sourceFeature: contextMenuFeature,
                 sourceAssemblyId: currentAssemblyId,
+                internetAccount: apolloInternetAccount,
               },
             ])
           }}

--- a/packages/jbrowse-plugin-apollo/src/ApolloSixFrameRenderer/configSchema.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloSixFrameRenderer/configSchema.ts
@@ -1,0 +1,7 @@
+import { ConfigurationSchema } from '@jbrowse/core/configuration'
+
+export default ConfigurationSchema(
+  'ApolloSixFrameRenderer',
+  {},
+  { explicitlyTyped: true },
+)

--- a/packages/jbrowse-plugin-apollo/src/ApolloSixFrameRenderer/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloSixFrameRenderer/index.ts
@@ -1,0 +1,3 @@
+export { default as ReactComponent } from './components/ApolloRendering'
+export { default as configSchema } from './configSchema'
+export { default as ApolloSixFrameRenderer } from './ApolloSixFrameRenderer'

--- a/packages/jbrowse-plugin-apollo/src/BackendDrivers/BackendDriver.ts
+++ b/packages/jbrowse-plugin-apollo/src/BackendDrivers/BackendDriver.ts
@@ -10,7 +10,7 @@ export abstract class BackendDriver {
 
   abstract getFeatures(region: Region): Promise<AnnotationFeatureSnapshot[]>
 
-  abstract getSequence(region: Region): Promise<string>
+  abstract getSequence(region: Region): Promise<{ seq: string; refSeq: string }>
 
   abstract getRefSeqs(): Promise<string[]>
 

--- a/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/components/TrackLines.tsx
+++ b/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/components/TrackLines.tsx
@@ -1,0 +1,22 @@
+import { observer } from 'mobx-react'
+import React from 'react'
+
+import { SixFrameFeatureDisplay } from '../stateModel'
+
+export const TrackLines = observer(
+  ({ model }: { model: SixFrameFeatureDisplay }) => {
+    const { height } = model
+    return (
+      <div
+        style={{
+          position: 'absolute',
+          left: 0,
+          top: height / 2,
+          width: '100%',
+        }}
+      >
+        <hr style={{ margin: 0, top: 0, color: 'black' }} />
+      </div>
+    )
+  },
+)

--- a/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/components/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/components/index.ts
@@ -1,0 +1,1 @@
+export * from './TrackLines'

--- a/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/configSchema.ts
+++ b/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/configSchema.ts
@@ -1,0 +1,18 @@
+import { ConfigurationSchema } from '@jbrowse/core/configuration'
+import PluginManager from '@jbrowse/core/PluginManager'
+import type LinearGenomeViewPlugin from '@jbrowse/plugin-linear-genome-view'
+
+import { configSchema as apolloRendererConfigSchema } from '../ApolloRenderer'
+
+export function configSchemaFactory(pluginManager: PluginManager) {
+  const LGVPlugin = pluginManager.getPlugin(
+    'LinearGenomeViewPlugin',
+  ) as LinearGenomeViewPlugin
+  const { baseLinearDisplayConfigSchema } = LGVPlugin.exports
+
+  return ConfigurationSchema(
+    'SixFrameFeatureDisplay',
+    { renderer: apolloRendererConfigSchema },
+    { baseConfiguration: baseLinearDisplayConfigSchema, explicitlyTyped: true },
+  )
+}

--- a/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/configSchema.ts
+++ b/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/configSchema.ts
@@ -2,7 +2,7 @@ import { ConfigurationSchema } from '@jbrowse/core/configuration'
 import PluginManager from '@jbrowse/core/PluginManager'
 import type LinearGenomeViewPlugin from '@jbrowse/plugin-linear-genome-view'
 
-import { configSchema as apolloRendererConfigSchema } from '../ApolloRenderer'
+import { configSchema as apolloRendererConfigSchema } from '../ApolloSixFrameRenderer'
 
 export function configSchemaFactory(pluginManager: PluginManager) {
   const LGVPlugin = pluginManager.getPlugin(

--- a/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/configSchema.ts
+++ b/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/configSchema.ts
@@ -12,7 +12,13 @@ export function configSchemaFactory(pluginManager: PluginManager) {
 
   return ConfigurationSchema(
     'SixFrameFeatureDisplay',
-    { renderer: apolloRendererConfigSchema },
+    {
+      renderer: apolloRendererConfigSchema,
+      height: {
+        type: 'number',
+        defaultValue: 120,
+      },
+    },
     { baseConfiguration: baseLinearDisplayConfigSchema, explicitlyTyped: true },
   )
 }

--- a/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/index.ts
@@ -1,0 +1,2 @@
+export { configSchemaFactory } from './configSchema'
+export { stateModelFactory } from './stateModel'

--- a/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/stateModel.ts
+++ b/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/stateModel.ts
@@ -387,6 +387,12 @@ export function stateModelFactory(
       get featuresHeight() {
         return (this.highestRow + 1) * self.apolloRowHeight
       },
+      get detailsHeight() {
+        return Math.max(
+          self.detailsMinHeight,
+          self.height - this.featuresHeight,
+        )
+      },
       trackMenuItems() {
         return [
           {

--- a/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/stateModel.ts
+++ b/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/stateModel.ts
@@ -24,6 +24,8 @@ export function stateModelFactory(
       configuration: ConfigurationReference(configSchema),
       apolloRowHeight: 20,
       detailsMinHeight: 200,
+      showStartCodons: true,
+      showStopCodons: true,
     })
     .volatile(() => ({
       apolloFeatureUnderMouse: undefined as AnnotationFeatureI | undefined,
@@ -209,6 +211,39 @@ export function stateModelFactory(
       },
       setApolloRowUnderMouse(row?: number) {
         self.apolloRowUnderMouse = row
+      },
+      toggleShowStartCodons() {
+        self.showStartCodons = !self.showStartCodons
+      },
+      toggleShowStopCodons() {
+        self.showStopCodons = !self.showStopCodons
+      },
+    }))
+    .views((self) => ({
+      get highestRow() {
+        if (!self.featureLayout.size) {
+          return 0
+        }
+        return Math.max(...self.featureLayout.keys())
+      },
+      get featuresHeight() {
+        return this.highestRow * self.apolloRowHeight
+      },
+      trackMenuItems() {
+        return [
+          {
+            label: 'Show start codons',
+            type: 'checkbox',
+            checked: self.showStartCodons,
+            onClick: () => self.toggleShowStartCodons(),
+          },
+          {
+            label: 'Show stop codons',
+            type: 'checkbox',
+            checked: self.showStopCodons,
+            onClick: () => self.toggleShowStopCodons(),
+          },
+        ]
       },
     }))
 }

--- a/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/stateModel.ts
+++ b/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/stateModel.ts
@@ -1,0 +1,219 @@
+import { ConfigurationReference } from '@jbrowse/core/configuration'
+import { AnyConfigurationSchemaType } from '@jbrowse/core/configuration/configurationSchema'
+import PluginManager from '@jbrowse/core/PluginManager'
+import { getContainingView, getSession } from '@jbrowse/core/util'
+import { getParentRenderProps } from '@jbrowse/core/util/tracks'
+import type LinearGenomeViewPlugin from '@jbrowse/plugin-linear-genome-view'
+import { AnnotationFeatureI } from 'apollo-mst'
+import { Instance, types } from 'mobx-state-tree'
+
+import { ApolloSession } from '../session'
+
+export function stateModelFactory(
+  pluginManager: PluginManager,
+  configSchema: AnyConfigurationSchemaType,
+) {
+  const LGVPlugin = pluginManager.getPlugin(
+    'LinearGenomeViewPlugin',
+  ) as LinearGenomeViewPlugin
+  const { BaseLinearDisplay } = LGVPlugin.exports
+
+  return BaseLinearDisplay.named('SixFrameFeatureDisplay')
+    .props({
+      type: types.literal('SixFrameFeatureDisplay'),
+      configuration: ConfigurationReference(configSchema),
+      apolloRowHeight: 20,
+      detailsMinHeight: 200,
+    })
+    .volatile(() => ({
+      apolloFeatureUnderMouse: undefined as AnnotationFeatureI | undefined,
+      apolloRowUnderMouse: undefined as number | undefined,
+    }))
+    .views((self) => {
+      const { renderProps: superRenderProps } = self
+      return {
+        renderProps() {
+          return {
+            ...superRenderProps(),
+            ...getParentRenderProps(self),
+            config: self.configuration.renderer,
+          }
+        },
+      }
+    })
+    .views((self) => ({
+      get regions() {
+        let blockDefinitions
+        try {
+          ;({ blockDefinitions } = self)
+        } catch (error) {
+          return []
+        }
+        const regions = blockDefinitions.contentBlocks.map(
+          ({ assemblyName, refName, start, end }) => ({
+            assemblyName,
+            refName,
+            start,
+            end,
+          }),
+        )
+        return regions
+      },
+      regionCannotBeRendered(/* region */) {
+        const view = getContainingView(self)
+        if (view && view.bpPerPx >= 200) {
+          return 'Zoom in to see annotations'
+        }
+        return undefined
+      },
+    }))
+    .views((self) => ({
+      get rendererTypeName() {
+        return self.configuration.renderer.type
+      },
+      get changeManager() {
+        const session = getSession(self) as ApolloSession
+        return session.apolloDataStore?.changeManager
+      },
+      get features() {
+        const { regions } = self
+        const session = getSession(self) as ApolloSession
+        const features = new Map<string, Map<string, AnnotationFeatureI>>()
+        for (const region of regions) {
+          const assembly = session.apolloDataStore.assemblies.get(
+            region.assemblyName,
+          )
+          const ref = assembly?.getByRefName(region.refName)
+          let filteredRef = features.get(region.refName)
+          if (!filteredRef) {
+            filteredRef = new Map<string, AnnotationFeatureI>()
+            features.set(region.refName, filteredRef)
+          }
+          for (const [featureId, feature] of ref?.features.entries() ||
+            new Map()) {
+            if (region.start < feature.end && region.end > feature.start) {
+              filteredRef.set(featureId, feature)
+            }
+          }
+        }
+        return features
+      },
+      get featuresMinMax() {
+        const minMax: Record<string, [number, number]> = {}
+        for (const [refSeq, featuresForRefSeq] of this.features || []) {
+          let min: number | undefined = undefined
+          let max: number | undefined = undefined
+          for (const [, featureLocation] of featuresForRefSeq) {
+            if (min === undefined) {
+              ;({ min } = featureLocation)
+            }
+            if (max === undefined) {
+              ;({ max } = featureLocation)
+            }
+            if (featureLocation.min < min) {
+              ;({ min } = featureLocation)
+            }
+            if (featureLocation.end > max) {
+              ;({ max } = featureLocation)
+            }
+          }
+          if (min !== undefined && max !== undefined) {
+            minMax[refSeq] = [min, max]
+          }
+        }
+        return minMax
+      },
+      get featureLayout() {
+        const forwardPhaseMap: Record<number, number> = {
+          0: 2,
+          1: 1,
+          2: 0,
+        }
+        const featureLayout: Map<number, [number, AnnotationFeatureI][]> =
+          new Map()
+        for (const [refSeq, featuresForRefSeq] of this.features || []) {
+          if (!featuresForRefSeq) {
+            continue
+          }
+          const minMaxfeatures = this.featuresMinMax[refSeq]
+          if (!minMaxfeatures) {
+            continue
+          }
+          const [min, max] = minMaxfeatures
+          const rows: boolean[][] = []
+          const rowCount = 6
+          for (let i = 0; i < rowCount; i++) {
+            const newRowNumber = rows.length
+            rows[newRowNumber] = new Array(max - min)
+            featureLayout.set(newRowNumber, [])
+          }
+          Array.from(featuresForRefSeq.values())
+            .sort((f1, f2) => {
+              const { min: start1, max: end1 } = f1
+              const { min: start2, max: end2 } = f2
+              return start1 - start2 || end1 - end2
+            })
+            .forEach((feature) => {
+              for (const [, childFeature] of feature.children || new Map()) {
+                if (childFeature.type === 'mRNA') {
+                  for (const [, grandChildFeature] of childFeature.children ||
+                    new Map()) {
+                    let startingRow = 0
+                    if (grandChildFeature.phase !== undefined) {
+                      startingRow = grandChildFeature.phase
+                      if (feature.strand === -1) {
+                        startingRow += 3
+                      } else {
+                        startingRow = forwardPhaseMap[grandChildFeature.phase]
+                      }
+                      const row = rows[startingRow]
+                      row.fill(
+                        true,
+                        grandChildFeature.min - min,
+                        grandChildFeature.max - min,
+                      )
+                      const layoutRow = featureLayout.get(startingRow)
+                      layoutRow?.push([0, grandChildFeature])
+                    }
+                  }
+                }
+              }
+            })
+        }
+        return featureLayout
+      },
+      getAssemblyId(assemblyName: string) {
+        const { assemblyManager } = getSession(self)
+        const assembly = assemblyManager.get(assemblyName)
+        if (!assembly) {
+          throw new Error(`Could not find assembly named ${assemblyName}`)
+        }
+        return assembly.name
+      },
+      get selectedFeature(): AnnotationFeatureI | undefined {
+        const session = getSession(self) as ApolloSession
+        return session.apolloSelectedFeature
+      },
+      get setSelectedFeature() {
+        const session = getSession(self) as ApolloSession
+        return session.apolloSetSelectedFeature
+      },
+    }))
+    .actions((self) => ({
+      setSelectedFeature(feature?: AnnotationFeatureI) {
+        const session = getSession(self) as ApolloSession
+        return session.apolloSetSelectedFeature(feature)
+      },
+      setApolloFeatureUnderMouse(feature?: AnnotationFeatureI) {
+        self.apolloFeatureUnderMouse = feature
+      },
+      setApolloRowUnderMouse(row?: number) {
+        self.apolloRowUnderMouse = row
+      },
+    }))
+}
+
+export type SixFrameFeatureDisplayStateModel = ReturnType<
+  typeof stateModelFactory
+>
+export type SixFrameFeatureDisplay = Instance<SixFrameFeatureDisplayStateModel>

--- a/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/stateModel.ts
+++ b/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/stateModel.ts
@@ -19,6 +19,17 @@ import { Instance, addDisposer, types } from 'mobx-state-tree'
 
 import { ApolloSession } from '../session'
 
+const forwardPhaseMap: Record<number, number> = {
+  0: 2,
+  1: 1,
+  2: 0,
+}
+const reversePhaseMap: Record<number, number> = {
+  3: 0,
+  4: 1,
+  5: 2,
+}
+
 export function stateModelFactory(
   pluginManager: PluginManager,
   configSchema: AnyConfigurationSchemaType,
@@ -209,16 +220,6 @@ export function stateModelFactory(
         return minMax
       },
       get codonLayout() {
-        const forwardPhaseMap: Record<number, number> = {
-          0: 2,
-          1: 1,
-          2: 0,
-        }
-        const reversePhaseMap: Record<number, number> = {
-          3: 0,
-          4: 1,
-          5: 2,
-        }
         const codonTable = generateCodonTable(defaultCodonTable)
         const codonLayout: Map<
           number,
@@ -284,11 +285,6 @@ export function stateModelFactory(
         return codonLayout
       },
       get featureLayout() {
-        const forwardPhaseMap: Record<number, number> = {
-          0: 2,
-          1: 1,
-          2: 0,
-        }
         const featureLayout: Map<number, [number, AnnotationFeatureI][]> =
           new Map()
         for (const [refSeq, featuresForRefSeq] of this.features || []) {

--- a/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/stateModel.ts
+++ b/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/stateModel.ts
@@ -115,6 +115,14 @@ export function stateModelFactory(
                       newBlocks.push(block)
                     }
                   })
+                  session.apolloDataStore.loadFeatures(
+                    newBlocks.map(({ assemblyName, refName, start, end }) => ({
+                      assemblyName,
+                      refName,
+                      start,
+                      end,
+                    })),
+                  )
                   session.apolloDataStore.loadRefSeq(
                     newBlocks.map(({ assemblyName, refName, start, end }) => ({
                       assemblyName,

--- a/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/stateModel.ts
+++ b/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/stateModel.ts
@@ -45,8 +45,9 @@ export function stateModelFactory(
       configuration: ConfigurationReference(configSchema),
       apolloRowHeight: 20,
       detailsMinHeight: 200,
-      showStartCodons: true,
+      showStartCodons: false,
       showStopCodons: true,
+      showIntronLines: true,
     })
     .volatile(() => ({
       apolloFeatureUnderMouse: undefined as AnnotationFeatureI | undefined,
@@ -389,6 +390,9 @@ export function stateModelFactory(
       toggleShowStopCodons() {
         self.showStopCodons = !self.showStopCodons
       },
+      toggleShowIntronLines() {
+        self.showIntronLines = !self.showIntronLines
+      },
     }))
     .views((self) => ({
       get highestRow() {
@@ -419,6 +423,12 @@ export function stateModelFactory(
             type: 'checkbox',
             checked: self.showStopCodons,
             onClick: () => self.toggleShowStopCodons(),
+          },
+          {
+            label: 'Show intron lines',
+            type: 'checkbox',
+            checked: self.showIntronLines,
+            onClick: () => self.toggleShowIntronLines(),
           },
         ]
       },

--- a/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/stateModel.ts
+++ b/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/stateModel.ts
@@ -285,7 +285,7 @@ export function stateModelFactory(
         return codonLayout
       },
       get featureLayout() {
-        const featureLayout: Map<number, [number, AnnotationFeatureI][]> =
+        const featureLayout: Map<number, [string, AnnotationFeatureI][]> =
           new Map()
         for (const [refSeq, featuresForRefSeq] of this.features || []) {
           if (!featuresForRefSeq) {
@@ -314,13 +314,30 @@ export function stateModelFactory(
                 if (childFeature.type === 'mRNA') {
                   for (const [, grandChildFeature] of childFeature.children ||
                     new Map()) {
-                    let startingRow = 0
-                    if (grandChildFeature.phase !== undefined) {
-                      startingRow = grandChildFeature.phase
+                    // let startingRow = 0
+                    // if (grandChildFeature.phase !== undefined) {
+                    //   startingRow = grandChildFeature.phase
+                    //   if (feature.strand === -1) {
+                    //     startingRow += 3
+                    //   } else {
+                    //     startingRow = forwardPhaseMap[grandChildFeature.phase]
+                    //   }
+                    //   const row = rows[startingRow]
+                    //   row.fill(
+                    //     true,
+                    //     grandChildFeature.min - min,
+                    //     grandChildFeature.max - min,
+                    //   )
+                    //   const layoutRow = featureLayout.get(startingRow)
+                    //   layoutRow?.push([0, grandChildFeature])
+                    // }
+                    let startingRow
+                    if (grandChildFeature.type === 'CDS') {
                       if (feature.strand === -1) {
-                        startingRow += 3
+                        startingRow = reversePhaseMap[grandChildFeature.min % 3]
                       } else {
-                        startingRow = forwardPhaseMap[grandChildFeature.phase]
+                        startingRow =
+                          forwardPhaseMap[(grandChildFeature.min - 1) % 3]
                       }
                       const row = rows[startingRow]
                       row.fill(
@@ -329,7 +346,7 @@ export function stateModelFactory(
                         grandChildFeature.max - min,
                       )
                       const layoutRow = featureLayout.get(startingRow)
-                      layoutRow?.push([0, grandChildFeature])
+                      layoutRow?.push([childFeature.testId, grandChildFeature])
                     }
                   }
                 }

--- a/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/stateModel.ts
+++ b/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/stateModel.ts
@@ -132,28 +132,15 @@ export function stateModelFactory(
       get sequence() {
         const { regions } = self
         const session = getSession(self) as ApolloSession
-        const sequence = new Map<string, unknown>()
+        const seq = new Map<string, unknown>()
         for (const region of regions) {
           const assembly = session.apolloDataStore.assemblies.get(
             region.assemblyName,
           )
           const ref = assembly?.getByRefName(region.refName)
-          let filteredRef = sequence.get(region.refName)
-          if (!filteredRef) {
-            filteredRef = Sequence.create({start: region.start, stop: region.end, sequence: })
-            sequence.set(region.refName, filteredRef)
-          }
-          for (const [seq] of ref?.sequence.entries() || new Map()) {
-            if (region.start < seq.end && region.end > seq.start) {
-              filteredRef = {
-                start: seq.start,
-                stop: seq.stop,
-                sequence: seq.sequence,
-              }
-            }
-          }
+          seq.set(region.refName, ref?.getSequence(region.start, region.end))
         }
-        return sequence
+        return seq
       },
       get features() {
         const { regions } = self

--- a/packages/jbrowse-plugin-apollo/src/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/index.ts
@@ -28,6 +28,11 @@ import {
   configSchema as apolloRendererConfigSchema,
 } from './ApolloRenderer'
 import { installApolloSequenceAdapter } from './ApolloSequenceAdapter'
+import {
+  ApolloSixFrameRenderer,
+  ReactComponent as ApolloSixFrameRendererReactComponent,
+  configSchema as apolloSixFrameRendererConfigSchema,
+} from './ApolloSixFrameRenderer'
 import { ViewChangeLog } from './components'
 import { DownloadGFF3 } from './components/DownloadGFF3'
 import {
@@ -124,6 +129,16 @@ export default class ApolloPlugin extends Plugin {
           name: 'ApolloRenderer',
           ReactComponent: ApolloRendererReactComponent,
           configSchema: apolloRendererConfigSchema,
+          pluginManager,
+        }),
+    )
+
+    pluginManager.addRendererType(
+      () =>
+        new ApolloSixFrameRenderer({
+          name: 'ApolloSixFrameRenderer',
+          ReactComponent: ApolloSixFrameRendererReactComponent,
+          configSchema: apolloSixFrameRendererConfigSchema,
           pluginManager,
         }),
     )

--- a/packages/jbrowse-plugin-apollo/src/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/index.ts
@@ -36,6 +36,10 @@ import {
 } from './LinearApolloDisplay'
 import { makeDisplayComponent } from './makeDisplayComponent'
 import { extendSession } from './session'
+import {
+  stateModelFactory as SixFrameFeatureDisplayStateModelFactory,
+  configSchemaFactory as sixFrameFeatureDisplayConfigSchemaFactory,
+} from './SixFrameFeatureDisplay'
 
 Object.entries(changes).forEach(([changeName, change]) => {
   changeRegistry.registerChange(changeName, change)
@@ -88,6 +92,23 @@ export default class ApolloPlugin extends Plugin {
         name: 'LinearApolloDisplay',
         configSchema,
         stateModel: LinearApolloDisplayStateModelFactory(
+          pluginManager,
+          configSchema,
+        ),
+        trackType: 'ApolloTrack',
+        viewType: 'LinearGenomeView',
+        ReactComponent: DisplayComponent,
+      })
+    })
+
+    pluginManager.addDisplayType(() => {
+      const configSchema =
+        sixFrameFeatureDisplayConfigSchemaFactory(pluginManager)
+      const DisplayComponent = makeDisplayComponent(pluginManager)
+      return new DisplayType({
+        name: 'SixFrameFeatureDisplay',
+        configSchema,
+        stateModel: SixFrameFeatureDisplayStateModelFactory(
           pluginManager,
           configSchema,
         ),

--- a/packages/jbrowse-plugin-apollo/src/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/index.ts
@@ -39,7 +39,10 @@ import {
   stateModelFactory as LinearApolloDisplayStateModelFactory,
   configSchemaFactory as linearApolloDisplayConfigSchemaFactory,
 } from './LinearApolloDisplay'
-import { makeDisplayComponent } from './makeDisplayComponent'
+import {
+  makeDisplayComponent,
+  makeSixFrameDisplayComponent,
+} from './makeDisplayComponent'
 import { extendSession } from './session'
 import {
   stateModelFactory as SixFrameFeatureDisplayStateModelFactory,
@@ -109,7 +112,7 @@ export default class ApolloPlugin extends Plugin {
     pluginManager.addDisplayType(() => {
       const configSchema =
         sixFrameFeatureDisplayConfigSchemaFactory(pluginManager)
-      const DisplayComponent = makeDisplayComponent(pluginManager)
+      const DisplayComponent = makeSixFrameDisplayComponent(pluginManager)
       return new DisplayType({
         name: 'SixFrameFeatureDisplay',
         configSchema,

--- a/packages/jbrowse-plugin-apollo/src/makeDisplayComponent.tsx
+++ b/packages/jbrowse-plugin-apollo/src/makeDisplayComponent.tsx
@@ -7,6 +7,8 @@ import { makeStyles } from 'tss-react/mui'
 
 import { ApolloDetails } from './LinearApolloDisplay/components'
 import { LinearApolloDisplay } from './LinearApolloDisplay/stateModel'
+import { TrackLines } from './SixFrameFeatureDisplay/components'
+import { SixFrameFeatureDisplay } from './SixFrameFeatureDisplay/stateModel'
 
 const useStyles = makeStyles()((theme) => ({
   shading: {
@@ -47,6 +49,44 @@ export function makeDisplayComponent(pluginManager: PluginManager) {
         </div>
         <div className={classes.details} style={{ height: detailsHeight }}>
           <ApolloDetails model={model} />
+        </div>
+      </div>
+    )
+  }
+  return observer(ApolloDisplayComponent)
+}
+
+export function makeSixFrameDisplayComponent(pluginManager: PluginManager) {
+  const LGVPlugin = pluginManager.getPlugin('LinearGenomeViewPlugin') as
+    | LinearGenomeViewPlugin
+    | undefined
+  if (!LGVPlugin) {
+    throw new Error('LinearGenomeView plugin not found')
+  }
+  const { BaseLinearDisplayComponent } = LGVPlugin.exports
+  function ApolloDisplayComponent({
+    model,
+    ...other
+  }: {
+    model: SixFrameFeatureDisplay
+  }) {
+    const { classes } = useStyles()
+    const { height, selectedFeature } = model
+    let { detailsHeight } = model
+    if (!selectedFeature) {
+      detailsHeight = 0
+    }
+    const featureAreaHeight = height - detailsHeight
+    return (
+      <div style={{ height: model.height }}>
+        <div className={classes.shading} style={{ height: featureAreaHeight }}>
+          <BaseLinearDisplayComponent model={model} {...other} />
+        </div>
+        {/* <div className={classes.details} style={{ height: detailsHeight }}>
+          <ApolloDetails model={model} />
+        </div> */}
+        <div className="testTrackLines">
+          <TrackLines model={model} />
         </div>
       </div>
     )

--- a/packages/jbrowse-plugin-apollo/src/session.ts
+++ b/packages/jbrowse-plugin-apollo/src/session.ts
@@ -131,12 +131,11 @@ const ClientDataStore = types
             sequence: [],
           })
         }
-        const newSequence = Sequence.create({
+        ref.addSequence({
           start: region.start,
           stop: region.end,
           sequence: seq,
         })
-        ref.sequence.push(newSequence)
       }
     }),
 

--- a/packages/jbrowse-plugin-apollo/src/session.ts
+++ b/packages/jbrowse-plugin-apollo/src/session.ts
@@ -213,6 +213,10 @@ export function extendSession(sessionModel: IAnyModelType) {
                 type: 'LinearApolloDisplay',
                 displayId: `apollo_track_${assembly.name}-LinearApolloDisplay`,
               },
+              {
+                type: 'SixFrameFeatureDisplay',
+                displayId: `apollo_track_${assembly.name}-SixFrameFeatureDisplay`,
+              },
             ],
           })
         }

--- a/packages/jbrowse-plugin-apollo/src/session.ts
+++ b/packages/jbrowse-plugin-apollo/src/session.ts
@@ -10,7 +10,6 @@ import {
   AnnotationFeatureSnapshot,
   ApolloAssembly,
   ApolloRefSeq,
-  Sequence,
 } from 'apollo-mst'
 import { autorun, observable } from 'mobx'
 import {


### PR DESCRIPTION
Very basic implementation.

I have used the LinearApolloDisplay as a basis for a new display: SixFrameFeatureDisplay (name expected to change). Most of the logic change is in the featureLayout method in stateModel.ts. Where before, new rows were added whenever features would potentially overlap, I am now tying the row number directly to the phase of each given feature. Naturally, as most features don't have a phase in the gff file, we end up with virtually all features plotted being CDS (but this is expected behaviour in Artemis), and I have to dig down two "generations" to find these CDS features for a given "gene" feature.

Still to do:
1) connecting lines between each CDS feature belonging to a common parent.
2) The central tracks representing forward/reverse strands (or at least a dividing horizontal line to represent the break between strands). Parent features might be plotted on these central tracks.
3) sequence integration (for stop codons, etc)
