### PR TITLE
Fix CDS with discontinuous locations coordinate change not saving to DB

### DIFF
--- a/packages/apollo-shared/src/Changes/DiscontinuousLocationEndChange.ts
+++ b/packages/apollo-shared/src/Changes/DiscontinuousLocationEndChange.ts
@@ -117,7 +117,7 @@ export class DiscontinuousLocationEndChange extends FeatureChange {
       }
 
       try {
-        topLevelFeature.markModified('discontinuousLocations')
+        topLevelFeature.markModified('children')
         await topLevelFeature.save()
       } catch (error) {
         logger.debug?.(`*** FAILED: ${error}`)

--- a/packages/apollo-shared/src/Changes/DiscontinuousLocationEndChange.ts
+++ b/packages/apollo-shared/src/Changes/DiscontinuousLocationEndChange.ts
@@ -117,7 +117,11 @@ export class DiscontinuousLocationEndChange extends FeatureChange {
       }
 
       try {
-        topLevelFeature.markModified('children')
+        if (topLevelFeature._id.equals(feature._id)) {
+          topLevelFeature.markModified('discontinuousLocations')
+        } else {
+          topLevelFeature.markModified('children')
+        }
         await topLevelFeature.save()
       } catch (error) {
         logger.debug?.(`*** FAILED: ${error}`)

--- a/packages/apollo-shared/src/Changes/DiscontinuousLocationStartChange.ts
+++ b/packages/apollo-shared/src/Changes/DiscontinuousLocationStartChange.ts
@@ -117,7 +117,11 @@ export class DiscontinuousLocationStartChange extends FeatureChange {
       }
 
       try {
-        topLevelFeature.markModified('children')
+        if (topLevelFeature._id.equals(feature._id)) {
+          topLevelFeature.markModified('discontinuousLocations')
+        } else {
+          topLevelFeature.markModified('children')
+        }
         await topLevelFeature.save()
       } catch (error) {
         logger.debug?.(`*** FAILED: ${error}`)

--- a/packages/apollo-shared/src/Changes/DiscontinuousLocationStartChange.ts
+++ b/packages/apollo-shared/src/Changes/DiscontinuousLocationStartChange.ts
@@ -117,7 +117,7 @@ export class DiscontinuousLocationStartChange extends FeatureChange {
       }
 
       try {
-        topLevelFeature.markModified('discontinuousLocations')
+        topLevelFeature.markModified('children')
         await topLevelFeature.save()
       } catch (error) {
         logger.debug?.(`*** FAILED: ${error}`)

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
@@ -147,7 +147,8 @@ export abstract class Glyph {
           }
         }
       } else {
-        location += `${feature.start}-${feature.end},..,${start}-${end}`
+        const [firstLoc] = discontinuousLocations
+        location += `${firstLoc.start}-${firstLoc.end},..,${start}-${end}`
       }
     } else {
       ;({ end, length, start } = feature)


### PR DESCRIPTION
### Description

- When we change CDS coordinate, the change is applied to the client but not to the server. It looks like we can't directly mark the attribute name as modified in mongoose due to which save isn't working as expected.
- Small fix in the tooltip to display discontinuous location coordinates correctly.