### PR TITLE
Update mui/x-data-grid to v6

### DIFF
--- a/packages/jbrowse-plugin-apollo/package.json
+++ b/packages/jbrowse-plugin-apollo/package.json
@@ -80,7 +80,7 @@
     "@jbrowse/development-tools": "^2.1.1",
     "@jest/globals": "^29.0.3",
     "@mui/material": "^5.9.1",
-    "@mui/x-data-grid": "^5.12.3",
+    "@mui/x-data-grid": "^6.0.1",
     "@types/cypress": "^1.1.3",
     "@types/node": "^16.11.6",
     "@types/prop-types": "^15",

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/ApolloDetails.tsx
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/ApolloDetails.tsx
@@ -3,7 +3,7 @@ import CloseIcon from '@mui/icons-material/Close'
 import { Autocomplete, IconButton, TextField } from '@mui/material'
 import {
   DataGrid,
-  GridColumns,
+  GridColDef,
   GridRenderEditCellParams,
   GridRowModel,
   MuiBaseEvent,
@@ -26,7 +26,7 @@ import { LinearApolloDisplay } from '../stateModel'
 function getFeatureColumns(
   editable: boolean,
   internetAccount: ApolloInternetAccountModel,
-): GridColumns {
+): GridColDef[] {
   return [
     { field: 'id', headerName: 'ID', width: 250 },
     {
@@ -225,7 +225,6 @@ export const ApolloDetails = observer(
           style={{ height: detailsHeight }}
           rows={selectedFeatureRows}
           columns={getFeatureColumns(editable, internetAccount)}
-          experimentalFeatures={{ newEditingApi: true }}
           processRowUpdate={processRowUpdate}
           onProcessRowUpdateError={console.error}
         />

--- a/packages/jbrowse-plugin-apollo/src/components/ManageUsers.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/ManageUsers.tsx
@@ -14,14 +14,11 @@ import {
 import {
   DataGrid,
   GridActionsCellItem,
-  GridCallbackDetails,
-  GridCellEditCommitParams,
   GridCellParams,
-  GridColumns,
+  GridColDef,
   GridRowId,
   GridRowParams,
   GridToolbar,
-  MuiEvent,
 } from '@mui/x-data-grid'
 import { DeleteUserChange, UserChange } from 'apollo-shared'
 import { getRoot } from 'mobx-state-tree'
@@ -113,7 +110,7 @@ export function ManageUsers({
     return false
   }
 
-  const gridColumns: GridColumns = [
+  const gridColumns: GridColDef[] = [
     { field: 'username', headerName: 'User', width: 140 },
     { field: 'email', headerName: 'Email', width: 160 },
     {
@@ -154,7 +151,7 @@ export function ManageUsers({
     setSelectedInternetAcount(newlySelectedInternetAccount)
   }
 
-  async function onChangeTableCell(change: UserChange, event: MuiEvent) {
+  async function onChangeTableCell(change: UserChange) {
     changeManager.submit(change, {
       internetAccountId: selectedInternetAcount.internetAccountId,
     })
@@ -193,18 +190,14 @@ export function ManageUsers({
             isCellEditable={(params: GridCellParams) =>
               !isCurrentUser(params.id)
             }
-            onCellEditCommit={(
-              params: GridCellEditCommitParams,
-              event: MuiEvent,
-              details: GridCallbackDetails,
-            ) => {
+            onCellEditStop={(params) => {
               if (params.field === 'role') {
                 const change = new UserChange({
                   typeName: 'UserChange',
                   role: params.value,
                   userId: params.id as string,
                 })
-                onChangeTableCell(change, event)
+                onChangeTableCell(change)
               }
             }}
           />

--- a/packages/jbrowse-plugin-apollo/src/components/ViewChangeLog.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/ViewChangeLog.tsx
@@ -14,7 +14,7 @@ import {
 import {
   DataGrid,
   GridActionsCellItem,
-  GridColumns,
+  GridColDef,
   GridRowsProp,
   GridToolbar,
 } from '@mui/x-data-grid'
@@ -51,7 +51,7 @@ export function ViewChangeLog({ session, handleClose }: ViewChangeLogProps) {
   const [assemblyId, setAssemblyId] = useState<string>()
   const [displayGridData, setDisplayGridData] = useState<GridRowsProp[]>([])
 
-  const gridColumns: GridColumns = [
+  const gridColumns: GridColDef[] = [
     {
       field: 'actions',
       type: 'actions',
@@ -69,7 +69,7 @@ export function ViewChangeLog({ session, handleClose }: ViewChangeLogProps) {
         />,
       ],
     },
-    { field: 'sequence', hide: true },
+    { field: 'sequence' },
     {
       field: 'typeName',
       headerName: 'Change type',
@@ -196,9 +196,8 @@ export function ViewChangeLog({ session, handleClose }: ViewChangeLogProps) {
             components={{ Toolbar: GridToolbar }}
             getRowHeight={() => 'auto'}
             initialState={{
-              sorting: {
-                sortModel: [{ field: 'sequence', sort: 'desc' }],
-              },
+              sorting: { sortModel: [{ field: 'sequence', sort: 'desc' }] },
+              columns: { columnVisibilityModel: { sequence: false } },
             }}
           />
         </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2632,7 +2632,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.17.9, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7":
+"@babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.17.9, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7":
   version: 7.18.9
   resolution: "@babel/runtime@npm:7.18.9"
   dependencies:
@@ -4247,7 +4247,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/utils@npm:^5.4.1, @mui/utils@npm:^5.9.1":
+"@mui/utils@npm:^5.11.13":
+  version: 5.12.0
+  resolution: "@mui/utils@npm:5.12.0"
+  dependencies:
+    "@babel/runtime": ^7.21.0
+    "@types/prop-types": ^15.7.5
+    "@types/react-is": ^16.7.1 || ^17.0.0
+    prop-types: ^15.8.1
+    react-is: ^18.2.0
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0
+  checksum: 87b2c7468803b083f50af28d7c215c45291e73fef16570848b596d0f1cde1fc613c20e8951f431217b31451de254744abd50eda5013dedec4982420b5bf1c6b6
+  languageName: node
+  linkType: hard
+
+"@mui/utils@npm:^5.9.1":
   version: 5.9.1
   resolution: "@mui/utils@npm:5.9.1"
   dependencies:
@@ -4262,21 +4277,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/x-data-grid@npm:^5.12.3":
-  version: 5.13.1
-  resolution: "@mui/x-data-grid@npm:5.13.1"
+"@mui/x-data-grid@npm:^6.0.1":
+  version: 6.1.0
+  resolution: "@mui/x-data-grid@npm:6.1.0"
   dependencies:
-    "@babel/runtime": ^7.18.6
-    "@mui/utils": ^5.4.1
+    "@babel/runtime": ^7.21.0
+    "@mui/utils": ^5.11.13
     clsx: ^1.2.1
     prop-types: ^15.8.1
-    reselect: ^4.1.6
+    reselect: ^4.1.7
   peerDependencies:
     "@mui/material": ^5.4.1
     "@mui/system": ^5.4.1
     react: ^17.0.2 || ^18.0.0
     react-dom: ^17.0.2 || ^18.0.0
-  checksum: 555ad87d91cb2170e8c280c7f07364dd15da61744f99b0e3a64643ddd3909f42fa6963fd67b23f621806d9ed03a8c6960dbe8937d4d56b5c734d0d3e0b9139cd
+  checksum: 21f5bf6e0ab7468ec65002bd07751bceba0b641a04f14ac5b9414a39c3a3fd7249ba8a5d7befc21f6787ce97899302fc9fc8fe4b2e5e817fa8b69e412e59a173
   languageName: node
   linkType: hard
 
@@ -11610,7 +11625,7 @@ __metadata:
     "@jest/globals": ^29.0.3
     "@mui/icons-material": ^5.8.4
     "@mui/material": ^5.9.1
-    "@mui/x-data-grid": ^5.12.3
+    "@mui/x-data-grid": ^6.0.1
     "@types/cypress": ^1.1.3
     "@types/node": ^16.11.6
     "@types/prop-types": ^15
@@ -15661,10 +15676,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"reselect@npm:^4.1.6":
-  version: 4.1.6
-  resolution: "reselect@npm:4.1.6"
-  checksum: 3ea1058422904063ec93c8f4693fe33dcb2178bbf417ace8db5b2c797a5875cf357d9308d11ed3942ee22507dd34ecfbf1f3a21340a4f31c206cab1d36ceef31
+"reselect@npm:^4.1.7":
+  version: 4.1.7
+  resolution: "reselect@npm:4.1.7"
+  checksum: 738d8e2b8f0dca154ad29de6a209c9fbca2d70ae6788fd85df87f2c74b95a65bbf2d16d43a9e2faff39de34d17a29d706ba08a6b2ee5660c09589edbd19af7e1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
JBrowse main branch has moved to `@mui/x-data-grid` v6. This PR adds the needed changes in `jbrowse-plugin-apollo` for that update.