### PR TITLE
Set default assembly in *Delete Assembly* menu

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/components/DeleteAssembly.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/DeleteAssembly.tsx
@@ -15,7 +15,7 @@ import {
 } from '@mui/material'
 import { DeleteAssemblyChange } from 'apollo-shared'
 import { getRoot } from 'mobx-state-tree'
-import React, { useState, useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { ApolloInternetAccountModel } from '../ApolloInternetAccount/model'
 import { ChangeManager } from '../ChangeManager'
@@ -46,8 +46,12 @@ export function DeleteAssembly({
   const [selectedInternetAcount, setSelectedInternetAcount] = useState(
     apolloInternetAccounts[0],
   )
-  const assemblies: AssemblyData[] = useAssemblies(internetAccounts, setErrorMessage)
-  
+
+  const assemblies: AssemblyData[] = useAssemblies(
+    internetAccounts,
+    setErrorMessage,
+  )
+
   useEffect(() => {
     if(assemblies.length > 0) {
       setSelectedAssembly(assemblies[0])

--- a/packages/jbrowse-plugin-apollo/src/components/DeleteAssembly.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/DeleteAssembly.tsx
@@ -53,7 +53,7 @@ export function DeleteAssembly({
   )
 
   useEffect(() => {
-    if(assemblies.length > 0) {
+    if (assemblies.length > 0) {
       setSelectedAssembly(assemblies[0])
     }
   }, [assemblies])

--- a/packages/jbrowse-plugin-apollo/src/components/DeleteAssembly.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/DeleteAssembly.tsx
@@ -15,7 +15,7 @@ import {
 } from '@mui/material'
 import { DeleteAssemblyChange } from 'apollo-shared'
 import { getRoot } from 'mobx-state-tree'
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 
 import { ApolloInternetAccountModel } from '../ApolloInternetAccount/model'
 import { ChangeManager } from '../ChangeManager'
@@ -46,7 +46,13 @@ export function DeleteAssembly({
   const [selectedInternetAcount, setSelectedInternetAcount] = useState(
     apolloInternetAccounts[0],
   )
-  const assemblies = useAssemblies(internetAccounts, setErrorMessage)
+  const assemblies: AssemblyData[] = useAssemblies(internetAccounts, setErrorMessage)
+  
+  useEffect(() => {
+    if(assemblies.length > 0) {
+      setSelectedAssembly(assemblies[0])
+    }
+  }, [assemblies])
 
   function handleChangeInternetAccount(e: SelectChangeEvent<string>) {
     setSubmitted(false)

--- a/packages/jbrowse-plugin-apollo/src/components/DeleteAssembly.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/DeleteAssembly.tsx
@@ -53,10 +53,10 @@ export function DeleteAssembly({
   )
 
   useEffect(() => {
-    if (assemblies.length > 0) {
+    if (assemblies.length > 0 && selectedAssembly === undefined) {
       setSelectedAssembly(assemblies[0])
     }
-  }, [assemblies])
+  }, [assemblies, selectedAssembly])
 
   function handleChangeInternetAccount(e: SelectChangeEvent<string>) {
     setSubmitted(false)


### PR DESCRIPTION
In *Delete Assembly* menu display the first assembly availaible instead of showing a blank box.