### PR TITLE
Convert to zero-based coordinates on import

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 dist/
 .eslintrc.js
 esm/
+coverage/

--- a/packages/apollo-common/src/AssemblySpecificChange.ts
+++ b/packages/apollo-common/src/AssemblySpecificChange.ts
@@ -286,7 +286,7 @@ function createFeature(
     gffId: '',
     refSeq,
     type,
-    start,
+    start: start - 1,
     end,
   }
   if (gff3Feature.length > 1) {
@@ -329,7 +329,7 @@ function createFeature(
           }
         }
       }
-      return { start: subStart, end: subEnd, phase: parsedPhase }
+      return { start: subStart - 1, end: subEnd, phase: parsedPhase }
     })
   }
   if (strand) {

--- a/packages/jbrowse-plugin-apollo/src/ApolloTextSearchAdapter/ApolloTextSearchAdapter.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloTextSearchAdapter/ApolloTextSearchAdapter.ts
@@ -35,7 +35,9 @@ export class ApolloTextSearchAdapter
         new BaseResult({
           label: query,
           trackId: this.trackId,
-          locString: `${feature.refSeq?.name}:${feature.start}..${feature.end}`,
+          locString: `${feature.refSeq?.name}:${feature.start + 1}..${
+            feature.end
+          }`,
         }),
     )
   }

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
@@ -135,24 +135,26 @@ export abstract class Glyph {
       if (!lastLoc) {
         return
       }
-      start = lastLoc?.start
-      end = lastLoc?.end
-      length = lastLoc?.end - lastLoc?.start
+      ;({ start } = lastLoc)
+      ;({ end } = lastLoc)
+      length = lastLoc.end - lastLoc.start
 
       if (discontinuousLocations.length <= 2) {
         for (const [i, loc] of discontinuousLocations.entries()) {
-          location += `${loc.start.toString()}-${loc.end.toString()}`
+          location += `${loc.start + 1}–${loc.end}`
           if (i !== discontinuousLocations.length - 1) {
             location += ','
           }
         }
       } else {
         const [firstLoc] = discontinuousLocations
-        location += `${firstLoc.start}-${firstLoc.end},..,${start}-${end}`
+        location += `${firstLoc.start + 1}–${firstLoc.end},…,${
+          lastLoc.start + 1
+        }–${lastLoc.end}`
       }
     } else {
       ;({ end, length, start } = feature)
-      location += `${start.toString()}-${end.toString()}`
+      location += `${start + 1}–${end}`
     }
 
     let startPx =

--- a/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/Feature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/Feature.tsx
@@ -232,7 +232,7 @@ export const Feature = observer(function Feature({
                       changeManager,
                       feature,
                       discontinuousLocations[index].start,
-                      newStart,
+                      newStart - 1,
                       index,
                     )
                   }
@@ -248,7 +248,7 @@ export const Feature = observer(function Feature({
                   changeManager,
                   feature,
                   start,
-                  newStart,
+                  newStart - 1,
                 )
               }
             />

--- a/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/Feature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/Feature.tsx
@@ -225,7 +225,7 @@ export const Feature = observer(function Feature({
               {discontinuousLocations.map((loc, index) => (
                 <NumberCell
                   key={`${_id}:${loc.start},${loc.phase}`}
-                  initialValue={loc.start}
+                  initialValue={loc.start + 1}
                   notifyError={notifyError}
                   onChangeCommitted={(newStart) =>
                     handleFeatureStartChange(
@@ -241,7 +241,7 @@ export const Feature = observer(function Feature({
             </div>
           ) : (
             <NumberCell
-              initialValue={start}
+              initialValue={start + 1}
               notifyError={notifyError}
               onChangeCommitted={(newStart) =>
                 handleFeatureStartChange(

--- a/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/HybridGrid.tsx
+++ b/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/HybridGrid.tsx
@@ -71,7 +71,7 @@ const HybridGrid = observer(function HybridGrid({
         }
       }
     }
-  }, [selectedFeature, seenFeatures, classes.selectedFeature])
+}, [selectedFeature, seenFeatures, classes.selectedFeature])
 
   return (
     <div
@@ -106,6 +106,11 @@ const HybridGrid = observer(function HybridGrid({
             .map(([featureId, feature]) => {
               const isSelected = selectedFeature?._id === featureId
               const isHovered = apolloHover?.feature?._id === featureId
+              // Set zero-based coordination
+              // const newEnd = feature.end+1
+              // feature.setEnd(newEnd)
+              const newStart = feature.start+1
+              feature.setStart(newStart) 
               return (
                 <Feature
                   key={featureId}

--- a/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/HybridGrid.tsx
+++ b/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/HybridGrid.tsx
@@ -106,11 +106,6 @@ const HybridGrid = observer(function HybridGrid({
             .map(([featureId, feature]) => {
               const isSelected = selectedFeature?._id === featureId
               const isHovered = apolloHover?.feature?._id === featureId
-              // Set zero-based coordination
-              // const newEnd = feature.end+1
-              // feature.setEnd(newEnd)
-              const newStart = feature.start+1
-              feature.setStart(newStart) 
               return (
                 <Feature
                   key={featureId}

--- a/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/HybridGrid.tsx
+++ b/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/HybridGrid.tsx
@@ -71,7 +71,7 @@ const HybridGrid = observer(function HybridGrid({
         }
       }
     }
-}, [selectedFeature, seenFeatures, classes.selectedFeature])
+  }, [selectedFeature, seenFeatures, classes.selectedFeature])
 
   return (
     <div

--- a/packages/jbrowse-plugin-apollo/src/components/AddChildFeature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/AddChildFeature.tsx
@@ -46,7 +46,7 @@ export function AddChildFeature({
 }: AddChildFeatureProps) {
   const { notify } = session as unknown as AbstractSessionModel
   const [end, setEnd] = useState(String(sourceFeature.end))
-  const [start, setStart] = useState(String(sourceFeature.start))
+  const [start, setStart] = useState(String(sourceFeature.start + 1))
   const [type, setType] = useState('')
   const [phase, setPhase] = useState('')
   const [phaseAsNumber, setPhaseAsNumber] = useState<PhaseEnum>()
@@ -102,7 +102,7 @@ export function AddChildFeature({
         _id: new ObjectID().toHexString(),
         gffId: '',
         refSeq: sourceFeature.refSeq,
-        start: Number(start),
+        start: Number(start) - 1,
         end: Number(end),
         type,
         phase: phaseAsNumber,

--- a/packages/jbrowse-plugin-apollo/src/components/AddFeature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/AddFeature.tsx
@@ -42,7 +42,7 @@ export function AddFeature({
 }: AddFeatureProps) {
   const { notify } = session as unknown as AbstractSessionModel
   const [end, setEnd] = useState(String(region.end))
-  const [start, setStart] = useState(String(region.start))
+  const [start, setStart] = useState(String(region.start + 1))
   const [type, setType] = useState('')
   const [phase, setPhase] = useState('')
   const [strand, setStrand] = useState<1 | -1 | undefined>()
@@ -83,7 +83,7 @@ export function AddFeature({
         _id: id,
         gffId: '',
         refSeq: refSeqId,
-        start: Number(start),
+        start: Number(start) - 1,
         end: Number(end),
         type,
         phase: phaseAsNumber,
@@ -169,7 +169,7 @@ export function AddFeature({
             type="number"
             fullWidth
             variant="outlined"
-            value={Number(start)+1}
+            value={Number(start)}
             onChange={(e) => setStart(e.target.value)}
           />
           <TextField

--- a/packages/jbrowse-plugin-apollo/src/components/AddFeature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/AddFeature.tsx
@@ -169,7 +169,8 @@ export function AddFeature({
             type="number"
             fullWidth
             variant="outlined"
-            value={start}
+            value={Number(start)+1}
+            // value={start}
             onChange={(e) => setStart(e.target.value)}
           />
           <TextField

--- a/packages/jbrowse-plugin-apollo/src/components/AddFeature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/AddFeature.tsx
@@ -170,7 +170,6 @@ export function AddFeature({
             fullWidth
             variant="outlined"
             value={Number(start)+1}
-            // value={start}
             onChange={(e) => setStart(e.target.value)}
           />
           <TextField

--- a/packages/jbrowse-plugin-apollo/src/components/OpenLocalFile.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/OpenLocalFile.tsx
@@ -263,7 +263,7 @@ function createFeature(gff3Feature: GFF3Feature): AnnotationFeatureSnapshot {
     gffId: '',
     refSeq: refName,
     type,
-    start,
+    start: start - 1,
     end,
   }
   if (gff3Feature.length > 1) {
@@ -297,7 +297,7 @@ function createFeature(gff3Feature: GFF3Feature): AnnotationFeatureSnapshot {
           }
         }
       }
-      return { start: subStart, end: subEnd, phase: parsedPhase }
+      return { start: subStart - 1, end: subEnd, phase: parsedPhase }
     })
   }
   if (strand) {


### PR DESCRIPTION
Here's a handy cheat sheet for dealing with one-based vs zero-based files: https://www.biostars.org/p/84686/

Internally JBrowse uses zero-based coordinates, but GFF3 uses one-based coordinates, and since we didn't do any conversion, we ended up with this mismatch that @dariober noted in this image:

![image](https://github.com/GMOD/Apollo3/assets/25592344/1b81570d-96a6-4974-95db-a5fbf709270b)

My first thought is that we should make the change in this PR so that the database is also zero-based, but if someone has a reason to keep the database the same and convert elsewhere, I'm certainly willing to listen.

@kyostiebi, does this change affect your CDS check calculations? Are there any other places this might have an effect you can think of?

Fixes #267