### PR TITLE
Show selected feature with rendering

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
@@ -20,8 +20,9 @@ export class BoxGlyph extends Glyph {
     row: number,
     reversed: boolean,
   ) {
-    const { lgv, theme, apolloRowHeight: rowHeight } = stateModel
+    const { lgv, theme, apolloRowHeight: rowHeight, session } = stateModel
     const { bpPerPx } = lgv
+    const { apolloSelectedFeature } = session
     const offsetPx = (feature.start - feature.min) / bpPerPx
     const widthPx = feature.length / bpPerPx
     const startPx = reversed ? xOffset - offsetPx - widthPx : xOffset + offsetPx
@@ -29,10 +30,18 @@ export class BoxGlyph extends Glyph {
     ctx.fillStyle = theme?.palette.text.primary || 'black'
     ctx.fillRect(startPx, top, widthPx, rowHeight)
     if (widthPx > 2) {
+      const backgroundColor =
+        apolloSelectedFeature && feature._id === apolloSelectedFeature._id
+          ? theme?.palette.text.primary || 'black'
+          : theme?.palette.background.default || 'white'
+      const textColor =
+        apolloSelectedFeature && feature._id === apolloSelectedFeature._id
+          ? theme?.palette.getContrastText(backgroundColor) || 'white'
+          : theme?.palette.text.primary || 'black'
       ctx.clearRect(startPx + 1, top + 1, widthPx - 2, rowHeight - 2)
-      ctx.fillStyle = theme?.palette.background.default || 'white'
+      ctx.fillStyle = backgroundColor
       ctx.fillRect(startPx + 1, top + 1, widthPx - 2, rowHeight - 2)
-      ctx.fillStyle = theme?.palette.text.primary || 'black'
+      ctx.fillStyle = textColor
       const textStart = Math.max(startPx + 1, 0)
       const textWidth = startPx - 1 + widthPx - textStart
       feature.type && ctx.fillText(feature.type, textStart, top + 11, textWidth)

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/CanonicalGeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/CanonicalGeneGlyph.ts
@@ -59,7 +59,7 @@ export class CanonicalGeneGlyph extends Glyph {
     row: number,
     reversed: boolean,
   ): void {
-    const { theme, lgv } = stateModel
+    const { theme, lgv, session } = stateModel
     const { bpPerPx } = lgv
     const rowHeight = stateModel.apolloRowHeight
     const utrHeight = Math.round(0.6 * rowHeight)
@@ -190,6 +190,15 @@ export class CanonicalGeneGlyph extends Glyph {
         currentCDS += 1
       })
     })
+    const { apolloSelectedFeature } = session
+    if (apolloSelectedFeature && feature._id === apolloSelectedFeature._id) {
+      const widthPx = feature.max - feature.min
+      const startPx = reversed ? xOffset - widthPx : xOffset
+      const top = row * rowHeight
+      const height = this.getRowCount(feature, bpPerPx) * rowHeight
+      ctx.fillStyle = theme?.palette.action.selected || 'rgba(0,0,0,0.08)'
+      ctx.fillRect(startPx, top, widthPx, height)
+    }
   }
 
   drawHover(stateModel: LinearApolloDisplay, ctx: CanvasRenderingContext2D) {

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GenericChildGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GenericChildGlyph.ts
@@ -42,8 +42,9 @@ export class GenericChildGlyph extends Glyph {
     reversed: boolean,
   ) {
     const features = this.featuresForRow(topLevelFeature)[row - topRow]
-    const { lgv, apolloRowHeight } = stateModel
+    const { lgv, theme, apolloRowHeight, session } = stateModel
     const { bpPerPx } = lgv
+    const { apolloSelectedFeature } = session
     const top = row * apolloRowHeight
 
     features.forEach((feature) => {
@@ -55,16 +56,27 @@ export class GenericChildGlyph extends Glyph {
       const rowCount = this.getRowCount(feature)
       if (rowCount > 1) {
         const featureHeight = rowCount * apolloRowHeight
-        ctx.fillStyle = 'rgba(255,0,0,0.25)'
+        ctx.fillStyle =
+          apolloSelectedFeature && feature._id === apolloSelectedFeature._id
+            ? 'rgba(130,0,0,0.45)'
+            : 'rgba(255,0,0,0.25)'
         ctx.fillRect(startPx, top, widthPx, featureHeight)
       }
-      ctx.fillStyle = 'black'
+      ctx.fillStyle = theme?.palette.text.primary || 'black'
       ctx.fillRect(startPx, top, widthPx, apolloRowHeight)
       if (widthPx > 2) {
+        const backgroundColor =
+          apolloSelectedFeature && feature._id === apolloSelectedFeature._id
+            ? theme?.palette.text.primary || 'black'
+            : theme?.palette.background.default || 'white'
+        const textColor =
+          apolloSelectedFeature && feature._id === apolloSelectedFeature._id
+            ? theme?.palette.getContrastText(backgroundColor) || 'white'
+            : theme?.palette.text.primary || 'black'
         ctx.clearRect(startPx + 1, top + 1, widthPx - 2, apolloRowHeight - 2)
-        ctx.fillStyle = 'rgba(255,255,255,0.75)'
+        ctx.fillStyle = backgroundColor
         ctx.fillRect(startPx + 1, top + 1, widthPx - 2, apolloRowHeight - 2)
-        ctx.fillStyle = 'black'
+        ctx.fillStyle = textColor
         const textStart = Math.max(startPx + 1, 0)
         const textWidth = startPx - 1 + widthPx - textStart
         feature.type &&

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/ImplicitExonGeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/ImplicitExonGeneGlyph.ts
@@ -57,7 +57,7 @@ export class ImplicitExonGeneGlyph extends Glyph {
     row: number,
     reversed?: boolean,
   ): void {
-    const { theme, lgv } = stateModel
+    const { theme, lgv, session } = stateModel
     const { bpPerPx } = lgv
     const rowHeight = stateModel.apolloRowHeight
     const utrHeight = Math.round(0.6 * rowHeight)
@@ -137,6 +137,15 @@ export class ImplicitExonGeneGlyph extends Glyph {
       })
       currentMRNA += 1
     })
+    const { apolloSelectedFeature } = session
+    if (apolloSelectedFeature && feature._id === apolloSelectedFeature._id) {
+      const widthPx = feature.max - feature.min
+      const startPx = reversed ? xOffset - widthPx : xOffset
+      const top = row * rowHeight
+      const height = this.getRowCount(feature, bpPerPx) * rowHeight
+      ctx.fillStyle = theme?.palette.action.selected || 'rgba(0,0,0,0.08)'
+      ctx.fillRect(startPx, top, widthPx, height)
+    }
   }
 
   drawHover(stateModel: LinearApolloDisplay, ctx: CanvasRenderingContext2D) {


### PR DESCRIPTION
This adds a change to the rendering so that if a feature is selected, it renders differently. Works in dark and light modes.

![image](https://github.com/GMOD/Apollo3/assets/25592344/32377512-3f64-4ad7-a4f2-53a4327c63f0)

![image](https://github.com/GMOD/Apollo3/assets/25592344/87b47f4a-2bc3-4a25-8aec-498a484d6a9b)

