### PR TITLE
Find feature by name/id

### DIFF
--- a/packages/apollo-collaboration-server/src/features/features.controller.ts
+++ b/packages/apollo-collaboration-server/src/features/features.controller.ts
@@ -115,4 +115,26 @@ export class FeaturesController {
     this.logger.debug(`Get all features`)
     return this.featuresService.findAll()
   }
+
+  /**
+   * Fetch feature by its name from featureNameIndex
+   * @param featureName 
+   * @returns a feature object
+   */
+  @Get('name/:name')
+  getFeatureByName(@Param('name') featureName: string) {
+    this.logger.debug(`Get feature by featurename: ${featureName}`)
+    return this.featuresService.findByName(featureName)
+  }
+
+  /**
+   * Fetch feature by its id attribute from featureIdIndex
+   * @param id 
+   * @returns a feature object
+   */
+  @Get('id/:id')
+  getFeatureById(@Param('id') id: string) {
+    this.logger.debug(`Get feature by id: ${id}`)
+    return this.featuresService.findByAttrId(id)
+  }
 }

--- a/packages/apollo-collaboration-server/src/features/features.controller.ts
+++ b/packages/apollo-collaboration-server/src/features/features.controller.ts
@@ -117,24 +117,14 @@ export class FeaturesController {
   }
 
   /**
-   * Fetch feature by its name from featureNameIndex
-   * @param featureName 
+   * Find feature using id/attribute (extendible to other attrs) from db index
+   * @param attrType attribute type in db document or db index type
+   * @param query query to fetch the feature from db index
    * @returns a feature object
    */
-  @Get('name/:name')
-  getFeatureByName(@Param('name') featureName: string) {
-    this.logger.debug(`Get feature by featurename: ${featureName}`)
-    return this.featuresService.findByName(featureName)
-  }
-
-  /**
-   * Fetch feature by its id attribute from featureIdIndex
-   * @param id 
-   * @returns a feature object
-   */
-  @Get('id/:id')
-  getFeatureById(@Param('id') id: string) {
-    this.logger.debug(`Get feature by id: ${id}`)
-    return this.featuresService.findByAttrId(id)
+  @Get(':attrtype/:query')
+  getFeatureByAttr(@Param('attrtype') attrType: string, @Param('query') query: string) {
+    this.logger.debug(`Get feature by attrtype and query: ${attrType}, ${query}`)
+    return this.featuresService.getFeatureByAttr(attrType, query)
   }
 }

--- a/packages/apollo-collaboration-server/src/features/features.controller.ts
+++ b/packages/apollo-collaboration-server/src/features/features.controller.ts
@@ -118,13 +118,18 @@ export class FeaturesController {
 
   /**
    * Find feature using id/attribute (extendible to other attrs) from db index
-   * @param attrType attribute type in db document or db index type
-   * @param query query to fetch the feature from db index
+   * @param attrType - attribute type in db document or db index type
+   * @param query - query to fetch the feature from db index
    * @returns a feature object
    */
   @Get(':attrtype/:query')
-  getFeatureByAttr(@Param('attrtype') attrType: string, @Param('query') query: string) {
-    this.logger.debug(`Get feature by attrtype and query: ${attrType}, ${query}`)
+  getFeatureByAttr(
+    @Param('attrtype') attrType: string,
+    @Param('query') query: string,
+  ) {
+    this.logger.debug(
+      `Get feature by attrtype and query: ${attrType}, ${query}`,
+    )
     return this.featuresService.getFeatureByAttr(attrType, query)
   }
 }

--- a/packages/apollo-collaboration-server/src/features/features.service.ts
+++ b/packages/apollo-collaboration-server/src/features/features.service.ts
@@ -28,12 +28,12 @@ function makeGFF3Feature(
   const locations = featureDocument.discontinuousLocations?.length
     ? featureDocument.discontinuousLocations
     : [
-        {
-          start: featureDocument.start,
-          end: featureDocument.end,
-          phase: featureDocument.phase,
-        },
-      ]
+      {
+        start: featureDocument.start,
+        end: featureDocument.end,
+        phase: featureDocument.phase,
+      },
+    ]
   const attributes: Record<string, string[]> = {
     ...(featureDocument.attributes || {}),
   }
@@ -114,16 +114,16 @@ function makeGFF3Feature(
       location.phase === 0
         ? '0'
         : location.phase === 1
-        ? '1'
-        : location.phase === 2
-        ? '2'
-        : null,
+          ? '1'
+          : location.phase === 2
+            ? '2'
+            : null,
     attributes: Object.keys(attributes).length ? attributes : null,
     derived_features: [],
     child_features: featureDocument.children
       ? Object.values(featureDocument.children).map((child) =>
-          makeGFF3Feature(child, refSeqs, attributes.ID[0]),
-        )
+        makeGFF3Feature(child, refSeqs, attributes.ID[0]),
+      )
       : [],
   }))
 }
@@ -140,7 +140,7 @@ export class FeaturesService {
     private readonly refSeqModel: Model<RefSeqDocument>,
     @InjectModel(Export.name)
     private readonly exportModel: Model<ExportDocument>,
-  ) {}
+  ) { }
 
   private readonly logger = new Logger(FeaturesService.name)
 
@@ -227,6 +227,44 @@ export class FeaturesService {
     }
     this.logger.debug(`Feature found: ${JSON.stringify(foundFeature)}`)
     return foundFeature
+  }
+
+  /**
+   * Get feature by its name from featureNameIndex (attributes.name)
+   * @param featureName 
+   */
+  async findByName(featureName: string) {
+    const feature = await this.featureModel
+      .find({ "attributes.name": featureName })
+      .populate("refSeq")
+      .exec()
+
+    if (!feature) {
+      const errMsg = `ERROR: The following featureName was not found in database index ='${featureName}'`
+      this.logger.error(errMsg)
+      throw new NotFoundException(errMsg)
+    }
+
+    return feature
+  }
+
+  /**
+   * Get feature by its id attribute from featureIdIndex (attributes.id)
+   * @param id 
+   */
+  async findByAttrId(id: string) {
+    const feature = await this.featureModel
+      .find({ "attributes.id": id })
+      .populate("refSeq")
+      .exec()
+
+    if (!feature) {
+      const errMsg = `ERROR: The following id was not found in database index ='${id}'`
+      this.logger.error(errMsg)
+      throw new NotFoundException(errMsg)
+    }
+
+    return feature
   }
 
   /**

--- a/packages/apollo-collaboration-server/src/features/features.service.ts
+++ b/packages/apollo-collaboration-server/src/features/features.service.ts
@@ -230,36 +230,19 @@ export class FeaturesService {
   }
 
   /**
-   * Get feature by its name from featureNameIndex (attributes.name)
-   * @param featureName 
+   * Get feature by its name/id from feature db index
+   * @param attrType attribute type or db index type
+   * @param query query string to fetch the feature
+   * @returns feature object
    */
-  async findByName(featureName: string) {
+  async getFeatureByAttr(attrType: string, query: string) {
     const feature = await this.featureModel
-      .find({ "attributes.name": featureName })
-      .populate("refSeq")
+      .find({ [`attributes.${attrType}`] : query })
+      .populate('refSeq')
       .exec()
 
     if (!feature) {
-      const errMsg = `ERROR: The following featureName was not found in database index ='${featureName}'`
-      this.logger.error(errMsg)
-      throw new NotFoundException(errMsg)
-    }
-
-    return feature
-  }
-
-  /**
-   * Get feature by its id attribute from featureIdIndex (attributes.id)
-   * @param id 
-   */
-  async findByAttrId(id: string) {
-    const feature = await this.featureModel
-      .find({ "attributes.id": id })
-      .populate("refSeq")
-      .exec()
-
-    if (!feature) {
-      const errMsg = `ERROR: The following id was not found in database index ='${id}'`
+      const errMsg = `ERROR: The following query ${query} was not found in database index ${attrType}`
       this.logger.error(errMsg)
       throw new NotFoundException(errMsg)
     }

--- a/packages/apollo-collaboration-server/src/features/features.service.ts
+++ b/packages/apollo-collaboration-server/src/features/features.service.ts
@@ -28,12 +28,12 @@ function makeGFF3Feature(
   const locations = featureDocument.discontinuousLocations?.length
     ? featureDocument.discontinuousLocations
     : [
-      {
-        start: featureDocument.start,
-        end: featureDocument.end,
-        phase: featureDocument.phase,
-      },
-    ]
+        {
+          start: featureDocument.start,
+          end: featureDocument.end,
+          phase: featureDocument.phase,
+        },
+      ]
   const attributes: Record<string, string[]> = {
     ...(featureDocument.attributes || {}),
   }
@@ -114,16 +114,16 @@ function makeGFF3Feature(
       location.phase === 0
         ? '0'
         : location.phase === 1
-          ? '1'
-          : location.phase === 2
-            ? '2'
-            : null,
+        ? '1'
+        : location.phase === 2
+        ? '2'
+        : null,
     attributes: Object.keys(attributes).length ? attributes : null,
     derived_features: [],
     child_features: featureDocument.children
       ? Object.values(featureDocument.children).map((child) =>
-        makeGFF3Feature(child, refSeqs, attributes.ID[0]),
-      )
+          makeGFF3Feature(child, refSeqs, attributes.ID[0]),
+        )
       : [],
   }))
 }
@@ -140,7 +140,7 @@ export class FeaturesService {
     private readonly refSeqModel: Model<RefSeqDocument>,
     @InjectModel(Export.name)
     private readonly exportModel: Model<ExportDocument>,
-  ) { }
+  ) {}
 
   private readonly logger = new Logger(FeaturesService.name)
 

--- a/packages/apollo-collaboration-server/src/features/features.service.ts
+++ b/packages/apollo-collaboration-server/src/features/features.service.ts
@@ -231,13 +231,13 @@ export class FeaturesService {
 
   /**
    * Get feature by its name/id from feature db index
-   * @param attrType attribute type or db index type
-   * @param query query string to fetch the feature
+   * @param attrType - attribute type or db index type
+   * @param query - query string to fetch the feature
    * @returns feature object
    */
   async getFeatureByAttr(attrType: string, query: string) {
     const feature = await this.featureModel
-      .find({ [`attributes.${attrType}`] : query })
+      .find({ [`attributes.${attrType}`]: new RegExp(`^${query}$`, 'i') })
       .populate('refSeq')
       .exec()
 

--- a/packages/apollo-schemas/src/feature.schema.ts
+++ b/packages/apollo-schemas/src/feature.schema.ts
@@ -66,5 +66,11 @@ FeatureSchema.add({ children: { type: Map, of: FeatureSchema } })
 
 FeatureSchema.index({ refSeq: 1, start: 1 })
 FeatureSchema.index({ refSeq: 1, end: 1 })
-FeatureSchema.index({'attributes.name': 1}, {background: true, name: 'featureNameIndex'})
-FeatureSchema.index({'attributes.id': 1}, {background: true, name: 'featureIdIndex'})
+FeatureSchema.index(
+  { 'attributes.name': 1 },
+  { background: true, name: 'featureNameIndex' },
+)
+FeatureSchema.index(
+  { 'attributes.id': 1 },
+  { background: true, name: 'featureIdIndex' },
+)

--- a/packages/apollo-schemas/src/feature.schema.ts
+++ b/packages/apollo-schemas/src/feature.schema.ts
@@ -66,3 +66,5 @@ FeatureSchema.add({ children: { type: Map, of: FeatureSchema } })
 
 FeatureSchema.index({ refSeq: 1, start: 1 })
 FeatureSchema.index({ refSeq: 1, end: 1 })
+FeatureSchema.index({'attributes.name': 1}, {background: true, name: 'featureNameIndex'})
+FeatureSchema.index({'attributes.id': 1}, {background: true, name: 'featureIdIndex'})

--- a/packages/jbrowse-plugin-apollo/jbrowse_config.json
+++ b/packages/jbrowse-plugin-apollo/jbrowse_config.json
@@ -15,12 +15,20 @@
           "main": "#6b4e2b"
         }
       }
+    },
+    "formatDetails": {
+      "feature": "jexl: {xrefs:apolloxreflink({interpro: 'https://www.ebi.ac.uk/interpro/entry/InterPro/',pfam: 'https://www.ebi.ac.uk/interpro/entry/pfam/',db_xref: {COG: 'https://www.ncbi.nlm.nih.gov/research/cog/cog/'}}, feature)}",
+      "subfeatures": "jexl: {xrefs:apolloxreflink({interpro: 'https://www.ebi.ac.uk/interpro/entry/InterPro/',pfam: 'https://www.ebi.ac.uk/interpro/entry/pfam/',db_xref: {COG: 'https://www.ncbi.nlm.nih.gov/research/cog/cog/'}}, feature)}"
     }
   },
   "plugins": [
     {
       "name": "Apollo",
       "url": "http://localhost:9000/dist/jbrowse-plugin-apollo.umd.development.js"
+    },
+    {
+      "name": "ApolloXrefLinkPlugin",
+      "url": "https://unpkg.com/apollo-xreflink-plugin@0.0.7/dist/apollo-xreflink-plugin.umd.production.min.js"
     }
   ],
   "internetAccounts": [

--- a/packages/jbrowse-plugin-apollo/jbrowse_config.json
+++ b/packages/jbrowse-plugin-apollo/jbrowse_config.json
@@ -15,20 +15,12 @@
           "main": "#6b4e2b"
         }
       }
-    },
-    "formatDetails": {
-      "feature": "jexl: {xrefs:apolloxreflink({interpro: 'https://www.ebi.ac.uk/interpro/entry/InterPro/',pfam: 'https://www.ebi.ac.uk/interpro/entry/pfam/',db_xref: {COG: 'https://www.ncbi.nlm.nih.gov/research/cog/cog/'}}, feature)}",
-      "subfeatures": "jexl: {xrefs:apolloxreflink({interpro: 'https://www.ebi.ac.uk/interpro/entry/InterPro/',pfam: 'https://www.ebi.ac.uk/interpro/entry/pfam/',db_xref: {COG: 'https://www.ncbi.nlm.nih.gov/research/cog/cog/'}}, feature)}"
     }
   },
   "plugins": [
     {
       "name": "Apollo",
       "url": "http://localhost:9000/dist/jbrowse-plugin-apollo.umd.development.js"
-    },
-    {
-      "name": "ApolloXrefLinkPlugin",
-      "url": "https://unpkg.com/apollo-xreflink-plugin@0.0.7/dist/apollo-xreflink-plugin.umd.production.min.js"
     }
   ],
   "internetAccounts": [

--- a/packages/jbrowse-plugin-apollo/src/ApolloTextSearchAdapter/ApolloTextSearchAdapter.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloTextSearchAdapter/ApolloTextSearchAdapter.ts
@@ -30,8 +30,8 @@ export class ApolloTextSearchAdapter extends BaseAdapter implements BaseTextSear
             .internetAccountPreAuthorization
     }
 
-    async fetchFeatureByAttr(attr_type: string, attr: string) {
-        const url = new URL(`features/${attr_type}/${attr}`, this.baseURL)
+    async fetchFeatureByAttr(attrType: string, attr: string) {
+        const url = new URL(`features/${attrType}/${attr}`, this.baseURL)
         const uri = url.toString()
         const location: UriLocation = { locationType: 'UriLocation', uri }
         if (this.internetAccountPreAuthorization) {
@@ -70,5 +70,6 @@ export class ApolloTextSearchAdapter extends BaseAdapter implements BaseTextSear
             .catch(err => err)
     }
 
-    freeResources() { }
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    freeResources() {}
 }

--- a/packages/jbrowse-plugin-apollo/src/ApolloTextSearchAdapter/ApolloTextSearchAdapter.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloTextSearchAdapter/ApolloTextSearchAdapter.ts
@@ -1,75 +1,82 @@
-import { AnyConfigurationModel, readConfObject } from "@jbrowse/core/configuration";
-import { BaseAdapter, BaseArgs, BaseTextSearchAdapter } from "@jbrowse/core/data_adapters/BaseAdapter";
-import { getSubAdapterType } from "@jbrowse/core/data_adapters/dataAdapterCache";
-import PluginManager from "@jbrowse/core/PluginManager";
-import BaseResult from "@jbrowse/core/TextSearch/BaseResults";
-import { UriLocation } from "@jbrowse/core/util";
-import { getFetcher } from "@jbrowse/core/util/io";
+import { readConfObject } from '@jbrowse/core/configuration'
+import {
+  BaseAdapter,
+  BaseArgs,
+  BaseTextSearchAdapter,
+} from '@jbrowse/core/data_adapters/BaseAdapter'
+import BaseResult from '@jbrowse/core/TextSearch/BaseResults'
+import { UriLocation } from '@jbrowse/core/util'
+import { getFetcher } from '@jbrowse/core/util/io'
 
-export class ApolloTextSearchAdapter extends BaseAdapter implements BaseTextSearchAdapter {
-    constructor(
-        config: AnyConfigurationModel,
-        getSubAdapter?: getSubAdapterType,
-        pluginManager?: PluginManager,
-    ) {
-        super(config, getSubAdapter, pluginManager)
+export class ApolloTextSearchAdapter
+  extends BaseAdapter
+  implements BaseTextSearchAdapter
+{
+  get baseURL() {
+    return readConfObject(this.config, 'baseURL').uri
+  }
+
+  get trackId() {
+    return readConfObject(this.config, 'trackId').uri
+  }
+
+  get internetAccountPreAuthorization():
+    | { authInfo: { token: string }; internetAccountType: string }
+    | undefined {
+    return readConfObject(this.config, 'baseURL')
+      .internetAccountPreAuthorization
+  }
+
+  async fetchFeatureByAttr(attrType: string, attr: string) {
+    const url = new URL(`features/${attrType}/${attr}`, this.baseURL)
+    const uri = url.toString()
+    const location: UriLocation = { locationType: 'UriLocation', uri }
+    if (this.internetAccountPreAuthorization) {
+      location.internetAccountPreAuthorization =
+        this.internetAccountPreAuthorization
+    }
+    const fetch = getFetcher(location, this.pluginManager)
+    return fetch(uri)
+      .then((res) => res.json())
+      .catch((err) => err)
+  }
+
+  mapBaseResult(
+    features: {
+      refSeq: any // eslint-disable-line @typescript-eslint/no-explicit-any
+      start: number
+      end: number
+    }[],
+    query: string,
+  ) {
+    return features.map(
+      (feature) =>
+        new BaseResult({
+          label: query,
+          displayString: query,
+          trackId: this.trackId,
+          locString: `${feature.refSeq?.name}:${feature.start}..${feature.end}`,
+        }),
+    )
+  }
+
+  searchIndex(args: BaseArgs): Promise<BaseResult[]> {
+    const query = args.queryString
+    const isId = query.startsWith('id:')
+    // portion of query after first occurance of ':'
+    const id = isId ? query.slice(query.indexOf(':') + 1) : null
+
+    if (isId && id) {
+      return this.fetchFeatureByAttr('id', id)
+        .then((features) => this.mapBaseResult(features, query))
+        .catch((err) => err)
     }
 
-    get baseURL(): string {
-        return readConfObject(this.config, 'baseURL').uri
-    }
+    return this.fetchFeatureByAttr('name', query)
+      .then((features) => this.mapBaseResult(features, query))
+      .catch((err) => err)
+  }
 
-    get trackId(): string {
-        return readConfObject(this.config, 'trackId').uri
-    }
-
-    get internetAccountPreAuthorization():
-        | { authInfo: { token: string }; internetAccountType: string }
-        | undefined {
-        return readConfObject(this.config, 'baseURL')
-            .internetAccountPreAuthorization
-    }
-
-    async fetchFeatureByAttr(attrType: string, attr: string) {
-        const url = new URL(`features/${attrType}/${attr}`, this.baseURL)
-        const uri = url.toString()
-        const location: UriLocation = { locationType: 'UriLocation', uri }
-        if (this.internetAccountPreAuthorization) {
-            location.internetAccountPreAuthorization =
-                this.internetAccountPreAuthorization
-        }
-        const fetch = getFetcher(location, this.pluginManager)
-        return fetch(uri)
-            .then(res => res.json())
-            .catch(err => err)
-    }
-
-    mapBaseResult(features: { refSeq: any; start: any; end: any; }[], query: string) {
-        return features.map((feature) => new BaseResult({
-            label: query,
-            displayString: query,
-            trackId: this.trackId,
-            locString: `${feature.refSeq?.name}:${feature.start}..${feature.end}`,
-        }))
-    }
-
-    searchIndex(args: BaseArgs): Promise<BaseResult[]> {
-        const query = args.queryString
-        const isId = query.startsWith('id:')
-        // portion of query after first occurance of ':' 
-        const id = isId ? query.slice(query.indexOf(':') + 1) : null;
-
-        if (isId && id) {
-            return this.fetchFeatureByAttr('id', id)
-                .then(features => this.mapBaseResult(features, query))
-                .catch(err => err)
-        }
-
-        return this.fetchFeatureByAttr('name', query)
-            .then(features => this.mapBaseResult(features, query))
-            .catch(err => err)
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    freeResources() {}
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  freeResources() {}
 }

--- a/packages/jbrowse-plugin-apollo/src/ApolloTextSearchAdapter/configSchema.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloTextSearchAdapter/configSchema.ts
@@ -22,6 +22,6 @@ export default ConfigurationSchema(
   },
   {
     explicitlyTyped: true,
-    explicitIdentifier: 'textSearchAdapterId'
+    explicitIdentifier: 'textSearchAdapterId',
   },
 )

--- a/packages/jbrowse-plugin-apollo/src/ApolloTextSearchAdapter/configSchema.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloTextSearchAdapter/configSchema.ts
@@ -1,0 +1,27 @@
+import { ConfigurationSchema } from '@jbrowse/core/configuration'
+
+export default ConfigurationSchema(
+  'ApolloTextSearchAdapter',
+  {
+    assemblyNames: {
+      type: 'stringArray',
+      defaultValue: [],
+      description: 'List of assemblies covered by text search adapter',
+    },
+    trackId: {
+      type: 'string',
+      defaultValue: '',
+    },
+    baseURL: {
+      type: 'fileLocation',
+      defaultValue: {
+        uri: '',
+        locationType: 'UriLocation',
+      },
+    },
+  },
+  {
+    explicitlyTyped: true,
+    explicitIdentifier: 'textSearchAdapterId'
+  },
+)

--- a/packages/jbrowse-plugin-apollo/src/ApolloTextSearchAdapter/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloTextSearchAdapter/index.ts
@@ -7,12 +7,12 @@ import configSchema from './configSchema'
 export function installApolloTextSearchAdapter(pluginManager: PluginManager) {
   pluginManager.addTextSearchAdapterType(
     () =>
-    new TextSearchAdapterType({
-      name: 'ApolloTextSearchAdapter',
-      displayName: 'Apollo text search adapter',
-      configSchema: configSchema,
-      AdapterClass: ApolloTextSearchAdapter,
-      description: 'Apollo Text Search adapter',
-    }),
+      new TextSearchAdapterType({
+        name: 'ApolloTextSearchAdapter',
+        displayName: 'Apollo text search adapter',
+        configSchema,
+        AdapterClass: ApolloTextSearchAdapter,
+        description: 'Apollo Text Search adapter',
+      }),
   )
 }

--- a/packages/jbrowse-plugin-apollo/src/ApolloTextSearchAdapter/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloTextSearchAdapter/index.ts
@@ -1,0 +1,18 @@
+import { TextSearchAdapterType } from '@jbrowse/core/pluggableElementTypes'
+import PluginManager from '@jbrowse/core/PluginManager'
+
+import { ApolloTextSearchAdapter } from './ApolloTextSearchAdapter'
+import configSchema from './configSchema'
+
+export function installApolloTextSearchAdapter(pluginManager: PluginManager) {
+  pluginManager.addTextSearchAdapterType(
+    () =>
+    new TextSearchAdapterType({
+      name: 'ApolloTextSearchAdapter',
+      displayName: 'Apollo text search adapter',
+      configSchema: configSchema,
+      AdapterClass: ApolloTextSearchAdapter,
+      description: 'Apollo Text Search adapter',
+    }),
+  )
+}

--- a/packages/jbrowse-plugin-apollo/src/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/index.ts
@@ -67,7 +67,7 @@ export default class ApolloPlugin extends Plugin {
   install(pluginManager: PluginManager) {
     installApolloSequenceAdapter(pluginManager)
     installApolloTextSearchAdapter(pluginManager)
-    
+
     pluginManager.addTrackType(() => {
       const configSchema = ConfigurationSchema(
         'ApolloTrack',

--- a/packages/jbrowse-plugin-apollo/src/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/index.ts
@@ -28,6 +28,7 @@ import {
   ReactComponent as ApolloSixFrameRendererReactComponent,
   configSchema as apolloSixFrameRendererConfigSchema,
 } from './ApolloSixFrameRenderer'
+import { installApolloTextSearchAdapter } from './ApolloTextSearchAdapter'
 import { ViewChangeLog } from './components'
 import { DownloadGFF3 } from './components/DownloadGFF3'
 import {
@@ -65,6 +66,8 @@ export default class ApolloPlugin extends Plugin {
 
   install(pluginManager: PluginManager) {
     installApolloSequenceAdapter(pluginManager)
+    installApolloTextSearchAdapter(pluginManager)
+    
     pluginManager.addTrackType(() => {
       const configSchema = ConfigurationSchema(
         'ApolloTrack',

--- a/packages/jbrowse-plugin-apollo/src/session.ts
+++ b/packages/jbrowse-plugin-apollo/src/session.ts
@@ -248,7 +248,7 @@ export function extendSession(
       apolloSetSelectedFeature(feature?: AnnotationFeatureI) {
         self.apolloSelectedFeature = feature
       },
-      addApolloTrackConfig(assembly: AssemblyModel, baseURL: any) {
+      addApolloTrackConfig(assembly: AssemblyModel, baseURL: string) {
         const trackId = `apollo_track_${assembly.name}`
         const hasTrack = Boolean(
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -266,10 +266,10 @@ export function extendSession(
               textSearchAdapter: {
                 type: 'ApolloTextSearchAdapter',
                 baseURL: { uri: baseURL, locationType: 'UriLocation' },
-                trackId: trackId,
+                trackId,
                 assemblyNames: [assembly.name],
                 textSearchAdapterId: 'apollo-search',
-              }
+              },
             },
             displays: [
               {

--- a/packages/jbrowse-plugin-apollo/src/session.ts
+++ b/packages/jbrowse-plugin-apollo/src/session.ts
@@ -248,7 +248,7 @@ export function extendSession(
       apolloSetSelectedFeature(feature?: AnnotationFeatureI) {
         self.apolloSelectedFeature = feature
       },
-      addApolloTrackConfig(assembly: AssemblyModel) {
+      addApolloTrackConfig(assembly: AssemblyModel, baseURL: any) {
         const trackId = `apollo_track_${assembly.name}`
         const hasTrack = Boolean(
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -262,6 +262,15 @@ export function extendSession(
               getConf(assembly, 'displayName') || assembly.name
             })`,
             assemblyNames: [assembly.name],
+            textSearching: {
+              textSearchAdapter: {
+                type: 'ApolloTextSearchAdapter',
+                baseURL: { uri: baseURL, locationType: 'UriLocation' },
+                trackId: trackId,
+                assemblyNames: [assembly.name],
+                textSearchAdapterId: 'apollo-search',
+              }
+            },
             displays: [
               {
                 type: 'LinearApolloDisplay',
@@ -415,7 +424,7 @@ export function extendSession(
             const { assemblyManager } = self
             const selectedAssembly = assemblyManager.get(assembly.name)
             if (selectedAssembly) {
-              self.addApolloTrackConfig(selectedAssembly)
+              self.addApolloTrackConfig(selectedAssembly, baseURL)
               continue
             }
             const url = new URL('refSeqs', baseURL)
@@ -479,7 +488,7 @@ export function extendSession(
             }
             ;(self.addSessionAssembly || self.addAssembly)(assemblyConfig)
             const a = yield assemblyManager.waitForAssembly(assemblyConfig.name)
-            self.addApolloTrackConfig(a)
+            self.addApolloTrackConfig(a, baseURL)
           }
 
           // GO stuff starts here


### PR DESCRIPTION
Find feature by name and id functionality

  **Search usage:**
- Enter the feature name to find the feature (no prefix needed for name)
  ex: murB (case insensitive)
<img width="821" alt="image" src="https://github.com/GMOD/Apollo3/assets/13611226/904de726-1a35-4a30-9990-65dbc4d36c5d">

- To find a feature by its id we need to prefix query with id:
  ex: id:bc2017--bc2017_01552 (case insensitive)
  id:gene:ENSG00000278181
<img width="746" alt="image" src="https://github.com/GMOD/Apollo3/assets/13611226/1e59fcb6-6c38-4e3a-9b35-1e739e545047">

**Docker images:**
shashankbrgowda/apollo-collaboration-server-alpha:latest
shashankbrgowda/jbrowse-plugin-apollo-alpha:latest
shashankbrgowda/jbrowse-web-apollo:v2.5.0


