### PR TITLE
Fix types after JBrowse 2.7.0 update

### DIFF
--- a/.husky/_/.gitignore
+++ b/.husky/_/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/packages/apollo-collaboration-server/package.json
+++ b/packages/apollo-collaboration-server/package.json
@@ -28,7 +28,7 @@
     "@emotion/styled": "^11.10.6",
     "@gmod/gff": "^1.2.0",
     "@gmod/indexedfasta": "^2.0.4",
-    "@jbrowse/core": "2.6.3",
+    "@jbrowse/core": "^2.7.0",
     "@mui/base": "^5.0.0-alpha.118",
     "@mui/material": "^5.11.10",
     "@nestjs/common": "^10.1.0",

--- a/packages/apollo-common/package.json
+++ b/packages/apollo-common/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@gmod/gff": "^1.2.0",
-    "@jbrowse/core": "2.6.3",
+    "@jbrowse/core": "^2.7.0",
     "apollo-schemas": "workspace:^",
     "bson-objectid": "^2.0.4",
     "tslib": "^2.3.1"

--- a/packages/apollo-mst/package.json
+++ b/packages/apollo-mst/package.json
@@ -6,7 +6,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@jbrowse/core": "2.6.3",
+    "@jbrowse/core": "^2.7.0",
     "mobx": "^6.6.1",
     "mobx-state-tree": "^5.1.7",
     "rxjs": "^7.4.0",

--- a/packages/apollo-shared/package.json
+++ b/packages/apollo-shared/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@gmod/gff": "^1.2.0",
     "@gmod/indexedfasta": "^2.0.4",
-    "@jbrowse/core": "2.6.3",
+    "@jbrowse/core": "^2.7.0",
     "apollo-common": "workspace:^",
     "apollo-mst": "workspace:^",
     "apollo-schemas": "workspace:^",

--- a/packages/jbrowse-plugin-apollo/package.json
+++ b/packages/jbrowse-plugin-apollo/package.json
@@ -75,7 +75,7 @@
     "tslib": "^2.3.1"
   },
   "peerDependencies": {
-    "@jbrowse/core": "2.6.3",
+    "@jbrowse/core": "^2.7.0",
     "@mui/material": "^5.11.10",
     "mobx": "^6.6.1",
     "mobx-react": "^7.2.1",
@@ -88,7 +88,7 @@
   },
   "devDependencies": {
     "@jbrowse/cli": "^2.6.2",
-    "@jbrowse/core": "2.6.3",
+    "@jbrowse/core": "^2.7.0",
     "@jbrowse/development-tools": "^2.1.1",
     "@jest/globals": "^29.0.3",
     "@mui/material": "^5.11.10",

--- a/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
@@ -104,7 +104,7 @@ const stateModelFactory = (
           const { role } = dec
           if (!role && !roleNotificationSent) {
             const { session } = getRoot<ApolloRootModel>(self)
-            session.notify(
+            ;(session as unknown as AbstractSessionModel).notify(
               'You have registered as a user but have not been given access. Ask your administrator to enable access for your account.',
               'warning',
             )
@@ -145,7 +145,7 @@ const stateModelFactory = (
       },
       addSocketListeners() {
         const { session } = getRoot<ApolloRootModel>(self)
-        const { notify } = session
+        const { notify } = session as unknown as AbstractSessionModel
         const token = self.retrieveToken()
         if (!token) {
           throw new Error('No Token found')
@@ -160,7 +160,7 @@ const stateModelFactory = (
             return // we did this change, no need to apply it again
           }
           const change = Change.fromJSON(message.changeInfo)
-          changeManager?.submit(change, { submitToBackend: false })
+          void changeManager?.submit(change, { submitToBackend: false })
         })
         socket.on('reconnect', async () => {
           notify('You are re-connected to the Apollo server.', 'success')
@@ -252,7 +252,7 @@ const stateModelFactory = (
         const serializedChanges = yield response.json()
         for (const serializedChange of serializedChanges) {
           const change = Change.fromJSON(serializedChange)
-          changeManager?.submit(change, { submitToBackend: false })
+          void changeManager?.submit(change, { submitToBackend: false })
         }
       }),
     }))
@@ -317,18 +317,19 @@ const stateModelFactory = (
             'Apollo',
             {
               label: 'Add Assembly',
-              onClick: (session: AbstractSessionModel) => {
-                session.queueDialog((doneCallback) => [
-                  AddAssembly,
-                  {
-                    session,
-                    handleClose: () => {
-                      doneCallback()
+              onClick: (session: ApolloSessionModel) => {
+                ;(session as unknown as AbstractSessionModel).queueDialog(
+                  (doneCallback) => [
+                    AddAssembly,
+                    {
+                      session,
+                      handleClose: () => {
+                        doneCallback()
+                      },
+                      changeManager: session.apolloDataStore.changeManager,
                     },
-                    changeManager: (session as ApolloSessionModel)
-                      .apolloDataStore.changeManager,
-                  },
-                ])
+                  ],
+                )
               },
             },
             0,
@@ -337,18 +338,19 @@ const stateModelFactory = (
             'Apollo',
             {
               label: 'Delete Assembly',
-              onClick: (session: AbstractSessionModel) => {
-                session.queueDialog((doneCallback) => [
-                  DeleteAssembly,
-                  {
-                    session,
-                    handleClose: () => {
-                      doneCallback()
+              onClick: (session: ApolloSessionModel) => {
+                ;(session as unknown as AbstractSessionModel).queueDialog(
+                  (doneCallback) => [
+                    DeleteAssembly,
+                    {
+                      session,
+                      handleClose: () => {
+                        doneCallback()
+                      },
+                      changeManager: session.apolloDataStore.changeManager,
                     },
-                    changeManager: (session as ApolloSessionModel)
-                      .apolloDataStore.changeManager,
-                  },
-                ])
+                  ],
+                )
               },
             },
             1,
@@ -357,18 +359,20 @@ const stateModelFactory = (
             'Apollo',
             {
               label: 'Import Features',
-              onClick: (session: AbstractSessionModel) => {
-                session.queueDialog((doneCallback) => [
-                  ImportFeatures,
-                  {
-                    session,
-                    handleClose: () => {
-                      doneCallback()
+              onClick: (session: ApolloSessionModel) => {
+                ;(session as unknown as AbstractSessionModel).queueDialog(
+                  (doneCallback) => [
+                    ImportFeatures,
+                    {
+                      session,
+                      handleClose: () => {
+                        doneCallback()
+                      },
+                      changeManager: (session as ApolloSessionModel)
+                        .apolloDataStore.changeManager,
                     },
-                    changeManager: (session as ApolloSessionModel)
-                      .apolloDataStore.changeManager,
-                  },
-                ])
+                  ],
+                )
               },
             },
             2,
@@ -377,18 +381,20 @@ const stateModelFactory = (
             'Apollo',
             {
               label: 'Manage Users',
-              onClick: (session: AbstractSessionModel) => {
-                session.queueDialog((doneCallback) => [
-                  ManageUsers,
-                  {
-                    session,
-                    handleClose: () => {
-                      doneCallback()
+              onClick: (session: ApolloSessionModel) => {
+                ;(session as unknown as AbstractSessionModel).queueDialog(
+                  (doneCallback) => [
+                    ManageUsers,
+                    {
+                      session,
+                      handleClose: () => {
+                        doneCallback()
+                      },
+                      changeManager: (session as ApolloSessionModel)
+                        .apolloDataStore.changeManager,
                     },
-                    changeManager: (session as ApolloSessionModel)
-                      .apolloDataStore.changeManager,
-                  },
-                ])
+                  ],
+                )
               },
             },
             9,
@@ -398,9 +404,10 @@ const stateModelFactory = (
             {
               label: 'Undo',
               onClick: (session: ApolloSessionModel) => {
-                const { apolloDataStore, notify } = session
+                const { apolloDataStore } = session
+                const { notify } = session as unknown as AbstractSessionModel
                 if (apolloDataStore.changeManager.recentChanges.length > 0) {
-                  apolloDataStore.changeManager.revertLastChange()
+                  void apolloDataStore.changeManager.revertLastChange()
                 } else {
                   notify('No changes to undo', 'info')
                 }
@@ -612,26 +619,28 @@ const stateModelFactory = (
                   authTypePromise = new Promise((resolve, reject) => {
                     const { session } = getRoot<ApolloRootModel>(self)
                     const { allowGuestUser, baseURL, name } = self
-                    session.queueDialog((doneCallback: () => void) => [
-                      AuthTypeSelector,
-                      {
-                        baseURL,
-                        name,
-                        handleClose: (newAuthType?: AuthType | Error) => {
-                          if (!newAuthType) {
-                            reject(new Error('user cancelled entry'))
-                          } else if (newAuthType instanceof Error) {
-                            reject(newAuthType)
-                          } else {
-                            resolve(newAuthType)
-                          }
-                          doneCallback()
+                    ;(session as unknown as AbstractSessionModel).queueDialog(
+                      (doneCallback: () => void) => [
+                        AuthTypeSelector,
+                        {
+                          baseURL,
+                          name,
+                          handleClose: (newAuthType?: AuthType | Error) => {
+                            if (!newAuthType) {
+                              reject(new Error('user cancelled entry'))
+                            } else if (newAuthType instanceof Error) {
+                              reject(newAuthType)
+                            } else {
+                              resolve(newAuthType)
+                            }
+                            doneCallback()
+                          },
+                          google: Boolean(googleClientId),
+                          microsoft: Boolean(microsoftClientId),
+                          allowGuestUser,
                         },
-                        google: Boolean(googleClientId),
-                        microsoft: Boolean(microsoftClientId),
-                        allowGuestUser,
-                      },
-                    ])
+                      ],
+                    )
                   })
                 }
               }

--- a/packages/jbrowse-plugin-apollo/src/ApolloSixFrameRenderer/components/ApolloRendering.tsx
+++ b/packages/jbrowse-plugin-apollo/src/ApolloSixFrameRenderer/components/ApolloRendering.tsx
@@ -1,5 +1,5 @@
 import { getConf } from '@jbrowse/core/configuration'
-import { AppRootModel, Region, getSession } from '@jbrowse/core/util'
+import { AbstractSessionModel, Region, getSession } from '@jbrowse/core/util'
 import { Menu, MenuItem } from '@mui/material'
 import { AnnotationFeatureI } from 'apollo-mst'
 import { LocationEndChange, LocationStartChange } from 'apollo-shared'
@@ -14,6 +14,7 @@ import { CopyFeature } from '../../components/CopyFeature'
 import { DeleteFeature } from '../../components/DeleteFeature'
 import { Collaborator } from '../../session'
 import { SixFrameFeatureDisplay } from '../../SixFrameFeatureDisplay/stateModel'
+import { ApolloRootModel } from '../../types'
 
 interface ApolloRenderingProps {
   assemblyName: string
@@ -85,7 +86,7 @@ function ApolloRendering(props: ApolloRenderingProps) {
   const [collaborators, setCollaborators] = useState<Collaborator[]>([])
 
   const { bpPerPx, displayModel, regions } = props
-  const session = getSession(displayModel)
+  const { session } = displayModel
   const { collaborators: collabs } = session
 
   // bridging mobx observability and React useEffect observability
@@ -120,7 +121,7 @@ function ApolloRendering(props: ApolloRenderingProps) {
   )
 
   const apolloInternetAccount = useMemo(() => {
-    const { internetAccounts } = getRoot(session) as AppRootModel
+    const { internetAccounts } = getRoot<ApolloRootModel>(session)
     const { assemblyName } = region
     const { assemblyManager } = getSession(displayModel)
     const assembly = assemblyManager.get(assemblyName)
@@ -574,21 +575,23 @@ function ApolloRendering(props: ApolloRenderingProps) {
               return
             }
             const currentAssemblyId = getAssemblyId(region.assemblyName)
-            session.queueDialog((doneCallback) => [
-              AddFeature,
-              {
-                session,
-                handleClose: () => {
-                  doneCallback()
-                  // eslint-disable-next-line unicorn/no-useless-undefined
-                  setContextMenuFeature(undefined)
+            ;(session as unknown as AbstractSessionModel).queueDialog(
+              (doneCallback) => [
+                AddFeature,
+                {
+                  session,
+                  handleClose: () => {
+                    doneCallback()
+                    // eslint-disable-next-line unicorn/no-useless-undefined
+                    setContextMenuFeature(undefined)
+                  },
+                  changeManager,
+                  sourceFeature: contextMenuFeature,
+                  sourceAssemblyId: currentAssemblyId,
+                  internetAccount: apolloInternetAccount,
                 },
-                changeManager,
-                sourceFeature: contextMenuFeature,
-                sourceAssemblyId: currentAssemblyId,
-                internetAccount: apolloInternetAccount,
-              },
-            ])
+              ],
+            )
           }}
         >
           Add child feature
@@ -602,20 +605,22 @@ function ApolloRendering(props: ApolloRenderingProps) {
               return
             }
             const currentAssemblyId = getAssemblyId(region.assemblyName)
-            session.queueDialog((doneCallback) => [
-              CopyFeature,
-              {
-                session,
-                handleClose: () => {
-                  doneCallback()
-                  // eslint-disable-next-line unicorn/no-useless-undefined
-                  setContextMenuFeature(undefined)
+            ;(session as unknown as AbstractSessionModel).queueDialog(
+              (doneCallback) => [
+                CopyFeature,
+                {
+                  session,
+                  handleClose: () => {
+                    doneCallback()
+                    // eslint-disable-next-line unicorn/no-useless-undefined
+                    setContextMenuFeature(undefined)
+                  },
+                  changeManager,
+                  sourceFeature: contextMenuFeature,
+                  sourceAssemblyId: currentAssemblyId,
                 },
-                changeManager,
-                sourceFeature: contextMenuFeature,
-                sourceAssemblyId: currentAssemblyId,
-              },
-            ])
+              ],
+            )
           }}
         >
           Copy features and annotations
@@ -629,22 +634,24 @@ function ApolloRendering(props: ApolloRenderingProps) {
               return
             }
             const currentAssemblyId = getAssemblyId(region.assemblyName)
-            session.queueDialog((doneCallback) => [
-              DeleteFeature,
-              {
-                session,
-                handleClose: () => {
-                  doneCallback()
-                  // eslint-disable-next-line unicorn/no-useless-undefined
-                  setContextMenuFeature(undefined)
+            ;(session as unknown as AbstractSessionModel).queueDialog(
+              (doneCallback) => [
+                DeleteFeature,
+                {
+                  session,
+                  handleClose: () => {
+                    doneCallback()
+                    // eslint-disable-next-line unicorn/no-useless-undefined
+                    setContextMenuFeature(undefined)
+                  },
+                  changeManager,
+                  sourceFeature: contextMenuFeature,
+                  sourceAssemblyId: currentAssemblyId,
+                  selectedFeature,
+                  setSelectedFeature,
                 },
-                changeManager,
-                sourceFeature: contextMenuFeature,
-                sourceAssemblyId: currentAssemblyId,
-                selectedFeature,
-                setSelectedFeature,
-              },
-            ])
+              ],
+            )
           }}
         >
           Delete feature

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
@@ -2,6 +2,7 @@ import { alpha } from '@mui/material'
 import { AnnotationFeatureI } from 'apollo-mst'
 import { LocationEndChange, LocationStartChange } from 'apollo-shared'
 
+import { ApolloSessionModel } from '../../session'
 import { LinearApolloDisplay } from '../stateModel'
 import { MousePosition } from '../stateModel/mouseEvents'
 import { CanvasMouseEvent } from '../types'
@@ -22,7 +23,7 @@ export class BoxGlyph extends Glyph {
   ) {
     const { apolloRowHeight: rowHeight, lgv, session, theme } = stateModel
     const { bpPerPx } = lgv
-    const { apolloSelectedFeature } = session
+    const { apolloSelectedFeature } = session as unknown as ApolloSessionModel
     const offsetPx = (feature.start - feature.min) / bpPerPx
     const widthPx = feature.length / bpPerPx
     const startPx = reversed ? xOffset - offsetPx - widthPx : xOffset + offsetPx
@@ -277,7 +278,7 @@ export class BoxGlyph extends Glyph {
     if (!changeManager) {
       throw new Error('no change manager')
     }
-    changeManager.submit(change)
+    void changeManager.submit(change)
     setCursor()
   }
 }

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
@@ -1,4 +1,5 @@
 import { MenuItem } from '@jbrowse/core/ui'
+import { AbstractSessionModel } from '@jbrowse/core/util'
 import { alpha } from '@mui/material'
 import { AnnotationFeatureI } from 'apollo-mst'
 
@@ -218,75 +219,83 @@ export abstract class Glyph {
           label: 'Add child feature',
           disabled: readOnly,
           onClick: () => {
-            session.queueDialog((doneCallback) => [
-              AddFeature,
-              {
-                session,
-                handleClose: () => {
-                  doneCallback()
+            ;(session as unknown as AbstractSessionModel).queueDialog(
+              (doneCallback) => [
+                AddFeature,
+                {
+                  session,
+                  handleClose: () => {
+                    doneCallback()
+                  },
+                  changeManager,
+                  sourceFeature,
+                  sourceAssemblyId,
+                  internetAccount,
                 },
-                changeManager,
-                sourceFeature,
-                sourceAssemblyId,
-                internetAccount,
-              },
-            ])
+              ],
+            )
           },
         },
         {
           label: 'Copy features and annotations',
           disabled: readOnly,
           onClick: () => {
-            session.queueDialog((doneCallback) => [
-              CopyFeature,
-              {
-                session,
-                handleClose: () => {
-                  doneCallback()
+            ;(session as unknown as AbstractSessionModel).queueDialog(
+              (doneCallback) => [
+                CopyFeature,
+                {
+                  session,
+                  handleClose: () => {
+                    doneCallback()
+                  },
+                  changeManager,
+                  sourceFeature,
+                  sourceAssemblyId: currentAssemblyId,
                 },
-                changeManager,
-                sourceFeature,
-                sourceAssemblyId: currentAssemblyId,
-              },
-            ])
+              ],
+            )
           },
         },
         {
           label: 'Delete feature',
           disabled: !admin,
           onClick: () => {
-            session.queueDialog((doneCallback) => [
-              DeleteFeature,
-              {
-                session,
-                handleClose: () => {
-                  doneCallback()
+            ;(session as unknown as AbstractSessionModel).queueDialog(
+              (doneCallback) => [
+                DeleteFeature,
+                {
+                  session,
+                  handleClose: () => {
+                    doneCallback()
+                  },
+                  changeManager,
+                  sourceFeature,
+                  sourceAssemblyId: currentAssemblyId,
+                  selectedFeature,
+                  setSelectedFeature,
                 },
-                changeManager,
-                sourceFeature,
-                sourceAssemblyId: currentAssemblyId,
-                selectedFeature,
-                setSelectedFeature,
-              },
-            ])
+              ],
+            )
           },
         },
         {
           label: 'Modify feature attribute',
           disabled: readOnly,
           onClick: () => {
-            session.queueDialog((doneCallback) => [
-              ModifyFeatureAttribute,
-              {
-                session,
-                handleClose: () => {
-                  doneCallback()
+            ;(session as unknown as AbstractSessionModel).queueDialog(
+              (doneCallback) => [
+                ModifyFeatureAttribute,
+                {
+                  session,
+                  handleClose: () => {
+                    doneCallback()
+                  },
+                  changeManager,
+                  sourceFeature,
+                  sourceAssemblyId: currentAssemblyId,
                 },
-                changeManager,
-                sourceFeature,
-                sourceAssemblyId: currentAssemblyId,
-              },
-            ])
+              ],
+            )
           },
         },
       )

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/base.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/base.ts
@@ -2,7 +2,11 @@ import { ConfigurationReference, getConf } from '@jbrowse/core/configuration'
 import { AnyConfigurationSchemaType } from '@jbrowse/core/configuration/configurationSchema'
 import { BaseDisplay } from '@jbrowse/core/pluggableElementTypes'
 import PluginManager from '@jbrowse/core/PluginManager'
-import { AppRootModel, getContainingView, getSession } from '@jbrowse/core/util'
+import {
+  AbstractSessionModel,
+  getContainingView,
+  getSession,
+} from '@jbrowse/core/util'
 import { getParentRenderProps } from '@jbrowse/core/util/tracks'
 // import type LinearGenomeViewPlugin from '@jbrowse/plugin-linear-genome-view'
 import type { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
@@ -11,6 +15,7 @@ import { autorun } from 'mobx'
 import { addDisposer, getRoot, types } from 'mobx-state-tree'
 
 import { ApolloInternetAccountModel } from '../../ApolloInternetAccount/model'
+import { ApolloSessionModel } from '../../session'
 import { ApolloRootModel } from '../../types'
 import { TrackHeightMixin } from './trackHeightMixin'
 
@@ -52,7 +57,7 @@ export function baseModelFactory(
         return self.configuration.renderer.type
       },
       get session() {
-        return getSession(self)
+        return getSession(self) as unknown as ApolloSessionModel
       },
       get regions() {
         const regions = self.lgv.dynamicBlocks.contentBlocks.map(
@@ -78,11 +83,10 @@ export function baseModelFactory(
     .views((self) => ({
       get apolloInternetAccount() {
         const [region] = self.regions
-        const { internetAccounts } = getRoot<ApolloRootModel>(
-          self,
-        ) as AppRootModel
+        const { internetAccounts } = getRoot<ApolloRootModel>(self)
         const { assemblyName } = region
-        const { assemblyManager } = self.session
+        const { assemblyManager } =
+          self.session as unknown as AbstractSessionModel
         const assembly = assemblyManager.get(assemblyName)
         if (!assembly) {
           throw new Error(`No assembly found with name ${assemblyName}`)
@@ -102,10 +106,12 @@ export function baseModelFactory(
         return matchingAccount
       },
       get changeManager() {
-        return self.session.apolloDataStore?.changeManager
+        return (self.session as unknown as ApolloSessionModel).apolloDataStore
+          ?.changeManager
       },
       getAssemblyId(assemblyName: string) {
-        const { assemblyManager } = self.session
+        const { assemblyManager } =
+          self.session as unknown as AbstractSessionModel
         const assembly = assemblyManager.get(assemblyName)
         if (!assembly) {
           throw new Error(`Could not find assembly named ${assemblyName}`)
@@ -113,12 +119,15 @@ export function baseModelFactory(
         return assembly.name
       },
       get selectedFeature(): AnnotationFeatureI | undefined {
-        return self.session.apolloSelectedFeature
+        return (self.session as unknown as ApolloSessionModel)
+          .apolloSelectedFeature
       },
     }))
     .actions((self) => ({
       setSelectedFeature(feature?: AnnotationFeatureI) {
-        return self.session.apolloSetSelectedFeature(feature)
+        return (
+          self.session as unknown as ApolloSessionModel
+        ).apolloSetSelectedFeature(feature)
       },
       afterAttach() {
         addDisposer(
@@ -128,7 +137,9 @@ export function baseModelFactory(
               if (!self.lgv.initialized || self.regionCannotBeRendered()) {
                 return
               }
-              self.session.apolloDataStore.loadFeatures(self.regions)
+              void (
+                self.session as unknown as ApolloSessionModel
+              ).apolloDataStore.loadFeatures(self.regions)
             },
             { name: 'LinearApolloDisplayLoadFeatures', delay: 1000 },
           ),

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/layouts.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/layouts.ts
@@ -1,10 +1,11 @@
 import { AnyConfigurationSchemaType } from '@jbrowse/core/configuration/configurationSchema'
 import PluginManager from '@jbrowse/core/PluginManager'
-import { doesIntersect2 } from '@jbrowse/core/util'
+import { AbstractSessionModel, doesIntersect2 } from '@jbrowse/core/util'
 import { AnnotationFeatureI } from 'apollo-mst'
 import { autorun, observable } from 'mobx'
 import { addDisposer, isAlive } from 'mobx-state-tree'
 
+import { ApolloSessionModel } from '../../session'
 import { baseModelFactory } from './base'
 import { getGlyph } from './getGlyph'
 
@@ -20,7 +21,8 @@ export function layoutsModelFactory(
     }))
     .views((self) => ({
       get featuresMinMax() {
-        const { assemblyManager } = self.session
+        const { assemblyManager } =
+          self.session as unknown as AbstractSessionModel
         return self.displayedRegions.map((region) => {
           const assembly = assemblyManager.get(region.assemblyName)
           let min: number | undefined
@@ -63,7 +65,8 @@ export function layoutsModelFactory(
     }))
     .views((self) => ({
       get featureLayouts() {
-        const { assemblyManager } = self.session
+        const { assemblyManager } =
+          self.session as unknown as AbstractSessionModel
         return self.displayedRegions.map((region, idx) => {
           const assembly = assemblyManager.get(region.assemblyName)
           const featureLayout = new Map<
@@ -172,9 +175,9 @@ export function layoutsModelFactory(
                 return
               }
               for (const region of self.regions) {
-                const assembly = self.session.apolloDataStore.assemblies.get(
-                  region.assemblyName,
-                )
+                const assembly = (
+                  self.session as unknown as ApolloSessionModel
+                ).apolloDataStore.assemblies.get(region.assemblyName)
                 const ref = assembly?.getByRefName(region.refName)
                 for (const [, feature] of ref?.features ?? new Map()) {
                   if (

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/rendering.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/rendering.ts
@@ -5,7 +5,7 @@ import { Theme } from '@mui/material'
 import { autorun } from 'mobx'
 import { Instance, addDisposer } from 'mobx-state-tree'
 
-import { Collaborator } from '../../session'
+import { ApolloSessionModel } from '../../session'
 import { getGlyph } from './getGlyph'
 import { layoutsModelFactory } from './layouts'
 
@@ -82,8 +82,9 @@ export function renderingModelIntermediateFactory(
                 self.lgv.dynamicBlocks.totalWidthPx,
                 self.featuresHeight,
               )
-              for (const collaborator of self.session
-                .collaborators as Collaborator[]) {
+              for (const collaborator of (
+                self.session as unknown as ApolloSessionModel
+              ).collaborators) {
                 const { locations } = collaborator
                 if (locations.length === 0) {
                   continue

--- a/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/stateModel.ts
+++ b/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/stateModel.ts
@@ -17,7 +17,7 @@ import { AnnotationFeatureI } from 'apollo-mst'
 import { autorun } from 'mobx'
 import { Instance, addDisposer, types } from 'mobx-state-tree'
 
-import { ApolloSession } from '../session'
+import { ApolloSession, ApolloSessionModel } from '../session'
 
 const forwardPhaseMap: Record<number, number> = { 0: 2, 1: 1, 2: 0 }
 const reversePhaseMap: Record<number, number> = { 3: 0, 4: 1, 5: 2 }
@@ -76,11 +76,14 @@ export function stateModelFactory(
         return regions
       },
       regionCannotBeRendered(/* region */) {
-        const view = getContainingView(self)
+        const view = getContainingView(self) as unknown as LinearGenomeViewModel
         if (view && view.bpPerPx >= 200) {
           return 'Zoom in to see annotations'
         }
         return
+      },
+      get session() {
+        return getSession(self) as unknown as ApolloSessionModel
       },
     }))
     .actions((self) => {

--- a/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/Feature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/Feature.tsx
@@ -1,3 +1,4 @@
+import { AbstractSessionModel } from '@jbrowse/core/util'
 import { AnnotationFeatureI } from 'apollo-mst'
 import { observer } from 'mobx-react'
 import React from 'react'
@@ -119,7 +120,8 @@ export const Feature = observer(function Feature({
   }
 
   // pop up a snackbar in the session notifying user of an error
-  const notifyError = (e: Error) => session.notify(e.message, 'error')
+  const notifyError = (e: Error) =>
+    (session as unknown as AbstractSessionModel).notify(e.message, 'error')
 
   return (
     <>

--- a/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/HybridGrid.tsx
+++ b/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/HybridGrid.tsx
@@ -5,6 +5,7 @@ import { observer } from 'mobx-react'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { makeStyles } from 'tss-react/mui'
 
+import { ApolloSessionModel } from '../../session'
 import { getApolloInternetAccount } from '../../util'
 import { DisplayStateModel } from '../types'
 import { Feature } from './Feature'
@@ -47,7 +48,9 @@ const HybridGrid = observer(function HybridGrid({
   const { filterText } = tabularEditor
 
   const internetAccount = useMemo(() => {
-    return getApolloInternetAccount(getSession(model))
+    return getApolloInternetAccount(
+      getSession(model) as unknown as ApolloSessionModel,
+    )
   }, [model])
 
   // scrolls to selected feature if one is selected and it's not already visible

--- a/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/featureContextMenuItems.ts
+++ b/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/featureContextMenuItems.ts
@@ -9,6 +9,7 @@ import {
   DeleteFeature,
   ModifyFeatureAttribute,
 } from '../../components'
+import { ApolloSessionModel } from '../../session'
 import { getApolloInternetAccount } from '../../util'
 
 export function featureContextMenuItems(
@@ -17,7 +18,7 @@ export function featureContextMenuItems(
   getAssemblyId: (assemblyName: string) => string,
   selectedFeature: AnnotationFeatureI | undefined,
   setSelectedFeature: (f: AnnotationFeatureI | undefined) => void,
-  session: AbstractSessionModel,
+  session: ApolloSessionModel,
   changeManager: ChangeManager,
 ) {
   const internetAccount = getApolloInternetAccount(session)
@@ -34,75 +35,83 @@ export function featureContextMenuItems(
         label: 'Add child feature',
         disabled: readOnly,
         onClick: () => {
-          session.queueDialog((doneCallback) => [
-            AddFeature,
-            {
-              session,
-              handleClose: () => {
-                doneCallback()
+          ;(session as unknown as AbstractSessionModel).queueDialog(
+            (doneCallback) => [
+              AddFeature,
+              {
+                session,
+                handleClose: () => {
+                  doneCallback()
+                },
+                changeManager,
+                sourceFeature: feature,
+                sourceAssemblyId,
+                internetAccount,
               },
-              changeManager,
-              sourceFeature: feature,
-              sourceAssemblyId,
-              internetAccount,
-            },
-          ])
+            ],
+          )
         },
       },
       {
         label: 'Copy features and annotations',
         disabled: readOnly,
         onClick: () => {
-          session.queueDialog((doneCallback) => [
-            CopyFeature,
-            {
-              session,
-              handleClose: () => {
-                doneCallback()
+          ;(session as unknown as AbstractSessionModel).queueDialog(
+            (doneCallback) => [
+              CopyFeature,
+              {
+                session,
+                handleClose: () => {
+                  doneCallback()
+                },
+                changeManager,
+                sourceFeature: feature,
+                sourceAssemblyId: currentAssemblyId,
               },
-              changeManager,
-              sourceFeature: feature,
-              sourceAssemblyId: currentAssemblyId,
-            },
-          ])
+            ],
+          )
         },
       },
       {
         label: 'Delete feature',
         disabled: !admin,
         onClick: () => {
-          session.queueDialog((doneCallback) => [
-            DeleteFeature,
-            {
-              session,
-              handleClose: () => {
-                doneCallback()
+          ;(session as unknown as AbstractSessionModel).queueDialog(
+            (doneCallback) => [
+              DeleteFeature,
+              {
+                session,
+                handleClose: () => {
+                  doneCallback()
+                },
+                changeManager,
+                sourceFeature: feature,
+                sourceAssemblyId: currentAssemblyId,
+                selectedFeature,
+                setSelectedFeature,
               },
-              changeManager,
-              sourceFeature: feature,
-              sourceAssemblyId: currentAssemblyId,
-              selectedFeature,
-              setSelectedFeature,
-            },
-          ])
+            ],
+          )
         },
       },
       {
         label: 'Edit attributes',
         disabled: readOnly,
         onClick: () => {
-          session.queueDialog((doneCallback) => [
-            ModifyFeatureAttribute,
-            {
-              session,
-              handleClose: () => {
-                doneCallback()
+          ;(session as unknown as AbstractSessionModel).queueDialog(
+            (doneCallback) => [
+              ModifyFeatureAttribute,
+              {
+                session,
+                handleClose: () => {
+                  doneCallback()
+                },
+                changeManager,
+                sourceFeature: feature,
+                sourceAssemblyId: currentAssemblyId,
               },
-              changeManager,
-              sourceFeature: feature,
-              sourceAssemblyId: currentAssemblyId,
-            },
-          ])
+            ],
+          )
         },
       },
     )

--- a/packages/jbrowse-plugin-apollo/src/components/AddAssembly.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/AddAssembly.tsx
@@ -1,4 +1,4 @@
-import { AbstractSessionModel, AppRootModel } from '@jbrowse/core/util'
+import { AbstractSessionModel } from '@jbrowse/core/util'
 import LinkIcon from '@mui/icons-material/Link'
 import {
   Box,
@@ -32,11 +32,13 @@ import React, { useState } from 'react'
 
 import { ApolloInternetAccountModel } from '../ApolloInternetAccount/model'
 import { ChangeManager } from '../ChangeManager'
+import { ApolloSessionModel } from '../session'
+import { ApolloRootModel } from '../types'
 import { createFetchErrorMessage } from '../util'
 import { Dialog } from './Dialog'
 
 interface AddAssemblyProps {
-  session: AbstractSessionModel
+  session: ApolloSessionModel
   handleClose(): void
   changeManager: ChangeManager
 }
@@ -52,8 +54,8 @@ export function AddAssembly({
   handleClose,
   session,
 }: AddAssemblyProps) {
-  const { internetAccounts } = getRoot(session) as AppRootModel
-  const { notify } = session
+  const { internetAccounts } = getRoot<ApolloRootModel>(session)
+  const { notify } = session as unknown as AbstractSessionModel
   const apolloInternetAccounts = internetAccounts.filter(
     (ia) => ia.type === 'ApolloInternetAccount',
   ) as ApolloInternetAccountModel[]

--- a/packages/jbrowse-plugin-apollo/src/components/AddFeature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/AddFeature.tsx
@@ -19,11 +19,12 @@ import React, { useState } from 'react'
 import { ChangeManager } from '../ChangeManager'
 import { isOntologyClass } from '../OntologyManager'
 import OntologyStore from '../OntologyManager/OntologyStore'
+import { ApolloSessionModel } from '../session'
 import { Dialog } from './Dialog'
 import { OntologyTermAutocomplete } from './OntologyTermAutocomplete'
 
 interface AddFeatureProps {
-  session: AbstractSessionModel
+  session: ApolloSessionModel
   handleClose(): void
   sourceFeature: AnnotationFeatureI
   sourceAssemblyId: string
@@ -43,7 +44,7 @@ export function AddFeature({
   sourceAssemblyId,
   sourceFeature,
 }: AddFeatureProps) {
-  const { notify } = session
+  const { notify } = session as unknown as AbstractSessionModel
   const [end, setEnd] = useState(String(sourceFeature.end))
   const [start, setStart] = useState(String(sourceFeature.start))
   const [type, setType] = useState('')

--- a/packages/jbrowse-plugin-apollo/src/components/CopyFeature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/CopyFeature.tsx
@@ -18,10 +18,11 @@ import { getSnapshot } from 'mobx-state-tree'
 import React, { useEffect, useState } from 'react'
 
 import { ChangeManager } from '../ChangeManager'
+import { ApolloSessionModel } from '../session'
 import { Dialog } from './Dialog'
 
 interface CopyFeatureProps {
-  session: AbstractSessionModel
+  session: ApolloSessionModel
   handleClose(): void
   sourceFeature: AnnotationFeatureI
   sourceAssemblyId: string
@@ -73,7 +74,7 @@ export function CopyFeature({
   sourceAssemblyId,
   sourceFeature,
 }: CopyFeatureProps) {
-  const { assemblyManager } = session
+  const { assemblyManager, notify } = session as unknown as AbstractSessionModel
   const assemblies = assemblyManager.assemblyList
 
   const [selectedAssemblyId, setSelectedAssemblyId] =
@@ -84,7 +85,6 @@ export function CopyFeature({
   const [selectedRefSeqId, setSelectedRefSeqId] = useState('')
   const [start, setStart] = useState(sourceFeature.start)
   const [errorMessage, setErrorMessage] = useState('')
-  const { notify } = session
 
   async function handleChangeAssembly(e: SelectChangeEvent<string>) {
     setSelectedAssemblyId(e.target.value)

--- a/packages/jbrowse-plugin-apollo/src/components/DeleteAssembly.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/DeleteAssembly.tsx
@@ -1,5 +1,4 @@
 import { Assembly } from '@jbrowse/core/assemblyManager/assembly'
-import { AppRootModel } from '@jbrowse/core/util'
 import {
   Button,
   Checkbox,
@@ -23,6 +22,7 @@ import {
 } from '../BackendDrivers'
 import { ChangeManager } from '../ChangeManager'
 import { ApolloSessionModel } from '../session'
+import { ApolloRootModel } from '../types'
 import { Dialog } from './Dialog'
 
 interface DeleteAssemblyProps {
@@ -36,7 +36,7 @@ export function DeleteAssembly({
   handleClose,
   session,
 }: DeleteAssemblyProps) {
-  const { internetAccounts } = getRoot(session) as AppRootModel
+  const { internetAccounts } = getRoot<ApolloRootModel>(session)
   const [selectedAssembly, setSelectedAssembly] = useState<Assembly>()
   const [errorMessage, setErrorMessage] = useState('')
   const [confirmDelete, setconfirmDelete] = useState(false)

--- a/packages/jbrowse-plugin-apollo/src/components/DeleteFeature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/DeleteFeature.tsx
@@ -1,4 +1,4 @@
-import { AbstractSessionModel, AppRootModel } from '@jbrowse/core/util'
+import { AbstractSessionModel } from '@jbrowse/core/util'
 import {
   Button,
   DialogActions,
@@ -12,10 +12,12 @@ import React, { useState } from 'react'
 
 import { ApolloInternetAccountModel } from '../ApolloInternetAccount/model'
 import { ChangeManager } from '../ChangeManager'
+import { ApolloSessionModel } from '../session'
+import { ApolloRootModel } from '../types'
 import { Dialog } from './Dialog'
 
 interface DeleteFeatureProps {
-  session: AbstractSessionModel
+  session: ApolloSessionModel
   handleClose(): void
   sourceFeature: AnnotationFeatureI
   sourceAssemblyId: string
@@ -33,8 +35,8 @@ export function DeleteFeature({
   sourceAssemblyId,
   sourceFeature,
 }: DeleteFeatureProps) {
-  const { internetAccounts } = getRoot(session) as AppRootModel
-  const { notify } = session
+  const { internetAccounts } = getRoot<ApolloRootModel>(session)
+  const { notify } = session as unknown as AbstractSessionModel
   const apolloInternetAccount = internetAccounts.find(
     (ia) => ia.type === 'ApolloInternetAccount',
   ) as ApolloInternetAccountModel | undefined

--- a/packages/jbrowse-plugin-apollo/src/components/ImportFeatures.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/ImportFeatures.tsx
@@ -1,5 +1,6 @@
 import { Assembly } from '@jbrowse/core/assemblyManager/assembly'
 import { getConf } from '@jbrowse/core/configuration'
+import { AbstractSessionModel } from '@jbrowse/core/util'
 import {
   Button,
   DialogActions,
@@ -35,7 +36,8 @@ export function ImportFeatures({
   handleClose,
   session,
 }: ImportFeaturesProps) {
-  const { apolloDataStore, notify } = session
+  const { apolloDataStore } = session
+  const { notify } = session as unknown as AbstractSessionModel
 
   const [file, setFile] = useState<File>()
   const [selectedAssembly, setSelectedAssembly] = useState<Assembly>()

--- a/packages/jbrowse-plugin-apollo/src/components/ManageUsers.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/ManageUsers.tsx
@@ -1,4 +1,4 @@
-import { AbstractRootModel, AbstractSessionModel } from '@jbrowse/core/util'
+import { AbstractRootModel } from '@jbrowse/core/util'
 import DeleteIcon from '@mui/icons-material/Delete'
 import {
   Button,
@@ -25,6 +25,7 @@ import React, { useCallback, useEffect, useState } from 'react'
 
 import { ApolloInternetAccountModel } from '../ApolloInternetAccount/model'
 import { ChangeManager } from '../ChangeManager'
+import { ApolloSessionModel } from '../session'
 import { createFetchErrorMessage } from '../util'
 import { Dialog } from './Dialog'
 
@@ -36,7 +37,7 @@ interface UserResponse {
 }
 
 interface ManageUsersProps {
-  session: AbstractSessionModel
+  session: ApolloSessionModel
   handleClose(): void
   changeManager: ChangeManager
 }
@@ -50,7 +51,7 @@ export function ManageUsers({
   handleClose,
   session,
 }: ManageUsersProps) {
-  const { internetAccounts } = getRoot(session) as ApolloRootModel
+  const { internetAccounts } = getRoot<ApolloRootModel>(session)
   const apolloInternetAccounts = internetAccounts.filter(
     (ia) =>
       ia.type === 'ApolloInternetAccount' && ia.getRole()?.includes('admin'),

--- a/packages/jbrowse-plugin-apollo/src/components/ModifyFeatureAttribute.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/ModifyFeatureAttribute.tsx
@@ -1,8 +1,4 @@
-import {
-  AbstractSessionModel,
-  AppRootModel,
-  getSession,
-} from '@jbrowse/core/util'
+import { AbstractSessionModel } from '@jbrowse/core/util'
 import DeleteIcon from '@mui/icons-material/Delete'
 import {
   Button,
@@ -28,11 +24,13 @@ import { makeStyles } from 'tss-react/mui'
 
 import { ApolloInternetAccountModel } from '../ApolloInternetAccount/model'
 import { ChangeManager } from '../ChangeManager'
+import { ApolloSessionModel } from '../session'
+import { ApolloRootModel } from '../types'
 import { Dialog } from './Dialog'
 import { OntologyTermMultiSelect } from './OntologyTermMultiSelect'
 
 interface ModifyFeatureAttributeProps {
-  session: AbstractSessionModel
+  session: ApolloSessionModel
   handleClose(): void
   sourceFeature: AnnotationFeatureI
   sourceAssemblyId: string
@@ -71,7 +69,7 @@ const useStyles = makeStyles()((theme) => ({
 }))
 
 export interface AttributeValueEditorProps {
-  session: ReturnType<typeof getSession>
+  session: ApolloSessionModel
   value: string[]
   onChange(newValue: string[]): void
 }
@@ -117,9 +115,9 @@ export function ModifyFeatureAttribute({
   sourceAssemblyId,
   sourceFeature,
 }: ModifyFeatureAttributeProps) {
-  const { notify } = session
+  const { notify } = session as unknown as AbstractSessionModel
 
-  const { internetAccounts } = getRoot(session) as AppRootModel
+  const { internetAccounts } = getRoot<ApolloRootModel>(session)
   const internetAccount = useMemo(() => {
     const apolloInternetAccount = internetAccounts.find(
       (ia) => ia.type === 'ApolloInternetAccount',

--- a/packages/jbrowse-plugin-apollo/src/components/OntologyTermAutocomplete.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/OntologyTermAutocomplete.tsx
@@ -1,4 +1,4 @@
-import { getSession, isAbortException } from '@jbrowse/core/util'
+import { AbstractSessionModel, isAbortException } from '@jbrowse/core/util'
 import {
   Autocomplete,
   AutocompleteRenderInputParams,
@@ -9,9 +9,10 @@ import React, { useCallback, useEffect, useState } from 'react'
 import type { OntologyManager } from '../OntologyManager'
 import { OntologyTerm, isDeprecated } from '../OntologyManager'
 import OntologyStore from '../OntologyManager/OntologyStore'
+import { ApolloSessionModel } from '../session'
 
 interface OntologyTermAutocompleteProps {
-  session: ReturnType<typeof getSession>
+  session: ApolloSessionModel
   ontologyName: string
   ontologyVersion?: string
   value: string
@@ -116,7 +117,10 @@ export function OntologyTermAutocomplete({
         },
         (error) => {
           if (!signal.aborted && !isAbortException(error)) {
-            session.notify(error.message, 'error')
+            ;(session as unknown as AbstractSessionModel).notify(
+              error.message,
+              'error',
+            )
           }
         },
       )

--- a/packages/jbrowse-plugin-apollo/src/components/OntologyTermMultiSelect.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/OntologyTermMultiSelect.tsx
@@ -1,4 +1,4 @@
-import { getSession, isAbortException } from '@jbrowse/core/util'
+import { isAbortException } from '@jbrowse/core/util'
 import {
   Autocomplete,
   AutocompleteRenderGetTagProps,
@@ -22,6 +22,7 @@ import {
 } from '../OntologyManager'
 import { Match } from '../OntologyManager/OntologyStore/fulltext'
 import { isDeprecated } from '../OntologyManager/OntologyStore/indexeddb-schema'
+import { ApolloSessionModel } from '../session'
 
 interface TermValue {
   term: OntologyTerm
@@ -111,7 +112,7 @@ export function OntologyTermMultiSelect({
   session,
   value: initialValue,
 }: {
-  session: ReturnType<typeof getSession>
+  session: ApolloSessionModel
   value: string[]
   ontologyName: string
   ontologyVersion?: string

--- a/packages/jbrowse-plugin-apollo/src/components/ViewChangeLog.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/ViewChangeLog.tsx
@@ -1,4 +1,3 @@
-import { AbstractSessionModel, AppRootModel } from '@jbrowse/core/util'
 import {
   Button,
   DialogActions,
@@ -20,11 +19,13 @@ import React, { useEffect, useState } from 'react'
 import { makeStyles } from 'tss-react/mui'
 
 import { ApolloInternetAccountModel } from '../ApolloInternetAccount/model'
+import { ApolloSessionModel } from '../session'
+import { ApolloRootModel } from '../types'
 import { createFetchErrorMessage } from '../util'
 import { Dialog } from './Dialog'
 
 interface ViewChangeLogProps {
-  session: AbstractSessionModel
+  session: ApolloSessionModel
   handleClose(): void
 }
 
@@ -44,7 +45,7 @@ const useStyles = makeStyles()((theme) => ({
 }))
 
 export function ViewChangeLog({ handleClose, session }: ViewChangeLogProps) {
-  const { internetAccounts } = getRoot(session) as AppRootModel
+  const { internetAccounts } = getRoot<ApolloRootModel>(session)
   const apolloInternetAccount = internetAccounts.find(
     (ia) => ia.type === 'ApolloInternetAccount',
   ) as ApolloInternetAccountModel | undefined

--- a/packages/jbrowse-plugin-apollo/src/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/index.ts
@@ -145,46 +145,51 @@ export default class ApolloPlugin extends Plugin {
       pluginManager.rootModel.insertMenu('Apollo', -1)
       pluginManager.rootModel.appendToMenu('Apollo', {
         label: 'Download GFF3',
-        onClick: (session: AbstractSessionModel) => {
-          session.queueDialog((doneCallback) => [
-            DownloadGFF3,
-            {
-              session,
-              handleClose: () => {
-                doneCallback()
+        onClick: (session: ApolloSessionModel) => {
+          ;(session as unknown as AbstractSessionModel).queueDialog(
+            (doneCallback) => [
+              DownloadGFF3,
+              {
+                session,
+                handleClose: () => {
+                  doneCallback()
+                },
               },
-            },
-          ])
+            ],
+          )
         },
       })
       pluginManager.rootModel.appendToMenu('Apollo', {
         label: 'View Change Log',
-        onClick: (session: AbstractSessionModel) => {
-          session.queueDialog((doneCallback) => [
-            ViewChangeLog,
-            {
-              session,
-              handleClose: () => {
-                doneCallback()
+        onClick: (session: ApolloSessionModel) => {
+          ;(session as unknown as AbstractSessionModel).queueDialog(
+            (doneCallback) => [
+              ViewChangeLog,
+              {
+                session,
+                handleClose: () => {
+                  doneCallback()
+                },
               },
-            },
-          ])
+            ],
+          )
         },
       })
       pluginManager.rootModel.appendToMenu('Apollo', {
         label: 'Open local GFF3 file',
-        onClick: (session: AbstractSessionModel) => {
-          session.queueDialog((doneCallback) => [
-            OpenLocalFile,
-            {
-              session,
-              handleClose: () => {
-                doneCallback()
+        onClick: (session: ApolloSessionModel) => {
+          ;(session as unknown as AbstractSessionModel).queueDialog(
+            (doneCallback) => [
+              OpenLocalFile,
+              {
+                session,
+                handleClose: () => {
+                  doneCallback()
+                },
+                inMemoryFileDriver: session.apolloDataStore.inMemoryFileDriver,
               },
-              inMemoryFileDriver: (session as ApolloSessionModel)
-                .apolloDataStore.inMemoryFileDriver,
-            },
-          ])
+            ],
+          )
         },
       })
     }

--- a/packages/jbrowse-plugin-apollo/src/session/ClientDataStore.ts
+++ b/packages/jbrowse-plugin-apollo/src/session/ClientDataStore.ts
@@ -1,6 +1,6 @@
 import { getConf, readConfObject } from '@jbrowse/core/configuration'
 import { ConfigurationModel } from '@jbrowse/core/configuration/types'
-import { AppRootModel, Region, getSession } from '@jbrowse/core/util'
+import { Region, getSession } from '@jbrowse/core/util'
 import { LocalPathLocation, UriLocation } from '@jbrowse/core/util/types/mst'
 import { ClientDataStore as ClientDataStoreType } from 'apollo-common'
 import {
@@ -45,10 +45,10 @@ export function clientDataStoreFactory(
     })
     .views((self) => ({
       get internetAccounts() {
-        return (getRoot<ApolloRootModel>(self) as AppRootModel).internetAccounts
+        return getRoot<ApolloRootModel>(self).internetAccounts
       },
       get pluginConfiguration() {
-        return (getRoot(self) as AppRootModel).jbrowse.configuration
+        return getRoot<ApolloRootModel>(self).jbrowse.configuration
           .ApolloPlugin as Instance<typeof ApolloPluginConfigurationSchema>
       },
       getFeature(featureId: string) {

--- a/packages/jbrowse-plugin-apollo/src/session/session.ts
+++ b/packages/jbrowse-plugin-apollo/src/session/session.ts
@@ -2,12 +2,15 @@ import { AssemblyModel } from '@jbrowse/core/assemblyManager/assembly'
 import { getConf } from '@jbrowse/core/configuration'
 import { BaseInternetAccountModel } from '@jbrowse/core/pluggableElementTypes'
 import PluginManager from '@jbrowse/core/PluginManager'
-import { AbstractSessionModel, AppRootModel } from '@jbrowse/core/util'
+import {
+  AbstractSessionModel,
+  SessionWithConfigEditing,
+} from '@jbrowse/core/util'
 import { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
 import { ClientDataStore as ClientDataStoreType } from 'apollo-common'
 import { AnnotationFeature, AnnotationFeatureI } from 'apollo-mst'
 import { autorun, observable } from 'mobx'
-import { IAnyModelType, Instance, flow, getRoot, types } from 'mobx-state-tree'
+import { Instance, flow, getRoot, types } from 'mobx-state-tree'
 
 import {
   ApolloInternetAccountModel,
@@ -55,7 +58,7 @@ export interface Collaborator {
 
 export function extendSession(
   pluginManager: PluginManager,
-  sessionModel: IAnyModelType,
+  sessionModel: ReturnType<typeof types.model>,
 ) {
   const aborter = new AbortController()
   const { signal } = aborter
@@ -98,11 +101,11 @@ export function extendSession(
       },
       addApolloTrackConfig(assembly: AssemblyModel, baseURL?: string) {
         const trackId = `apollo_track_${assembly.name}`
-        const hasTrack =
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          self.tracks.some((track: any) => track.trackId === trackId)
+        const hasTrack = (self as unknown as AbstractSessionModel).tracks.some(
+          (track) => track.trackId === trackId,
+        )
         if (!hasTrack) {
-          self.addTrackConf({
+          ;(self as unknown as SessionWithConfigEditing).addTrackConf({
             type: 'ApolloTrack',
             trackId,
             name: `Annotations (${
@@ -135,18 +138,20 @@ export function extendSession(
         }
       },
       broadcastLocations() {
-        const { internetAccounts } = getRoot<ApolloRootModel>(
-          self,
-        ) as AppRootModel
+        const { internetAccounts } = getRoot<ApolloRootModel>(self)
         const locations: {
           assemblyName: string
           refName: string
           start: number
           end: number
         }[] = []
-        for (const view of self.views) {
-          if (view.type === 'LinearGenomeView' && view.initialized) {
-            const { dynamicBlocks } = view as LinearGenomeViewModel
+        for (const view of (self as unknown as AbstractSessionModel).views) {
+          if (view.type !== 'LinearGenomeView') {
+            return
+          }
+          const lgv = view as unknown as LinearGenomeViewModel
+          if (lgv.initialized) {
+            const { dynamicBlocks } = lgv
             // eslint-disable-next-line unicorn/no-array-for-each
             dynamicBlocks.forEach((block) => {
               if (block.regionNumber !== undefined) {
@@ -187,10 +192,10 @@ export function extendSession(
           }
         }
       },
+    }))
+    .actions((self) => ({
       afterCreate: flow(function* afterCreate() {
-        const { internetAccounts } = getRoot<ApolloRootModel>(
-          self,
-        ) as AppRootModel
+        const { internetAccounts } = getRoot<ApolloRootModel>(self)
         autorun(
           () => {
             // broadcastLocations() // **** This is not working and therefore we need to duplicate broadcastLocations() -method code here because autorun() does not observe changes otherwise
@@ -200,9 +205,14 @@ export function extendSession(
               start: number
               end: number
             }[] = []
-            for (const view of self.views) {
-              if (view.type === 'LinearGenomeView' && view.initialized) {
-                const { dynamicBlocks } = view as LinearGenomeViewModel
+            for (const view of (self as unknown as AbstractSessionModel)
+              .views) {
+              if (view.type !== 'LinearGenomeView') {
+                return
+              }
+              const lgv = view as unknown as LinearGenomeViewModel
+              if (lgv.initialized) {
+                const { dynamicBlocks } = lgv as LinearGenomeViewModel
                 // eslint-disable-next-line unicorn/no-array-for-each
                 dynamicBlocks.forEach((block) => {
                   if (block.regionNumber !== undefined) {
@@ -284,9 +294,14 @@ export function extendSession(
             continue
           }
           for (const assembly of fetchedAssemblies) {
-            const { addAssembly, addSessionAssembly, assemblyManager } = self
+            const { addAssembly, addSessionAssembly, assemblyManager } =
+              self as unknown as AbstractSessionModel & {
+                // eslint-disable-next-line @typescript-eslint/ban-types
+                addSessionAssembly: Function
+              }
             const selectedAssembly = assemblyManager.get(assembly.name)
             if (selectedAssembly) {
+              // @ts-expect-error MST type coercion problem?
               self.addApolloTrackConfig(selectedAssembly, baseURL)
               continue
             }

--- a/packages/jbrowse-plugin-apollo/src/types.ts
+++ b/packages/jbrowse-plugin-apollo/src/types.ts
@@ -4,7 +4,7 @@ import { AppRootModel } from '@jbrowse/core/util'
 import { ApolloInternetAccountModel } from './ApolloInternetAccount/model'
 import { ApolloSessionModel } from './session'
 
-export interface ApolloRootModel extends AppRootModel {
+export interface ApolloRootModel extends Omit<AppRootModel, 'session'> {
   session: ApolloSessionModel
   internetAccounts: (BaseInternetAccountModel | ApolloInternetAccountModel)[]
 }

--- a/packages/jbrowse-plugin-apollo/src/util/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/util/index.ts
@@ -1,7 +1,8 @@
-import { AbstractSessionModel, AppRootModel } from '@jbrowse/core/util'
 import { getParent } from 'mobx-state-tree'
 
 import { ApolloInternetAccountModel } from '../ApolloInternetAccount/model'
+import { ApolloSessionModel } from '../session'
+import { ApolloRootModel } from '../types'
 
 export async function createFetchErrorMessage(
   response: Response,
@@ -20,8 +21,8 @@ export async function createFetchErrorMessage(
 }
 
 /** given a session, get our ApolloInternetAccount */
-export function getApolloInternetAccount(session: AbstractSessionModel) {
-  const { internetAccounts } = getParent<AppRootModel>(session)
+export function getApolloInternetAccount(session: ApolloSessionModel) {
+  const { internetAccounts } = getParent<ApolloRootModel>(session)
   const apolloInternetAccount = internetAccounts.find(
     (ia) => ia.type === 'ApolloInternetAccount',
   ) as ApolloInternetAccountModel | undefined

--- a/packages/jbrowse-plugin-apollo/tsconfig.json
+++ b/packages/jbrowse-plugin-apollo/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": false,
     "target": "ES6",
     "rootDir": "./src",
     "noEmit": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2926,9 +2926,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jbrowse/core@npm:2.6.3":
-  version: 2.6.3
-  resolution: "@jbrowse/core@npm:2.6.3"
+"@jbrowse/core@npm:^2.7.0":
+  version: 2.7.0
+  resolution: "@jbrowse/core@npm:2.7.0"
   dependencies:
     "@babel/runtime": ^7.17.9
     "@gmod/bgzf-filehandle": ^1.4.3
@@ -2938,8 +2938,8 @@ __metadata:
     canvas-sequencer: ^3.1.0
     canvas2svg: ^1.0.16
     clone: ^2.1.2
-    clsx: ^1.0.4
-    color: ^3.1.3
+    clsx: ^2.0.0
+    colord: ^2.9.3
     copy-to-clipboard: ^3.3.1
     deepmerge: ^4.2.2
     detect-node: ^2.1.0
@@ -2957,20 +2957,19 @@ __metadata:
     rbush: ^3.0.1
     react-error-boundary: ^4.0.3
     serialize-error: ^8.0.0
-    shortid: ^2.2.13
     svg-path-generator: ^1.1.0
   peerDependencies:
     "@mui/material": ^5.0.0
     "@mui/x-data-grid": ^6.0.1
     mobx: ^6.0.0
-    mobx-react: ^7.0.0
+    mobx-react: ^9.0.0
     mobx-state-tree: ^5.0.0
     prop-types: ^15.0.0
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     rxjs: ^7.0.0
     tss-react: ^4.0.0
-  checksum: 915461755144b8bf99313a6efb5f486fd56ebfc9c14e0072ec61888be64f4bc66f5ec7c7ea73a9784ed967d0ef2eed2eb5a857aa133afffeac469f06a6165107
+  checksum: 8eb972e5e7d037277b6f237dbd2e872efb32200e647c834f82568b41feaa876c3a9ebf8ae0028435e5a16c43deb17f004b15d67ad104412698c13f1e53b87055
   languageName: node
   linkType: hard
 
@@ -6050,7 +6049,7 @@ __metadata:
     "@emotion/styled": ^11.10.6
     "@gmod/gff": ^1.2.0
     "@gmod/indexedfasta": ^2.0.4
-    "@jbrowse/core": 2.6.3
+    "@jbrowse/core": ^2.7.0
     "@mui/base": ^5.0.0-alpha.118
     "@mui/material": ^5.11.10
     "@nestjs/cli": ^10.1.10
@@ -6133,7 +6132,7 @@ __metadata:
   resolution: "apollo-common@workspace:packages/apollo-common"
   dependencies:
     "@gmod/gff": ^1.2.0
-    "@jbrowse/core": 2.6.3
+    "@jbrowse/core": ^2.7.0
     "@nestjs/common": ^10.1.0
     "@nestjs/core": ^10.1.0
     "@types/node": ^18.14.2
@@ -6161,7 +6160,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "apollo-mst@workspace:packages/apollo-mst"
   dependencies:
-    "@jbrowse/core": 2.6.3
+    "@jbrowse/core": ^2.7.0
     mobx: ^6.6.1
     mobx-state-tree: ^5.1.7
     rxjs: ^7.4.0
@@ -6194,7 +6193,7 @@ __metadata:
   dependencies:
     "@gmod/gff": ^1.2.0
     "@gmod/indexedfasta": ^2.0.4
-    "@jbrowse/core": 2.6.3
+    "@jbrowse/core": ^2.7.0
     "@nestjs/common": ^10.1.0
     "@nestjs/core": ^10.1.0
     "@types/node": ^18.14.2
@@ -7765,6 +7764,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"clsx@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "clsx@npm:2.0.0"
+  checksum: a2cfb2351b254611acf92faa0daf15220f4cd648bdf96ce369d729813b85336993871a4bf6978ddea2b81b5a130478339c20d9d0b5c6fc287e5147f0c059276e
+  languageName: node
+  linkType: hard
+
 "co@npm:^4.6.0":
   version: 4.6.0
   resolution: "co@npm:4.6.0"
@@ -7779,7 +7785,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-convert@npm:^1.9.0, color-convert@npm:^1.9.3":
+"color-convert@npm:^1.9.0":
   version: 1.9.3
   resolution: "color-convert@npm:1.9.3"
   dependencies:
@@ -7804,20 +7810,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-name@npm:^1.0.0, color-name@npm:~1.1.4":
+"color-name@npm:~1.1.4":
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: b0445859521eb4021cd0fb0cc1a75cecf67fceecae89b63f62b201cca8d345baf8b952c966862a9d9a2632987d4f6581f0ec8d957dfacece86f0a7919316f610
-  languageName: node
-  linkType: hard
-
-"color-string@npm:^1.6.0":
-  version: 1.9.1
-  resolution: "color-string@npm:1.9.1"
-  dependencies:
-    color-name: ^1.0.0
-    simple-swizzle: ^0.2.2
-  checksum: c13fe7cff7885f603f49105827d621ce87f4571d78ba28ef4a3f1a104304748f620615e6bf065ecd2145d0d9dad83a3553f52bb25ede7239d18e9f81622f1cc5
   languageName: node
   linkType: hard
 
@@ -7830,13 +7826,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color@npm:^3.1.3":
-  version: 3.2.1
-  resolution: "color@npm:3.2.1"
-  dependencies:
-    color-convert: ^1.9.3
-    color-string: ^1.6.0
-  checksum: f81220e8b774d35865c2561be921f5652117638dcda7ca4029262046e37fc2444ac7bbfdd110cf1fd9c074a4ee5eda8f85944ffbdda26186b602dd9bb05f6400
+"colord@npm:^2.9.3":
+  version: 2.9.3
+  resolution: "colord@npm:2.9.3"
+  checksum: 95d909bfbcfd8d5605cbb5af56f2d1ce2b323990258fd7c0d2eb0e6d3bb177254d7fb8213758db56bb4ede708964f78c6b992b326615f81a18a6aaf11d64c650
   languageName: node
   linkType: hard
 
@@ -11435,13 +11428,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-arrayish@npm:^0.3.1":
-  version: 0.3.2
-  resolution: "is-arrayish@npm:0.3.2"
-  checksum: 977e64f54d91c8f169b59afcd80ff19227e9f5c791fa28fa2e5bce355cbaf6c2c356711b734656e80c9dd4a854dd7efcf7894402f1031dfc5de5d620775b4d5f
-  languageName: node
-  linkType: hard
-
 "is-bigint@npm:^1.0.1":
   version: 1.0.4
   resolution: "is-bigint@npm:1.0.4"
@@ -11956,7 +11942,7 @@ __metadata:
     "@emotion/styled": ^11.10.6
     "@gmod/gff": ^1.2.0
     "@jbrowse/cli": ^2.6.2
-    "@jbrowse/core": 2.6.3
+    "@jbrowse/core": ^2.7.0
     "@jbrowse/development-tools": ^2.1.1
     "@jbrowse/plugin-authentication": ^2.0.1
     "@jbrowse/plugin-linear-genome-view": ^2.0.1
@@ -12009,7 +11995,7 @@ __metadata:
     tss-react: ^4.6.1
     typescript: ^5.1.6
   peerDependencies:
-    "@jbrowse/core": 2.6.3
+    "@jbrowse/core": ^2.7.0
     "@mui/material": ^5.11.10
     mobx: ^6.6.1
     mobx-react: ^7.2.1
@@ -14170,13 +14156,6 @@ __metadata:
   version: 0.0.8
   resolution: "mute-stream@npm:0.0.8"
   checksum: ff48d251fc3f827e5b1206cda0ffdaec885e56057ee86a3155e1951bc940fd5f33531774b1cc8414d7668c10a8907f863f6561875ee6e8768931a62121a531a1
-  languageName: node
-  linkType: hard
-
-"nanoid@npm:^2.1.0":
-  version: 2.1.11
-  resolution: "nanoid@npm:2.1.11"
-  checksum: 18cd14386816873849787eb4e65667021bfdeb019a8f14c74287c23594c67b7c0e8f42c7d69f6aedf05cd3d100f1ddc41184f9f9b6b17fbaea1c3ee3f0704eec
   languageName: node
   linkType: hard
 
@@ -16808,15 +16787,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shortid@npm:^2.2.13":
-  version: 2.2.16
-  resolution: "shortid@npm:2.2.16"
-  dependencies:
-    nanoid: ^2.1.0
-  checksum: 0790ce22fe20aacc226915160da178b5a6af7814d1796404684f6699b60f77e291d39ad3b6b2b4c6efcf5553e1deeee7e29a48b8f46955de1425e67ab934e309
-  languageName: node
-  linkType: hard
-
 "shx@npm:^0.3.3":
   version: 0.3.4
   resolution: "shx@npm:0.3.4"
@@ -16858,15 +16828,6 @@ __metadata:
   version: 4.0.2
   resolution: "signal-exit@npm:4.0.2"
   checksum: 41f5928431cc6e91087bf0343db786a6313dd7c6fd7e551dbc141c95bb5fb26663444fd9df8ea47c5d7fc202f60aa7468c3162a9365cbb0615fc5e1b1328fe31
-  languageName: node
-  linkType: hard
-
-"simple-swizzle@npm:^0.2.2":
-  version: 0.2.2
-  resolution: "simple-swizzle@npm:0.2.2"
-  dependencies:
-    is-arrayish: ^0.3.1
-  checksum: a7f3f2ab5c76c4472d5c578df892e857323e452d9f392e1b5cf74b74db66e6294a1e1b8b390b519fa1b96b5b613f2a37db6cffef52c3f1f8f3c5ea64eb2d54c0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This updates `@jbrowse/core` to v2.7.0, which includes some type changes to the session. This adds some type changes to match, and also refactors a bit so that internally everything is `ApolloSessionModel` by default, and we cast to `AbstractSessionModel` only when necessary.