### PR TITLE
Adds "loading" and "no data" messages to graphical and tabular displays when relevant

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/LinearApolloDisplay.tsx
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/LinearApolloDisplay.tsx
@@ -1,5 +1,6 @@
 import { Menu, MenuItem } from '@jbrowse/core/ui'
-import { getContainingView } from '@jbrowse/core/util'
+import { getContainingView, getSession } from '@jbrowse/core/util'
+import LoadingEllipses from '@jbrowse/core/ui/LoadingEllipses'
 import type { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
 import { Alert, Tooltip, useTheme } from '@mui/material'
 import { observer } from 'mobx-react'
@@ -13,7 +14,7 @@ interface LinearApolloDisplayProps {
 }
 export type Coord = [number, number]
 
-const useStyles = makeStyles()({
+const useStyles = makeStyles()((theme) => ({
   canvasContainer: {
     position: 'relative',
     left: 0,
@@ -26,7 +27,18 @@ const useStyles = makeStyles()({
     textOverflow: 'ellipsis',
     overflow: 'hidden',
   },
-})
+  loading: {
+    backgroundColor: theme.palette.background.default,
+    backgroundImage: `repeating-linear-gradient(45deg, transparent, transparent 5px, ${theme.palette.action.disabledBackground} 5px, ${theme.palette.action.disabledBackground} 10px)`,
+    position: 'absolute',
+    height: 50,
+    width: 300,
+    right: 0,
+    zIndex: 10,
+    pointerEvents: 'none',
+    textAlign: 'center',
+  },
+}))
 
 export const LinearApolloDisplay = observer(function LinearApolloDisplay(
   props: LinearApolloDisplayProps,
@@ -55,10 +67,13 @@ export const LinearApolloDisplay = observer(function LinearApolloDisplay(
   useEffect(() => setTheme(theme), [theme, setTheme])
   const [contextCoord, setContextCoord] = useState<Coord>()
   const [contextMenuItems, setContextMenuItems] = useState<MenuItem[]>([])
+  const { loadingRegions } = getSession(model).apolloDataStore
   const message = regionCannotBeRendered()
+
   if (!isShown) {
     return null
   }
+
   return (
     <div
       className={classes.canvasContainer}
@@ -75,6 +90,11 @@ export const LinearApolloDisplay = observer(function LinearApolloDisplay(
         }
       }}
     >
+      { loadingRegions ? (
+        <div className={classes.loading}>
+          <LoadingEllipses />
+        </div>
+      ) : null}
       {message ? (
         <Alert severity="warning" classes={{ message: classes.ellipses }}>
           <Tooltip title={message}>

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/base.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/base.ts
@@ -130,7 +130,7 @@ export function baseModelFactory(
               }
               self.session.apolloDataStore.loadFeatures(self.regions)
             },
-            { name: 'LinearApolloDisplayLoadFeatures', delay: 1000 },
+            { name: 'LinearApolloDisplayLoadFeatures' },
           ),
         )
       },

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/rendering.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/rendering.ts
@@ -1,5 +1,6 @@
 import { AnyConfigurationSchemaType } from '@jbrowse/core/configuration/configurationSchema'
 import PluginManager from '@jbrowse/core/PluginManager'
+import { getSession } from '@jbrowse/core/util'
 import { doesIntersect2 } from '@jbrowse/core/util'
 import { Theme } from '@mui/material'
 import { autorun } from 'mobx'
@@ -157,6 +158,10 @@ export function renderingModelFactory(
             )
             for (const [idx, featureLayout] of self.featureLayouts.entries()) {
               const displayedRegion = self.displayedRegions[idx]
+              if (featureLayout.size === 0) {
+                // loading cancelled if there is nothing to display
+                getSession(self).apolloSetLoadingRegions(false)
+              }
               for (const [row, featureLayoutRow] of featureLayout.entries()) {
                 for (const [featureRow, feature] of featureLayoutRow) {
                   if (featureRow > 0) {
@@ -186,6 +191,10 @@ export function renderingModelFactory(
                     row,
                     displayedRegion.reversed,
                   )
+                  if (feature.gffId === getSession(self).apolloDataStore.lastFeat.gffId) {
+                    // ensures the loading message is dismissed when the last feature to load is drawn
+                    getSession(self).apolloSetLoadingRegions(false)
+                  }
                 }
               }
             }

--- a/packages/jbrowse-plugin-apollo/src/session/ClientDataStore.ts
+++ b/packages/jbrowse-plugin-apollo/src/session/ClientDataStore.ts
@@ -104,6 +104,8 @@ export function clientDataStoreFactory(
         self as unknown as ClientDataStoreType,
       ),
       ontologyManager: OntologyManagerType.create(),
+      loadingRegions: false,
+      lastFeat: {}
     }))
     .actions((self) => ({
       afterCreate() {
@@ -188,10 +190,17 @@ export function clientDataStoreFactory(
         }
         return internetAccount
       },
+      setLoadingRegions(state: boolean) {
+        self.loadingRegions = state
+      },
+      setLastFeat(feat: Region) {
+        self.lastFeat = feat
+      }
     }))
     .actions((self) => ({
       loadFeatures: flow(function* loadFeatures(regions: Region[]) {
         for (const region of regions) {
+          self.setLoadingRegions(true)
           const backendDriver = self.getBackendDriver(region.assemblyName)
           const features = (yield backendDriver.getFeatures(
             region,
@@ -199,6 +208,7 @@ export function clientDataStoreFactory(
           if (features.length === 0) {
             continue
           }
+          self.setLastFeat(features.slice(-1)[0] as unknown as Region)
           const { assemblyName, refName } = region
           let assembly = self.assemblies.get(assemblyName)
           if (!assembly) {

--- a/packages/jbrowse-plugin-apollo/src/session/session.ts
+++ b/packages/jbrowse-plugin-apollo/src/session/session.ts
@@ -22,6 +22,7 @@ export interface ApolloSession extends AbstractSessionModel {
   apolloDataStore: ClientDataStoreType & { changeManager: ChangeManager }
   apolloSelectedFeature?: AnnotationFeatureI
   apolloSetSelectedFeature(feature?: AnnotationFeatureI): void
+  apolloSetLoadingRegions(loading?: boolean): void
 }
 
 interface ApolloAssemblyResponse {
@@ -95,6 +96,9 @@ export function extendSession(
     .actions((self) => ({
       apolloSetSelectedFeature(feature?: AnnotationFeatureI) {
         self.apolloSelectedFeature = feature
+      },
+      apolloSetLoadingRegions(loading?: boolean) {
+        self.apolloDataStore.setLoadingRegions(loading)
       },
       addApolloTrackConfig(assembly: AssemblyModel, baseURL?: string) {
         const trackId = `apollo_track_${assembly.name}`


### PR DESCRIPTION
resolves https://github.com/GMOD/Apollo3/issues/286

## summary of changes
- adds loading bar to graphical and tabular displays when data is loading and glyphs are being drawn, these messages are dismissed based on when the last loaded element has been drawn in the autorun
- ⚠️ adds filtering to the "seenFeatures" for the tabular display such that what is written in the table is the same as what can be seen in the graphical display -- **needs review**
- adds a "no data" message when there is no data to be displayed in the tabular view -- that is, that there is nothing drawn on the graphical display