### PR TITLE
Add Operations and GetAssembliesOperation

### DIFF
--- a/packages/apollo-collaboration-server/src/app.module.ts
+++ b/packages/apollo-collaboration-server/src/app.module.ts
@@ -9,9 +9,11 @@ import Joi from 'joi'
 import { AssembliesModule } from './assemblies/assemblies.module'
 import { AuthenticationModule } from './authentication/authentication.module'
 import { ChangesModule } from './changes/changes.module'
+import { CountersModule } from './counters/counters.module'
 import { FeaturesModule } from './features/features.module'
 import { FilesModule } from './files/files.module'
 import { MessagesModule } from './messages/messages.module'
+import { OperationsModule } from './operations/operations.module'
 import { RefSeqChunksModule } from './refSeqChunks/refSeqChunks.module'
 import { RefSeqsModule } from './refSeqs/refSeqs.module'
 import { UsersModule } from './users/users.module'
@@ -114,6 +116,8 @@ async function mongoDBURIFactory(
     FilesModule,
     UsersModule,
     MessagesModule,
+    OperationsModule,
+    CountersModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: JwtAuthGuard },

--- a/packages/apollo-collaboration-server/src/assemblies/assemblies.module.ts
+++ b/packages/apollo-collaboration-server/src/assemblies/assemblies.module.ts
@@ -1,7 +1,8 @@
-import { Module } from '@nestjs/common'
+import { Module, forwardRef } from '@nestjs/common'
 import { MongooseModule } from '@nestjs/mongoose'
 import { Assembly, AssemblySchema } from 'apollo-schemas'
 
+import { OperationsModule } from '../operations/operations.module'
 import { AssembliesController } from './assemblies.controller'
 import { AssembliesService } from './assemblies.service'
 
@@ -12,6 +13,7 @@ import { AssembliesService } from './assemblies.service'
     MongooseModule.forFeature([
       { name: Assembly.name, schema: AssemblySchema },
     ]),
+    forwardRef(() => OperationsModule),
   ],
   exports: [MongooseModule],
 })

--- a/packages/apollo-collaboration-server/src/assemblies/assemblies.service.ts
+++ b/packages/apollo-collaboration-server/src/assemblies/assemblies.service.ts
@@ -1,8 +1,10 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { InjectModel } from '@nestjs/mongoose'
 import { Assembly, AssemblyDocument } from 'apollo-schemas'
+import { GetAssembliesOperation } from 'apollo-shared'
 import { Model } from 'mongoose'
 
+import { OperationsService } from '../operations/operations.service'
 import { CreateAssemblyDto } from './dto/create-assembly.dto'
 import { UpdateAssemblyDto } from './dto/update-assembly.dto'
 
@@ -11,6 +13,7 @@ export class AssembliesService {
   constructor(
     @InjectModel(Assembly.name)
     private readonly assemblyModel: Model<AssemblyDocument>,
+    private readonly operationsService: OperationsService,
   ) {}
 
   private readonly logger = new Logger(AssembliesService.name)
@@ -20,7 +23,9 @@ export class AssembliesService {
   }
 
   findAll() {
-    return this.assemblyModel.find({ status: 0 }).exec()
+    return this.operationsService.executeOperation<GetAssembliesOperation>({
+      typeName: 'GetAssembliesOperation',
+    })
   }
 
   async findOne(id: string) {

--- a/packages/apollo-collaboration-server/src/changes/changes.service.ts
+++ b/packages/apollo-collaboration-server/src/changes/changes.service.ts
@@ -100,7 +100,7 @@ export class ChangesService {
     let changeDoc: ChangeDocument | undefined
     await this.featureModel.db.transaction(async (session) => {
       try {
-        await change.apply({
+        await change.execute({
           typeName: 'Server',
           featureModel: this.featureModel,
           assemblyModel: this.assemblyModel,

--- a/packages/apollo-collaboration-server/src/features/features.module.ts
+++ b/packages/apollo-collaboration-server/src/features/features.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common'
+import { Module, forwardRef } from '@nestjs/common'
 import { MongooseModule, getConnectionToken } from '@nestjs/mongoose'
 import { Export, ExportSchema, Feature, FeatureSchema } from 'apollo-schemas'
 import idValidator from 'mongoose-id-validator'
@@ -12,7 +12,7 @@ import { FeaturesService } from './features.service'
   controllers: [FeaturesController],
   providers: [FeaturesService],
   imports: [
-    AssembliesModule,
+    forwardRef(() => AssembliesModule),
     RefSeqsModule,
     MongooseModule.forFeatureAsync([
       {
@@ -23,8 +23,11 @@ import { FeaturesService } from './features.service'
         },
         inject: [getConnectionToken()],
       },
+      {
+        name: Export.name,
+        useFactory: () => ExportSchema,
+      },
     ]),
-    MongooseModule.forFeature([{ name: Export.name, schema: ExportSchema }]),
   ],
   exports: [MongooseModule],
 })

--- a/packages/apollo-collaboration-server/src/files/files.module.ts
+++ b/packages/apollo-collaboration-server/src/files/files.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common'
+import { Module, forwardRef } from '@nestjs/common'
 import { MongooseModule } from '@nestjs/mongoose'
 import { File, FileSchema } from 'apollo-schemas'
 
@@ -15,7 +15,7 @@ import { FilesService } from './files.service'
   imports: [
     MongooseModule.forFeature([{ name: File.name, schema: FileSchema }]),
     FeaturesModule,
-    AssembliesModule,
+    forwardRef(() => AssembliesModule),
     RefSeqsModule,
     RefSeqChunksModule,
   ],

--- a/packages/apollo-collaboration-server/src/main.ts
+++ b/packages/apollo-collaboration-server/src/main.ts
@@ -5,6 +5,8 @@ import {
   ParentChildValidation,
   changeRegistry,
   changes,
+  operationRegistry,
+  operations,
   validationRegistry,
 } from 'apollo-shared'
 import session from 'express-session'
@@ -29,6 +31,10 @@ async function bootstrap() {
 
   Object.entries(changes).forEach(([changeName, change]) => {
     changeRegistry.registerChange(changeName, change)
+  })
+
+  Object.entries(operations).forEach(([operationName, operation]) => {
+    operationRegistry.registerOperation(operationName, operation)
   })
 
   validationRegistry.registerValidation(new CoreValidation())

--- a/packages/apollo-collaboration-server/src/operations/operations.module.ts
+++ b/packages/apollo-collaboration-server/src/operations/operations.module.ts
@@ -1,0 +1,27 @@
+import { Module, forwardRef } from '@nestjs/common'
+
+import { AssembliesModule } from '../assemblies/assemblies.module'
+import { CountersModule } from '../counters/counters.module'
+import { FeaturesModule } from '../features/features.module'
+import { FilesModule } from '../files/files.module'
+import { MessagesModule } from '../messages/messages.module'
+import { RefSeqChunksModule } from '../refSeqChunks/refSeqChunks.module'
+import { RefSeqsModule } from '../refSeqs/refSeqs.module'
+import { UsersModule } from '../users/users.module'
+import { OperationsService } from './operations.service'
+
+@Module({
+  imports: [
+    forwardRef(() => AssembliesModule),
+    RefSeqsModule,
+    RefSeqChunksModule,
+    FeaturesModule,
+    FilesModule,
+    UsersModule,
+    CountersModule,
+    MessagesModule,
+  ],
+  providers: [OperationsService],
+  exports: [OperationsService],
+})
+export class OperationsModule {}

--- a/packages/apollo-collaboration-server/src/operations/operations.service.spec.ts
+++ b/packages/apollo-collaboration-server/src/operations/operations.service.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing'
+
+import { OperationsService } from './operations.service'
+
+describe('OperationsService', () => {
+  let service: OperationsService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [OperationsService],
+    }).compile()
+
+    service = module.get<OperationsService>(OperationsService)
+  })
+
+  it('should be defined', () => {
+    expect(service).toBeDefined()
+  })
+})

--- a/packages/apollo-collaboration-server/src/operations/operations.service.ts
+++ b/packages/apollo-collaboration-server/src/operations/operations.service.ts
@@ -1,0 +1,70 @@
+import { Injectable, Logger } from '@nestjs/common'
+import { InjectModel } from '@nestjs/mongoose'
+import {
+  Assembly,
+  AssemblyDocument,
+  Feature,
+  FeatureDocument,
+  File,
+  FileDocument,
+  RefSeq,
+  RefSeqChunk,
+  RefSeqChunkDocument,
+  RefSeqDocument,
+  User,
+  UserDocument,
+} from 'apollo-schemas'
+import {
+  Operation,
+  SerializedOperation,
+  operationRegistry,
+} from 'apollo-shared'
+import { Model } from 'mongoose'
+
+import { CountersService } from '../counters/counters.service'
+import { FilesService } from '../files/files.service'
+
+@Injectable()
+export class OperationsService {
+  constructor(
+    @InjectModel(Assembly.name)
+    private readonly assemblyModel: Model<AssemblyDocument>,
+    @InjectModel(User.name)
+    private readonly userModel: Model<UserDocument>,
+    @InjectModel(Feature.name)
+    private readonly featureModel: Model<FeatureDocument>,
+    @InjectModel(File.name)
+    private readonly fileModel: Model<FileDocument>,
+    @InjectModel(RefSeq.name)
+    private readonly refSeqModel: Model<RefSeqDocument>,
+    @InjectModel(RefSeqChunk.name)
+    private readonly refSeqChunkModel: Model<RefSeqChunkDocument>,
+    private readonly filesService: FilesService,
+    private readonly countersService: CountersService,
+  ) {}
+
+  private readonly logger = new Logger(OperationsService.name)
+
+  async executeOperation<T extends Operation>(
+    serializedOperation: SerializedOperation,
+  ): Promise<ReturnType<T['executeOnServer']>> {
+    const OperationType = operationRegistry.getOperationType(
+      serializedOperation.typeName,
+    )
+    const operation = new OperationType(serializedOperation)
+    // @ts-ignore
+    return operation.execute({
+      typeName: 'Server',
+      featureModel: this.featureModel,
+      assemblyModel: this.assemblyModel,
+      refSeqModel: this.refSeqModel,
+      refSeqChunkModel: this.refSeqChunkModel,
+      fileModel: this.fileModel,
+      userModel: this.userModel,
+      // session: await startSession(),
+      filesService: this.filesService,
+      counterService: this.countersService,
+      user: '',
+    })
+  }
+}

--- a/packages/apollo-shared/src/Changes/AddAssemblyAndFeaturesFromFileChange.ts
+++ b/packages/apollo-shared/src/Changes/AddAssemblyAndFeaturesFromFileChange.ts
@@ -62,7 +62,7 @@ export class AddAssemblyAndFeaturesFromFileChange extends AssemblySpecificChange
    * @param backend - parameters from backend
    * @returns
    */
-  async applyToServer(backend: ServerDataStore) {
+  async executeOnServer(backend: ServerDataStore) {
     const { assemblyModel, fileModel, filesService, user } = backend
     const { changes, assembly, logger } = this
     for (const change of changes) {
@@ -112,12 +112,12 @@ export class AddAssemblyAndFeaturesFromFileChange extends AssemblySpecificChange
     }
   }
 
-  async applyToLocalGFF3(backend: LocalGFF3DataStore) {
-    throw new Error('applyToLocalGFF3 not implemented')
+  async executeOnLocalGFF3(backend: LocalGFF3DataStore) {
+    throw new Error('executeOnLocalGFF3 not implemented')
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  async applyToClient(dataStore: ClientDataStore) {}
+  async executeOnClient(dataStore: ClientDataStore) {}
 
   getInverse() {
     const { typeName, changes, assembly, logger } = this

--- a/packages/apollo-shared/src/Changes/AddAssemblyFromFileChange.ts
+++ b/packages/apollo-shared/src/Changes/AddAssemblyFromFileChange.ts
@@ -60,7 +60,7 @@ export class AddAssemblyFromFileChange extends AssemblySpecificChange {
    * @param backend - parameters from backend
    * @returns
    */
-  async applyToServer(backend: ServerDataStore) {
+  async executeOnServer(backend: ServerDataStore) {
     const { assemblyModel, fileModel, user } = backend
     const { changes, assembly, logger } = this
 
@@ -102,12 +102,12 @@ export class AddAssemblyFromFileChange extends AssemblySpecificChange {
     }
   }
 
-  async applyToLocalGFF3(backend: LocalGFF3DataStore) {
-    throw new Error('applyToLocalGFF3 not implemented')
+  async executeOnLocalGFF3(backend: LocalGFF3DataStore) {
+    throw new Error('executeOnLocalGFF3 not implemented')
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  async applyToClient(dataStore: ClientDataStore) {}
+  async executeOnClient(dataStore: ClientDataStore) {}
 
   getInverse() {
     const { typeName, changes, assembly, logger } = this

--- a/packages/apollo-shared/src/Changes/AddFeatureChange.ts
+++ b/packages/apollo-shared/src/Changes/AddFeatureChange.ts
@@ -55,7 +55,7 @@ export class AddFeatureChange extends FeatureChange {
    * @param backend - parameters from backend
    * @returns
    */
-  async applyToServer(backend: ServerDataStore) {
+  async executeOnServer(backend: ServerDataStore) {
     const { assemblyModel, featureModel, refSeqModel, session } = backend
     const { changes, assembly, logger } = this
 
@@ -141,11 +141,11 @@ export class AddFeatureChange extends FeatureChange {
     logger.debug?.(`Added ${featureCnt} new feature(s) into database.`)
   }
 
-  async applyToLocalGFF3(backend: LocalGFF3DataStore) {
-    throw new Error('applyToLocalGFF3 not implemented')
+  async executeOnLocalGFF3(backend: LocalGFF3DataStore) {
+    throw new Error('executeOnLocalGFF3 not implemented')
   }
 
-  async applyToClient(dataStore: ClientDataStore) {
+  async executeOnClient(dataStore: ClientDataStore) {
     if (!dataStore) {
       throw new Error('No data store')
     }

--- a/packages/apollo-shared/src/Changes/AddFeaturesFromFileChange.ts
+++ b/packages/apollo-shared/src/Changes/AddFeaturesFromFileChange.ts
@@ -61,7 +61,7 @@ export class AddFeaturesFromFileChange extends AssemblySpecificChange {
    * @param backend - parameters from backend
    * @returns
    */
-  async applyToServer(backend: ServerDataStore) {
+  async executeOnServer(backend: ServerDataStore) {
     const { filesService, fileModel } = backend
     const { changes, logger } = this
 
@@ -95,12 +95,12 @@ export class AddFeaturesFromFileChange extends AssemblySpecificChange {
     logger.debug?.(`New features added into database!`)
   }
 
-  async applyToLocalGFF3(backend: LocalGFF3DataStore) {
-    throw new Error('applyToLocalGFF3 not implemented')
+  async executeOnLocalGFF3(backend: LocalGFF3DataStore) {
+    throw new Error('executeOnLocalGFF3 not implemented')
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  async applyToClient(dataStore: ClientDataStore) {}
+  async executeOnClient(dataStore: ClientDataStore) {}
 
   getInverse() {
     const { typeName, changes, assembly, logger } = this

--- a/packages/apollo-shared/src/Changes/CopyFeatureChange.ts
+++ b/packages/apollo-shared/src/Changes/CopyFeatureChange.ts
@@ -61,7 +61,7 @@ export class CopyFeatureChange extends FeatureChange {
    * @param backend - parameters from backend
    * @returns
    */
-  async applyToServer(backend: ServerDataStore) {
+  async executeOnServer(backend: ServerDataStore) {
     const { featureModel, session, refSeqModel } = backend
     const { changes, assembly, logger } = this
 
@@ -136,11 +136,11 @@ export class CopyFeatureChange extends FeatureChange {
     }
   }
 
-  async applyToLocalGFF3(backend: LocalGFF3DataStore) {
-    throw new Error('applyToLocalGFF3 not implemented')
+  async executeOnLocalGFF3(backend: LocalGFF3DataStore) {
+    throw new Error('executeOnLocalGFF3 not implemented')
   }
 
-  async applyToClient(dataStore: ClientDataStore) {
+  async executeOnClient(dataStore: ClientDataStore) {
     if (!dataStore) {
       throw new Error('No data store')
     }

--- a/packages/apollo-shared/src/Changes/DeleteAssemblyChange.ts
+++ b/packages/apollo-shared/src/Changes/DeleteAssemblyChange.ts
@@ -29,7 +29,7 @@ export class DeleteAssemblyChange extends AssemblySpecificChange {
    * @param backend - parameters from backend
    * @returns
    */
-  async applyToServer(backend: ServerDataStore) {
+  async executeOnServer(backend: ServerDataStore) {
     const {
       assemblyModel,
       featureModel,
@@ -68,11 +68,11 @@ export class DeleteAssemblyChange extends AssemblySpecificChange {
     this.logger.debug?.(`Assembly "${assembly}" deleted from database.`)
   }
 
-  async applyToLocalGFF3(backend: LocalGFF3DataStore) {
-    throw new Error('applyToLocalGFF3 not implemented')
+  async executeOnLocalGFF3(backend: LocalGFF3DataStore) {
+    throw new Error('executeOnLocalGFF3 not implemented')
   }
 
-  async applyToClient(dataStore: ClientDataStore) {
+  async executeOnClient(dataStore: ClientDataStore) {
     const { assembly } = this
     if (!dataStore) {
       throw new Error('No data store')

--- a/packages/apollo-shared/src/Changes/DeleteFeatureChange.ts
+++ b/packages/apollo-shared/src/Changes/DeleteFeatureChange.ts
@@ -62,7 +62,7 @@ export class DeleteFeatureChange extends FeatureChange {
    * @param backend - parameters from backend
    * @returns
    */
-  async applyToServer(backend: ServerDataStore) {
+  async executeOnServer(backend: ServerDataStore) {
     const { featureModel, session } = backend
     const { changes, logger } = this
 
@@ -152,11 +152,11 @@ export class DeleteFeatureChange extends FeatureChange {
     )
   }
 
-  async applyToLocalGFF3(backend: LocalGFF3DataStore) {
-    throw new Error('applyToLocalGFF3 not implemented')
+  async executeOnLocalGFF3(backend: LocalGFF3DataStore) {
+    throw new Error('executeOnLocalGFF3 not implemented')
   }
 
-  async applyToClient(dataStore: ClientDataStore) {
+  async executeOnClient(dataStore: ClientDataStore) {
     if (!dataStore) {
       throw new Error('No data store')
     }

--- a/packages/apollo-shared/src/Changes/DeleteUserChange.ts
+++ b/packages/apollo-shared/src/Changes/DeleteUserChange.ts
@@ -44,7 +44,7 @@ export class DeleteUserChange extends Change {
     return { typeName, userId }
   }
 
-  async applyToServer(backend: ServerDataStore) {
+  async executeOnServer(backend: ServerDataStore) {
     const { userModel, session } = backend
     const { userId, logger } = this
     const user = await userModel
@@ -58,12 +58,12 @@ export class DeleteUserChange extends Change {
     }
   }
 
-  async applyToLocalGFF3(backend: LocalGFF3DataStore) {
-    throw new Error('applyToLocalGFF3 not implemented')
+  async executeOnLocalGFF3(backend: LocalGFF3DataStore) {
+    throw new Error('executeOnLocalGFF3 not implemented')
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  async applyToClient(dataStore: ClientDataStore) {}
+  async executeOnClient(dataStore: ClientDataStore) {}
 
   getInverse() {
     const { typeName, userId, logger } = this

--- a/packages/apollo-shared/src/Changes/FeatureAttributeChange.ts
+++ b/packages/apollo-shared/src/Changes/FeatureAttributeChange.ts
@@ -62,7 +62,7 @@ export class FeatureAttributeChange extends FeatureChange {
    * @param backend - parameters from backend
    * @returns
    */
-  async applyToServer(backend: ServerDataStore) {
+  async executeOnServer(backend: ServerDataStore) {
     const { featureModel, session } = backend
     const { changes, logger } = this
 
@@ -123,11 +123,11 @@ export class FeatureAttributeChange extends FeatureChange {
     }
   }
 
-  async applyToLocalGFF3(backend: LocalGFF3DataStore) {
+  async executeOnLocalGFF3(backend: LocalGFF3DataStore) {
     throw new Error('applyToLocalGFF3 not implemented')
   }
 
-  async applyToClient(dataStore: ClientDataStore) {
+  async executeOnClient(dataStore: ClientDataStore) {
     if (!dataStore) {
       throw new Error('No data store')
     }

--- a/packages/apollo-shared/src/Changes/LocationEndChange.ts
+++ b/packages/apollo-shared/src/Changes/LocationEndChange.ts
@@ -56,7 +56,7 @@ export class LocationEndChange extends FeatureChange {
    * @param backend - parameters from backend
    * @returns
    */
-  async applyToServer(backend: ServerDataStore) {
+  async executeOnServer(backend: ServerDataStore) {
     const { featureModel, session } = backend
     const { changes, logger } = this
     const featuresForChanges: {
@@ -121,11 +121,11 @@ export class LocationEndChange extends FeatureChange {
     }
   }
 
-  async applyToLocalGFF3(backend: LocalGFF3DataStore) {
-    throw new Error('applyToLocalGFF3 not implemented')
+  async executeOnLocalGFF3(backend: LocalGFF3DataStore) {
+    throw new Error('executeOnLocalGFF3 not implemented')
   }
 
-  async applyToClient(dataStore: ClientDataStore) {
+  async executeOnClient(dataStore: ClientDataStore) {
     if (!dataStore) {
       throw new Error('No data store')
     }

--- a/packages/apollo-shared/src/Changes/LocationStartChange.ts
+++ b/packages/apollo-shared/src/Changes/LocationStartChange.ts
@@ -56,7 +56,7 @@ export class LocationStartChange extends FeatureChange {
    * @param backend - parameters from backend
    * @returns
    */
-  async applyToServer(backend: ServerDataStore) {
+  async executeOnServer(backend: ServerDataStore) {
     const { featureModel, session } = backend
     const { changes, logger } = this
     const featuresForChanges: {
@@ -121,11 +121,11 @@ export class LocationStartChange extends FeatureChange {
     }
   }
 
-  async applyToLocalGFF3(backend: LocalGFF3DataStore) {
-    throw new Error('applyToLocalGFF3 not implemented')
+  async executeOnLocalGFF3(backend: LocalGFF3DataStore) {
+    throw new Error('executeOnLocalGFF3 not implemented')
   }
 
-  async applyToClient(dataStore: ClientDataStore) {
+  async executeOnClient(dataStore: ClientDataStore) {
     if (!dataStore) {
       throw new Error('No data store')
     }

--- a/packages/apollo-shared/src/Changes/TypeChange.ts
+++ b/packages/apollo-shared/src/Changes/TypeChange.ts
@@ -55,7 +55,7 @@ export class TypeChange extends FeatureChange {
    * @param backend - parameters from backend
    * @returns
    */
-  async applyToServer(backend: ServerDataStore) {
+  async executeOnServer(backend: ServerDataStore) {
     const { featureModel, session } = backend
     const { changes, logger } = this
     const featuresForChanges: {
@@ -120,11 +120,11 @@ export class TypeChange extends FeatureChange {
     }
   }
 
-  async applyToLocalGFF3(backend: LocalGFF3DataStore) {
-    throw new Error('applyToLocalGFF3 not implemented')
+  async executeOnLocalGFF3(backend: LocalGFF3DataStore) {
+    throw new Error('executeOnLocalGFF3 not implemented')
   }
 
-  async applyToClient(dataStore: ClientDataStore) {
+  async executeOnClient(dataStore: ClientDataStore) {
     if (!dataStore) {
       throw new Error('No data store')
     }

--- a/packages/apollo-shared/src/Changes/UserChange.ts
+++ b/packages/apollo-shared/src/Changes/UserChange.ts
@@ -48,7 +48,7 @@ export class UserChange extends Change {
     return { typeName, userId, changes }
   }
 
-  async applyToServer(backend: ServerDataStore) {
+  async executeOnServer(backend: ServerDataStore) {
     const { userModel, session } = backend
     const { changes, userId, logger } = this
 
@@ -67,12 +67,12 @@ export class UserChange extends Change {
     }
   }
 
-  async applyToLocalGFF3(backend: LocalGFF3DataStore) {
-    throw new Error('applyToLocalGFF3 not implemented')
+  async executeOnLocalGFF3(backend: LocalGFF3DataStore) {
+    throw new Error('executeOnLocalGFF3 not implemented')
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  async applyToClient(dataStore: ClientDataStore) {}
+  async executeOnClient(dataStore: ClientDataStore) {}
 
   getInverse() {
     const { typeName, changes, userId, logger } = this

--- a/packages/apollo-shared/src/Changes/abstract/Change.ts
+++ b/packages/apollo-shared/src/Changes/abstract/Change.ts
@@ -7,12 +7,13 @@ import {
 } from 'apollo-mst'
 
 import {
+  BackendDataStore,
   LocalGFF3DataStore,
   Operation,
   OperationOptions,
   SerializedOperation,
   ServerDataStore,
-} from '../../Operations'
+} from '../../Operations/abstract'
 import { changeRegistry } from '..'
 
 export interface ClientDataStore {
@@ -32,7 +33,7 @@ export { ServerDataStore, LocalGFF3DataStore }
 export type SerializedChange = SerializedOperation
 export type ChangeOptions = OperationOptions
 
-export type DataStore = ServerDataStore | LocalGFF3DataStore | ClientDataStore
+export type DataStore = BackendDataStore | ClientDataStore
 
 export abstract class Change extends Operation {
   /**

--- a/packages/apollo-shared/src/Changes/abstract/Change.ts
+++ b/packages/apollo-shared/src/Changes/abstract/Change.ts
@@ -1,25 +1,19 @@
-import type { ReadStream } from 'fs'
-import type { FileHandle } from 'fs/promises'
-
 import { Region } from '@jbrowse/core/util'
 import { AppRootModel } from '@jbrowse/core/util'
-import type { LoggerService } from '@nestjs/common'
 import {
   AnnotationFeatureI,
   AnnotationFeatureSnapshot,
   ApolloAssemblyI,
 } from 'apollo-mst'
-import {
-  AssemblyDocument,
-  FeatureDocument,
-  FileDocument,
-  RefSeqChunkDocument,
-  RefSeqDocument,
-  UserDocument,
-} from 'apollo-schemas'
-import type { ClientSession, Model } from 'mongoose'
 
-import { changeRegistry } from '../'
+import {
+  LocalGFF3DataStore,
+  Operation,
+  OperationOptions,
+  SerializedOperation,
+  ServerDataStore,
+} from '../../Operations'
+import { changeRegistry } from '..'
 
 export interface ClientDataStore {
   typeName: 'Client'
@@ -33,58 +27,14 @@ export interface ClientDataStore {
   deleteAssembly(assemblyId: string): void
 }
 
-export interface LocalGFF3DataStore {
-  typeName: 'LocalGFF3'
-  gff3Handle: FileHandle
-}
+export { ServerDataStore, LocalGFF3DataStore }
 
-interface CreateFileDto {
-  readonly _id: string
-  readonly basename: string
-  readonly checksum: string
-  readonly type: 'text/x-gff3' | 'text/x-fasta'
-  readonly user: string
-}
-
-export interface ServerDataStore {
-  typeName: 'Server'
-  featureModel: Model<FeatureDocument>
-  assemblyModel: Model<AssemblyDocument>
-  refSeqModel: Model<RefSeqDocument>
-  refSeqChunkModel: Model<RefSeqChunkDocument>
-  fileModel: Model<FileDocument>
-  userModel: Model<UserDocument>
-  session: ClientSession
-  filesService: {
-    getFileStream(file: FileDocument): ReadStream
-    parseGFF3(stream: ReadStream): ReadStream
-    create(createFileDto: CreateFileDto): void
-    remove(id: string): void
-  }
-  counterService: {
-    getNextSequenceValue(sequenceName: string): Promise<number>
-  }
-  user: string
-}
-
-export interface SerializedChange {
-  typeName: string
-}
+export type SerializedChange = SerializedOperation
+export type ChangeOptions = OperationOptions
 
 export type DataStore = ServerDataStore | LocalGFF3DataStore | ClientDataStore
 
-export interface ChangeOptions {
-  logger: LoggerService
-}
-
-export abstract class Change implements SerializedChange {
-  protected logger: LoggerService
-  abstract typeName: string
-
-  constructor(json: SerializedChange, options?: ChangeOptions) {
-    this.logger = options?.logger || console
-  }
-
+export abstract class Change extends Operation {
   /**
    * If a non-empty string, a snackbar will display in JBrowse with this message
    * when a successful response is received from the server.
@@ -93,32 +43,25 @@ export abstract class Change implements SerializedChange {
     return ''
   }
 
-  static fromJSON(json: SerializedChange, options?: ChangeOptions): Change {
+  static fromJSON(json: SerializedOperation, options?: ChangeOptions): Change {
     const ChangeType = changeRegistry.getChangeType(json.typeName)
     return new ChangeType(json, options?.logger && { logger: options.logger })
   }
 
-  abstract toJSON(): SerializedChange
-
-  async apply(backend: DataStore): Promise<void> {
+  async execute(backend: DataStore): Promise<void> {
     const backendType = backend.typeName
-    if (backendType === 'Server') {
-      return this.applyToServer(backend)
+    if (backendType === 'LocalGFF3' || backendType === 'Server') {
+      super.execute(backend)
+    } else if (backendType === 'Client') {
+      return this.executeOnClient(backend)
+    } else {
+      throw new Error(
+        `no change implementation for backend type '${backendType}'`,
+      )
     }
-    if (backendType === 'LocalGFF3') {
-      return this.applyToLocalGFF3(backend)
-    }
-    if (backendType === 'Client') {
-      return this.applyToClient(backend)
-    }
-    throw new Error(
-      `no change implementation for backend type '${backendType}'`,
-    )
   }
 
-  abstract applyToServer(backend: ServerDataStore): Promise<void>
-  abstract applyToLocalGFF3(backend: LocalGFF3DataStore): Promise<void>
-  abstract applyToClient(backend: ClientDataStore): Promise<void>
+  abstract executeOnClient(backend: ClientDataStore): Promise<void>
 
   abstract getInverse(): Change
 }

--- a/packages/apollo-shared/src/Operations/GetAssembliesOperation.ts
+++ b/packages/apollo-shared/src/Operations/GetAssembliesOperation.ts
@@ -1,0 +1,27 @@
+import {
+  LocalGFF3DataStore,
+  Operation,
+  SerializedOperation,
+  ServerDataStore,
+} from './abstract'
+
+interface SerializedGetAssembliesOperation extends SerializedOperation {
+  typeName: 'GetAssembliesOperation'
+}
+
+export class GetAssembliesOperation extends Operation {
+  typeName = 'GetAssembliesOperation' as const
+
+  toJSON(): SerializedGetAssembliesOperation {
+    const { typeName } = this
+    return { typeName }
+  }
+
+  executeOnServer(backend: ServerDataStore) {
+    return backend.assemblyModel.find({ status: 0 }).exec()
+  }
+
+  async executeOnLocalGFF3(backend: LocalGFF3DataStore) {
+    throw new Error('executeOnLocalGFF3 not implemented')
+  }
+}

--- a/packages/apollo-shared/src/Operations/abstract/Operation.ts
+++ b/packages/apollo-shared/src/Operations/abstract/Operation.ts
@@ -12,8 +12,6 @@ import {
 } from 'apollo-schemas'
 import type { ClientSession, Model } from 'mongoose'
 
-import { operationRegistry } from '..'
-
 export interface LocalGFF3DataStore {
   typeName: 'LocalGFF3'
   gff3Handle: FileHandle
@@ -66,20 +64,9 @@ export abstract class Operation implements SerializedOperation {
     this.logger = options?.logger || console
   }
 
-  static fromJSON(
-    json: SerializedOperation,
-    options?: OperationOptions,
-  ): Operation {
-    const OperationType = operationRegistry.getOperationType(json.typeName)
-    return new OperationType(
-      json,
-      options?.logger && { logger: options.logger },
-    )
-  }
-
   abstract toJSON(): SerializedOperation
 
-  async execute(backend: BackendDataStore): Promise<void> {
+  async execute(backend: BackendDataStore): Promise<unknown> {
     const backendType = backend.typeName
     if (backendType === 'Server') {
       return this.executeOnServer(backend)
@@ -92,6 +79,6 @@ export abstract class Operation implements SerializedOperation {
     )
   }
 
-  abstract executeOnServer(backend: ServerDataStore): Promise<void>
-  abstract executeOnLocalGFF3(backend: LocalGFF3DataStore): Promise<void>
+  abstract executeOnServer(backend: ServerDataStore): Promise<unknown>
+  abstract executeOnLocalGFF3(backend: LocalGFF3DataStore): Promise<unknown>
 }

--- a/packages/apollo-shared/src/Operations/abstract/Operation.ts
+++ b/packages/apollo-shared/src/Operations/abstract/Operation.ts
@@ -1,0 +1,97 @@
+import type { ReadStream } from 'fs'
+import type { FileHandle } from 'fs/promises'
+
+import type { LoggerService } from '@nestjs/common'
+import {
+  AssemblyDocument,
+  FeatureDocument,
+  FileDocument,
+  RefSeqChunkDocument,
+  RefSeqDocument,
+  UserDocument,
+} from 'apollo-schemas'
+import type { ClientSession, Model } from 'mongoose'
+
+import { operationRegistry } from '..'
+
+export interface LocalGFF3DataStore {
+  typeName: 'LocalGFF3'
+  gff3Handle: FileHandle
+}
+
+interface CreateFileDto {
+  readonly _id: string
+  readonly basename: string
+  readonly checksum: string
+  readonly type: 'text/x-gff3' | 'text/x-fasta'
+  readonly user: string
+}
+
+export interface ServerDataStore {
+  typeName: 'Server'
+  featureModel: Model<FeatureDocument>
+  assemblyModel: Model<AssemblyDocument>
+  refSeqModel: Model<RefSeqDocument>
+  refSeqChunkModel: Model<RefSeqChunkDocument>
+  fileModel: Model<FileDocument>
+  userModel: Model<UserDocument>
+  session: ClientSession
+  filesService: {
+    getFileStream(file: FileDocument): ReadStream
+    parseGFF3(stream: ReadStream): ReadStream
+    create(createFileDto: CreateFileDto): void
+    remove(id: string): void
+  }
+  counterService: {
+    getNextSequenceValue(sequenceName: string): Promise<number>
+  }
+  user: string
+}
+
+export interface SerializedOperation {
+  typeName: string
+}
+
+export type BackendDataStore = ServerDataStore | LocalGFF3DataStore
+
+export interface OperationOptions {
+  logger: LoggerService
+}
+
+export abstract class Operation implements SerializedOperation {
+  protected logger: LoggerService
+  abstract typeName: string
+
+  constructor(json: SerializedOperation, options?: OperationOptions) {
+    this.logger = options?.logger || console
+  }
+
+  static fromJSON(
+    json: SerializedOperation,
+    options?: OperationOptions,
+  ): Operation {
+    const OperationType = operationRegistry.getOperationType(json.typeName)
+    return new OperationType(
+      json,
+      options?.logger && { logger: options.logger },
+    )
+  }
+
+  abstract toJSON(): SerializedOperation
+
+  async execute(backend: BackendDataStore): Promise<void> {
+    const backendType = backend.typeName
+    if (backendType === 'Server') {
+      return this.executeOnServer(backend)
+    }
+    if (backendType === 'LocalGFF3') {
+      return this.executeOnLocalGFF3(backend)
+    }
+    throw new Error(
+      `no operation implementation for backend type '${backendType}'`,
+    )
+  }
+
+  abstract executeOnServer(backend: ServerDataStore): Promise<void>
+  abstract executeOnLocalGFF3(backend: LocalGFF3DataStore): Promise<void>
+}

--- a/packages/apollo-shared/src/Operations/abstract/index.ts
+++ b/packages/apollo-shared/src/Operations/abstract/index.ts
@@ -1,0 +1,1 @@
+export * from './Operation'

--- a/packages/apollo-shared/src/Operations/index.ts
+++ b/packages/apollo-shared/src/Operations/index.ts
@@ -1,6 +1,8 @@
 import { Operation } from './abstract/Operation'
+import { GetAssembliesOperation } from './GetAssembliesOperation'
 
-export const operations = {}
+export const operations = { GetAssembliesOperation }
+export * from './GetAssembliesOperation'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type OperationType = new (...args: any[]) => Operation

--- a/packages/apollo-shared/src/Operations/index.ts
+++ b/packages/apollo-shared/src/Operations/index.ts
@@ -1,8 +1,6 @@
-import { Operation } from './abstract'
+import { Operation } from './abstract/Operation'
 
 export const operations = {}
-
-export * from './abstract'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type OperationType = new (...args: any[]) => Operation

--- a/packages/apollo-shared/src/Operations/index.ts
+++ b/packages/apollo-shared/src/Operations/index.ts
@@ -1,0 +1,30 @@
+import { Operation } from './abstract'
+
+export const operations = {}
+
+export * from './abstract'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type OperationType = new (...args: any[]) => Operation
+
+class OperationTypeRegistry {
+  operations: Map<string, OperationType> = new Map()
+
+  registerOperation(name: string, operationType: OperationType): void {
+    if (this.operations.has(name)) {
+      throw new Error(`operation type "${name}" has already been registered`)
+    }
+    this.operations.set(name, operationType)
+  }
+
+  getOperationType(name: string): OperationType {
+    const RegisteredOperationType = this.operations.get(name)
+    if (!RegisteredOperationType) {
+      throw new Error(`No operation constructor registered for "${name}"`)
+    }
+    return RegisteredOperationType
+  }
+}
+
+/** global singleton of all known types of operations */
+export const operationRegistry = new OperationTypeRegistry()

--- a/packages/apollo-shared/src/index.ts
+++ b/packages/apollo-shared/src/index.ts
@@ -1,4 +1,6 @@
 export * from './Changes'
 export * from './Changes/abstract'
+export * from './Operations'
+export * from './Operations/abstract'
 export * from './Validations'
 export * from './Common'

--- a/packages/jbrowse-plugin-apollo/src/ChangeManager.ts
+++ b/packages/jbrowse-plugin-apollo/src/ChangeManager.ts
@@ -36,7 +36,7 @@ export class ChangeManager {
 
     try {
       // submit to client data store
-      await change.apply(this.dataStore)
+      await change.execute(this.dataStore)
     } catch (error) {
       console.error(error)
       session.notify(String(error), 'error')


### PR DESCRIPTION
Adds a base abstract class Operation that is now the base of the Change abstract class. Adds GetAssembliesOperation as the first class to use the new base class.

Fixes #165 