### PR TITLE
Implement search-by-feature

### DIFF
--- a/packages/apollo-collaboration-server/src/features/features.controller.ts
+++ b/packages/apollo-collaboration-server/src/features/features.controller.ts
@@ -61,6 +61,17 @@ export class FeaturesController {
   }
 
   /**
+   * Search database for queries
+   * For testing try to go to:
+   * http://localhost:3999/features/searchFeatures?term=exonerate
+   */
+  @Public()
+  @Get('searchFeatures')
+  async searchFeatures(@Query() request: { term: string }) {
+    return this.featuresService.searchFeatures(request)
+  }
+
+  /**
    * Get and ID to be used with exportGFF3. ID will be valid for 5 minutes.
    * @param request -
    * @returns The ID of an export that will be valid for 5 minutes

--- a/packages/apollo-collaboration-server/src/features/features.service.ts
+++ b/packages/apollo-collaboration-server/src/features/features.service.ts
@@ -303,7 +303,7 @@ export class FeaturesService {
       end: searchDto.end,
     })
   }
-  
+
   async searchFeatures(searchDto: { term: string }) {
     return this.featureModel
       .find({ $text: { $search: searchDto.term } })

--- a/packages/apollo-collaboration-server/src/features/features.service.ts
+++ b/packages/apollo-collaboration-server/src/features/features.service.ts
@@ -303,4 +303,11 @@ export class FeaturesService {
       end: searchDto.end,
     })
   }
+  
+  async searchFeatures(searchDto: { term: string }) {
+    return this.featureModel
+      .find({ $text: { $search: searchDto.term } })
+      .populate('refSeq')
+      .exec()
+  }
 }

--- a/packages/apollo-schemas/src/feature.schema.ts
+++ b/packages/apollo-schemas/src/feature.schema.ts
@@ -66,3 +66,4 @@ FeatureSchema.add({ children: { type: Map, of: FeatureSchema } })
 
 FeatureSchema.index({ refSeq: 1, start: 1 })
 FeatureSchema.index({ refSeq: 1, end: 1 })
+FeatureSchema.index({ '$**': 'text' })

--- a/packages/jbrowse-plugin-apollo/src/ApolloTextSearchAdapter/ApolloTextSearchAdapter.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloTextSearchAdapter/ApolloTextSearchAdapter.ts
@@ -1,0 +1,95 @@
+import { readConfObject } from '@jbrowse/core/configuration'
+import {
+  BaseAdapter,
+  BaseTextSearchAdapter,
+  BaseTextSearchArgs,
+} from '@jbrowse/core/data_adapters/BaseAdapter'
+import BaseResult from '@jbrowse/core/TextSearch/BaseResults'
+import { UriLocation } from '@jbrowse/core/util'
+import { getFetcher } from '@jbrowse/core/util/io'
+
+export class ApolloTextSearchAdapter
+  extends BaseAdapter
+  implements BaseTextSearchAdapter
+{
+  get baseURL() {
+    return readConfObject(this.config, 'baseURL').uri
+  }
+
+  get trackId() {
+    return readConfObject(this.config, 'trackId').uri
+  }
+
+  get internetAccountPreAuthorization():
+    | { authInfo: { token: string }; internetAccountType: string }
+    | undefined {
+    return readConfObject(this.config, 'baseURL')
+      .internetAccountPreAuthorization
+  }
+
+  async searchFeatures(term: string) {
+    const url = new URL(`features/searchFeatures?term=${term}`, this.baseURL)
+    const uri = url.toString()
+    const location: UriLocation = { locationType: 'UriLocation', uri }
+    if (this.internetAccountPreAuthorization) {
+      location.internetAccountPreAuthorization =
+        this.internetAccountPreAuthorization
+    }
+    const fetch = getFetcher(location, this.pluginManager)
+    return fetch(uri)
+      .then((res) => res.json())
+      .catch((err) => err)
+  }
+
+  // async fetchFeatureByAttr(attrType: string, attr: string) {
+  //   const url = new URL(`features/${attrType}/${attr}`, this.baseURL)
+  //   const uri = url.toString()
+  //   const location: UriLocation = { locationType: 'UriLocation', uri }
+  //   if (this.internetAccountPreAuthorization) {
+  //     location.internetAccountPreAuthorization =
+  //       this.internetAccountPreAuthorization
+  //   }
+  //   const fetch = getFetcher(location, this.pluginManager)
+  //   return fetch(uri)
+  //     .then((res) => res.json())
+  //     .catch((err) => err)
+  // }
+
+  mapBaseResult(
+    features: {
+      refSeq: any // eslint-disable-line @typescript-eslint/no-explicit-any
+      start: number
+      end: number
+    }[],
+    query: string,
+  ) {
+    return features.map(
+      (feature) =>
+        new BaseResult({
+          label: query,
+          displayString: query,
+          trackId: this.trackId,
+          locString: `${feature.refSeq?.name}:${feature.start}..${feature.end}`,
+        }),
+    )
+  }
+
+  searchIndex(args: BaseTextSearchArgs): Promise<BaseResult[]> {
+    const query = args.queryString
+    // const isId = query.startsWith('id:')
+    // // portion of query after first occurance of ':'
+    // const id = isId ? query.slice(query.indexOf(':') + 1) : null
+
+    // if (isId && id) {
+    //   return this.fetchFeatureByAttr('id', id)
+    //     .then((features) => this.mapBaseResult(features, query))
+    //     .catch((err) => err)
+    // }
+    return this.searchFeatures(query)
+      .then((features) => this.mapBaseResult(features, query))
+      .catch((err) => err)
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  freeResources() {}
+}

--- a/packages/jbrowse-plugin-apollo/src/ApolloTextSearchAdapter/ApolloTextSearchAdapter.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloTextSearchAdapter/ApolloTextSearchAdapter.ts
@@ -41,20 +41,6 @@ export class ApolloTextSearchAdapter
       .catch((err) => err)
   }
 
-  // async fetchFeatureByAttr(attrType: string, attr: string) {
-  //   const url = new URL(`features/${attrType}/${attr}`, this.baseURL)
-  //   const uri = url.toString()
-  //   const location: UriLocation = { locationType: 'UriLocation', uri }
-  //   if (this.internetAccountPreAuthorization) {
-  //     location.internetAccountPreAuthorization =
-  //       this.internetAccountPreAuthorization
-  //   }
-  //   const fetch = getFetcher(location, this.pluginManager)
-  //   return fetch(uri)
-  //     .then((res) => res.json())
-  //     .catch((err) => err)
-  // }
-
   mapBaseResult(
     features: {
       refSeq: any // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -76,15 +62,6 @@ export class ApolloTextSearchAdapter
 
   searchIndex(args: BaseTextSearchArgs): Promise<BaseResult[]> {
     const query = args.queryString
-    // const isId = query.startsWith('id:')
-    // // portion of query after first occurance of ':'
-    // const id = isId ? query.slice(query.indexOf(':') + 1) : null
-
-    // if (isId && id) {
-    //   return this.fetchFeatureByAttr('id', id)
-    //     .then((features) => this.mapBaseResult(features, query))
-    //     .catch((err) => err)
-    // }
     return this.searchFeatures(query)
       .then((features) => this.mapBaseResult(features, query))
       .catch((err) => err)

--- a/packages/jbrowse-plugin-apollo/src/ApolloTextSearchAdapter/configSchema.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloTextSearchAdapter/configSchema.ts
@@ -1,0 +1,27 @@
+import { ConfigurationSchema } from '@jbrowse/core/configuration'
+
+export default ConfigurationSchema(
+  'ApolloTextSearchAdapter',
+  {
+    assemblyNames: {
+      type: 'stringArray',
+      defaultValue: [],
+      description: 'List of assemblies covered by text search adapter',
+    },
+    trackId: {
+      type: 'string',
+      defaultValue: '',
+    },
+    baseURL: {
+      type: 'fileLocation',
+      defaultValue: {
+        uri: '',
+        locationType: 'UriLocation',
+      },
+    },
+  },
+  {
+    explicitlyTyped: true,
+    explicitIdentifier: 'textSearchAdapterId',
+  },
+)

--- a/packages/jbrowse-plugin-apollo/src/ApolloTextSearchAdapter/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloTextSearchAdapter/index.ts
@@ -1,0 +1,18 @@
+import { TextSearchAdapterType } from '@jbrowse/core/pluggableElementTypes'
+import PluginManager from '@jbrowse/core/PluginManager'
+
+import { ApolloTextSearchAdapter } from './ApolloTextSearchAdapter'
+import configSchema from './configSchema'
+
+export function installApolloTextSearchAdapter(pluginManager: PluginManager) {
+  pluginManager.addTextSearchAdapterType(
+    () =>
+      new TextSearchAdapterType({
+        name: 'ApolloTextSearchAdapter',
+        displayName: 'Apollo text search adapter',
+        configSchema,
+        AdapterClass: ApolloTextSearchAdapter,
+        description: 'Apollo Text Search adapter',
+      }),
+  )
+}

--- a/packages/jbrowse-plugin-apollo/src/components/ImportFeatures.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/ImportFeatures.tsx
@@ -255,14 +255,13 @@ export function ImportFeatures({
             {submitted ? 'Submitting...' : 'Submit'}
           </Button>
           <Button
-            disabled={submitted}
             variant="outlined"
             type="submit"
             onClick={() => {
               handleClose()
             }}
           >
-            Cancel
+            Close
           </Button>
         </DialogActions>
       </form>

--- a/packages/jbrowse-plugin-apollo/src/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/index.ts
@@ -28,6 +28,7 @@ import {
   ReactComponent as ApolloSixFrameRendererReactComponent,
   configSchema as apolloSixFrameRendererConfigSchema,
 } from './ApolloSixFrameRenderer'
+import { installApolloTextSearchAdapter } from './ApolloTextSearchAdapter'
 import { DownloadGFF3, OpenLocalFile, ViewChangeLog } from './components'
 import ApolloPluginConfigurationSchema from './config'
 import {
@@ -58,6 +59,7 @@ export default class ApolloPlugin extends Plugin {
 
   install(pluginManager: PluginManager) {
     installApolloSequenceAdapter(pluginManager)
+    installApolloTextSearchAdapter(pluginManager)
     pluginManager.addTrackType(() => {
       const configSchema = ConfigurationSchema(
         'ApolloTrack',

--- a/packages/jbrowse-plugin-apollo/src/session/session.ts
+++ b/packages/jbrowse-plugin-apollo/src/session/session.ts
@@ -98,7 +98,7 @@ export function extendSession(
       apolloSetSelectedFeature(feature?: AnnotationFeatureI) {
         self.apolloSelectedFeature = feature
       },
-      addApolloTrackConfig(assembly: AssemblyModel) {
+      addApolloTrackConfig(assembly: AssemblyModel, baseURL: string) {
         const trackId = `apollo_track_${assembly.name}`
         const hasTrack = Boolean(
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -113,6 +113,15 @@ export function extendSession(
               getConf(assembly, 'displayName') || assembly.name
             })`,
             assemblyNames: [assembly.name],
+            textSearching: {
+              textSearchAdapter: {
+                type: 'ApolloTextSearchAdapter',
+                baseURL: { uri: baseURL, locationType: 'UriLocation' },
+                trackId,
+                assemblyNames: [assembly.name],
+                textSearchAdapterId: 'apollo-search',
+              },
+            },
             displays: [
               {
                 type: 'LinearApolloDisplay',
@@ -277,7 +286,7 @@ export function extendSession(
             const { assemblyManager } = self
             const selectedAssembly = assemblyManager.get(assembly.name)
             if (selectedAssembly) {
-              self.addApolloTrackConfig(selectedAssembly)
+              self.addApolloTrackConfig(selectedAssembly, baseURL)
               continue
             }
             const url = new URL('refSeqs', baseURL)
@@ -342,7 +351,7 @@ export function extendSession(
             }
             ;(self.addSessionAssembly || self.addAssembly)(assemblyConfig)
             const a = yield assemblyManager.waitForAssembly(assemblyConfig.name)
-            self.addApolloTrackConfig(a)
+            self.addApolloTrackConfig(a, baseURL)
           }
         }
       }),


### PR DESCRIPTION
Searches the mongodb *features* collection for matches to a query. A couple of notes:

* This searches all (and only) the documents in the *features* collection. This means that if the loaded assembly(s) do not contain the query but another assembly contains it, you still get hits from the search.

* If a query returns multiple features, the order of the hits in the selection box is in seemingly random order. E.g.:

![image](https://github.com/GMOD/Apollo3/assets/6883382/5a89f07c-a4dd-4877-83bd-bf55cb7ac909)
