### PR TITLE
Add coverage information to PRs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,3 +25,7 @@ jobs:
         run: yarn eslint --report-unused-disable-directives --max-warnings 0 --ext .js,.ts,.jsx,.tsx .
       - name: Test codebase
         run: yarn test
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+comment: false
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start:server": "yarn workspace apollo-collaboration-server run start",
     "start:plugin": "yarn workspace jbrowse-plugin-apollo run start",
     "start": "npm-run-all --print-label --parallel start:shared start:server start:plugin",
-    "test": "yarn workspace jbrowse-plugin-apollo run test"
+    "test": "yarn workspace jbrowse-plugin-apollo run test:ci"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.1.0",

--- a/packages/jbrowse-plugin-apollo/jest.config.js
+++ b/packages/jbrowse-plugin-apollo/jest.config.js
@@ -5,4 +5,5 @@ module.exports = {
   testPathIgnorePatterns: ['<rootDir>/cypress/'],
   automock: false,
   setupFiles: ['./jestSetup.js', 'fake-indexeddb/auto'],
+  collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}'],
 }

--- a/packages/jbrowse-plugin-apollo/package.json
+++ b/packages/jbrowse-plugin-apollo/package.json
@@ -36,6 +36,7 @@
     "build": "yarn build:shared && yarn clean && rollup --config",
     "browse": "serve --listen 8999 .jbrowse",
     "test": "jest",
+    "test:ci": "jest --coverage",
     "test:e2e": "start-test \"npm-run-all --parallel start browse\" \"9000|8999\" \"npm-run-all cypress:run\"",
     "cypress:run": "cypress run --browser chrome --config baseUrl=http://localhost:8999",
     "cypress:open": "cypress open --config baseUrl=http://localhost:8999",


### PR DESCRIPTION
Adds a Codecov report to PRs. Informational only for now, so it won't fail the PR's checks.