### PR TITLE
don't reload feature data from session snapshot

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/session/ClientDataStore.ts
+++ b/packages/jbrowse-plugin-apollo/src/session/ClientDataStore.ts
@@ -11,6 +11,7 @@ import {
 } from 'apollo-mst'
 import {
   Instance,
+  SnapshotIn,
   flow,
   getParentOfType,
   getRoot,
@@ -35,7 +36,7 @@ import { ApolloRootModel } from '../types'
 export function clientDataStoreFactory(
   AnnotationFeatureExtended: typeof AnnotationFeature,
 ) {
-  return types
+  const clientStoreType = types
     .model('ClientDataStore', {
       typeName: types.optional(types.literal('Client'), 'Client'),
       assemblies: types.map(ApolloAssembly),
@@ -236,4 +237,12 @@ export function clientDataStoreFactory(
         }
       }),
     }))
+
+  // assembly and feature data isn't actually reloaded on reload unless we delete it from the snap
+  return types.snapshotProcessor(clientStoreType, {
+    preProcessor(snap: SnapshotIn<typeof clientStoreType>) {
+      delete snap.assemblies
+      return snap
+    },
+  })
 }

--- a/packages/jbrowse-plugin-apollo/src/session/ClientDataStore.ts
+++ b/packages/jbrowse-plugin-apollo/src/session/ClientDataStore.ts
@@ -12,6 +12,7 @@ import {
 import {
   Instance,
   SnapshotIn,
+  SnapshotOut,
   flow,
   getParentOfType,
   getRoot,
@@ -241,8 +242,10 @@ export function clientDataStoreFactory(
   // assembly and feature data isn't actually reloaded on reload unless we delete it from the snap
   return types.snapshotProcessor(clientStoreType, {
     preProcessor(snap: SnapshotIn<typeof clientStoreType>) {
-      delete snap.assemblies
-      return snap
+      return { ...snap, assemblies: {} }
+    },
+    postProcessor(snap: SnapshotOut<typeof clientStoreType>) {
+      return { ...snap, assemblies: {} }
     },
   })
 }


### PR DESCRIPTION
While working just now I discovered that the assemblies and feature data are being preserved in the session snapshots.

This isn't what we want for obvious reasons.