### PR TITLE
Fix text search of features does not handle spaces in attribute values

### DIFF
--- a/packages/apollo-collaboration-server/src/features/features.service.ts
+++ b/packages/apollo-collaboration-server/src/features/features.service.ts
@@ -311,7 +311,7 @@ export class FeaturesService {
       .find({ assembly: assemblyIds })
       .exec()
     return this.featureModel
-      .find({ $text: { $search: term }, refSeq: refSeqs })
+      .find({ $text: { $search: `"${term}"` }, refSeq: refSeqs })
       .populate('refSeq')
       .exec()
   }


### PR DESCRIPTION
Enclosing search term in quotes seems to fix the issue. 

Fixes #262