### PR TITLE
fix #204 in AddFeatureChange.executeOnClient

### DIFF
--- a/packages/apollo-shared/package.json
+++ b/packages/apollo-shared/package.json
@@ -24,6 +24,7 @@
     "@nestjs/core": "^9.2.1",
     "@types/node": "^16.0.0",
     "@types/rimraf": "^3",
+    "mobx": "^6.6.1",
     "mobx-state-tree": "^5.1.5",
     "mongoose": "^6.2.10",
     "rimraf": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6389,6 +6389,7 @@ __metadata:
     apollo-schemas: "workspace:^"
     bson-objectid: ^2.0.3
     jwt-decode: ^3.1.2
+    mobx: ^6.6.1
     mobx-state-tree: ^5.1.5
     mongoose: ^6.2.10
     regenerator-runtime: ^0.13.9


### PR DESCRIPTION
Was not remembering to create an ID for the parent feature if it didn't
have one, but only when executing on the client.

This led to the behavior in #204 because:

> 2. In my case, I added a new sub-feature which type was **_exon_region_** to existing **_exon_** which start is 69796 and end is 73033.

`AddFeatureChange.executeOnServer` creates an ID for the parent feature (which didn't already have one), but **only on the server**. Parent still has no ID in the client data store.

> 3. I exported the assembly (GFF3), OK.

Parent still has no ID in the client data store, but that's OK.

> 4. I opened the exon's "_**Modify feature attribute**_" -modal window from context menu. Without making any modification, I pressed "_**Submit changes**_"

Attributes in the client data store, with no ID, are copied into the feature in the backend, which clobbers the autogenerated ID that was added in step 2 above.

> 5. I tried to export the assembly again
> `[Nest] 18341  - 05/02/2023, 4:41:06 PM   ERROR [FeaturesService] GFF3 export failed`
> `[Nest] 18341  - 05/02/2023, 4:41:06 PM   ERROR [FeaturesService] TypeError: Cannot read properties of undefined (reading '0')`

Fails because a parent with children has no ID.

fixes #204


This PR also adds mobx as a devDep on apollo-shared, because it's needed for proper TS typings on MST types.array and types.map