### PR TITLE
Simplify login to only a single endpoint

### DIFF
--- a/docker/config/config.json
+++ b/docker/config/config.json
@@ -30,15 +30,7 @@
       "name": "Demo Server",
       "description": "A server hosting a small fictional organism to demonstrate Apollo capabilities",
       "domains": ["localhost:3999"],
-      "baseURL": "http://localhost:3999",
-      "google": {
-        "authEndpoint": "http://localhost:3999/auth/google" ,
-        "clientId": "1054515969695-3hpfg1gd0ld3sgj135kfgikolu86vv30.apps.googleusercontent.com"
-      },
-      "microsoft": {
-        "authEndpoint": "http://localhost:3999/auth/microsoft" ,
-        "clientId": "fabdd045-163c-4712-9d40-dbbb043b3090"
-      }
+      "baseURL": "http://localhost:3999"
     }
   ],
   "defaultSession": {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -144,7 +144,7 @@ up authentication with Google and get those values.
   `http://example.com`
 - Enter the following as an authorized redirect URI, replacing the `example.com`
   with the correct value for your URL:
-  `http://example.com:3999/auth/google/redirect`
+  `http://example.com:3999/auth/google`
 - Click "Create"
 - Take note of Client ID and Client secret listed
 
@@ -152,26 +152,6 @@ Now that you have the client ID and secret, you'll need to add them to your
 `apollo.env` file. There are placeholders in the file for these in the file, so
 you'll need to uncomment those lines (remove the `# ` from the beginning) and
 fill in the correct values for `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`.
-Then you'll also need to edit `config.json` as well. In the "internetAccounts"
-section, add an auth endpoint and the client ID so that it looks like this:
-
-```json
-{
-  "internetAccounts": [
-    {
-      "type": "ApolloInternetAccount",
-      "internetAccountId": "apolloInternetAccount",
-      "name": "Apollo Server",
-      "description": "Apollo server for my organization",
-      "baseURL": "http://example.com:3999",
-      "google": {
-        "authEndpoint": "http://example.com:3999/auth/google",
-        "clientId": "1054515969789-3hpfg1gd0ld3sgj135kfgikolu86vv30.apps.googleusercontent.com"
-      }
-    }
-  ]
-}
-```
 
 Now restart the Docker Compose stack and re-copy `config.json` by running
 

--- a/packages/apollo-collaboration-server/src/utils/google.guard.ts
+++ b/packages/apollo-collaboration-server/src/utils/google.guard.ts
@@ -5,11 +5,13 @@ import { AuthGuard, IAuthModuleOptions } from '@nestjs/passport'
 export class GoogleAuthGuard extends AuthGuard('google') {
   getAuthenticateOptions(
     context: ExecutionContext,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ): IAuthModuleOptions<any> | undefined {
+  ): IAuthModuleOptions | undefined {
     const [req] = context.getArgs()
-    const urlSearchParams = new URLSearchParams(req.originalUrl)
-    const appURL = urlSearchParams.get('state')
-    return { state: { appURL } }
+    const { query } = req
+    const redirectUri = query.redirect_uri
+    if (redirectUri) {
+      return { state: { redirect_uri: redirectUri } }
+    }
+    return
   }
 }

--- a/packages/apollo-collaboration-server/src/utils/microsoft.guard.ts
+++ b/packages/apollo-collaboration-server/src/utils/microsoft.guard.ts
@@ -5,11 +5,13 @@ import { AuthGuard, IAuthModuleOptions } from '@nestjs/passport'
 export class MicrosoftAuthGuard extends AuthGuard('microsoft') {
   getAuthenticateOptions(
     context: ExecutionContext,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ): IAuthModuleOptions<any> | undefined {
+  ): IAuthModuleOptions | undefined {
     const [req] = context.getArgs()
-    const urlSearchParams = new URLSearchParams(req.originalUrl)
-    const appURL = urlSearchParams.get('state')
-    return { state: { appURL } }
+    const { query } = req
+    const redirectUri = query.redirect_uri
+    if (redirectUri) {
+      return { state: { redirect_uri: redirectUri } }
+    }
+    return
   }
 }

--- a/packages/apollo-collaboration-server/src/utils/strategies/google.strategy.ts
+++ b/packages/apollo-collaboration-server/src/utils/strategies/google.strategy.ts
@@ -54,7 +54,7 @@ export class GoogleStrategy extends PassportStrategy(Strategy) {
       callbackURI.port = String(port)
       callbackURI.pathname = `${callbackURI.pathname}${
         callbackURI.pathname.endsWith('/') ? '' : '/'
-      }auth/google/redirect`
+      }auth/google`
       callbackURL = callbackURI.href
     }
     super({

--- a/packages/apollo-collaboration-server/src/utils/strategies/microsoft.strategy.ts
+++ b/packages/apollo-collaboration-server/src/utils/strategies/microsoft.strategy.ts
@@ -64,7 +64,7 @@ export class MicrosoftStrategy extends PassportStrategy(Strategy) {
       callbackURI.port = String(port)
       callbackURI.pathname = `${callbackURI.pathname}${
         callbackURI.pathname.endsWith('/') ? '' : '/'
-      }auth/microsoft/redirect`
+      }auth/microsoft`
       callbackURL = callbackURI.href
     }
     super({

--- a/packages/jbrowse-plugin-apollo/cypress/fixtures/apollo_view.json
+++ b/packages/jbrowse-plugin-apollo/cypress/fixtures/apollo_view.json
@@ -30,15 +30,7 @@
       "name": "Demo Server",
       "description": "A server hosting a small fictional organism to demonstrate Apollo capabilities",
       "domains": ["localhost:3999"],
-      "baseURL": "http://localhost:3999",
-      "google": {
-        "authEndpoint": "http://localhost:3999/auth/google" ,
-        "clientId": "1054515969695-3hpfg1gd0ld3sgj135kfgikolu86vv30.apps.googleusercontent.com"
-      },
-      "microsoft": {
-        "authEndpoint": "http://localhost:3999/auth/microsoft" ,
-        "clientId": "fabdd045-163c-4712-9d40-dbbb043b3090"
-      }
+      "baseURL": "http://localhost:3999"
     }
   ],
   "defaultSession": {

--- a/packages/jbrowse-plugin-apollo/jbrowse_config.json
+++ b/packages/jbrowse-plugin-apollo/jbrowse_config.json
@@ -52,15 +52,7 @@
       "name": "Demo Server",
       "description": "A server hosting a small fictional organism to demonstrate Apollo capabilities",
       "domains": ["localhost:3999"],
-      "baseURL": "http://localhost:3999",
-      "google": {
-        "authEndpoint": "http://localhost:3999/auth/google" ,
-        "clientId": "1054515969695-3hpfg1gd0ld3sgj135kfgikolu86vv30.apps.googleusercontent.com"
-      },
-      "microsoft": {
-        "authEndpoint": "http://localhost:3999/auth/microsoft" ,
-        "clientId": "fabdd045-163c-4712-9d40-dbbb043b3090"
-      }
+      "baseURL": "http://localhost:3999"
     }
   ],
   "defaultSession": {

--- a/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/addMenuItems.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/addMenuItems.ts
@@ -1,0 +1,142 @@
+import PluginManager from '@jbrowse/core/PluginManager'
+import { MenuItem } from '@jbrowse/core/ui'
+import { AbstractSessionModel, isAbstractMenuManager } from '@jbrowse/core/util'
+
+import {
+  AddAssembly,
+  DeleteAssembly,
+  ImportFeatures,
+  ManageUsers,
+} from '../components'
+import { ApolloSessionModel } from '../session'
+
+interface Menu {
+  label: string
+  menuItems: MenuItem[]
+}
+
+export type Role = 'admin' | 'user' | 'readOnly'
+
+export function addMenuItems(pluginManager: PluginManager, role: Role) {
+  if (!(role === 'admin' && isAbstractMenuManager(pluginManager.rootModel))) {
+    return
+  }
+  const { rootModel } = pluginManager
+  const { menus } = rootModel as unknown as { menus: Menu[] }
+  // Find 'Apollo' menu and its items
+  const apolloMenu = menus.find((menu) => {
+    return menu.label === 'Apollo'
+  })
+  if (!apolloMenu) {
+    return
+  }
+  const { menuItems } = apolloMenu
+  if (
+    !menuItems.some(
+      (menuItem) => 'label' in menuItem && menuItem.label === 'Add Assembly',
+    )
+  ) {
+    rootModel.insertInMenu(
+      'Apollo',
+      {
+        label: 'Add Assembly',
+        onClick: (session: ApolloSessionModel) => {
+          ;(session as unknown as AbstractSessionModel).queueDialog(
+            (doneCallback) => [
+              AddAssembly,
+              {
+                session,
+                handleClose: () => {
+                  doneCallback()
+                },
+                changeManager: session.apolloDataStore.changeManager,
+              },
+            ],
+          )
+        },
+      },
+      0,
+    )
+    rootModel.insertInMenu(
+      'Apollo',
+      {
+        label: 'Delete Assembly',
+        onClick: (session: ApolloSessionModel) => {
+          ;(session as unknown as AbstractSessionModel).queueDialog(
+            (doneCallback) => [
+              DeleteAssembly,
+              {
+                session,
+                handleClose: () => {
+                  doneCallback()
+                },
+                changeManager: session.apolloDataStore.changeManager,
+              },
+            ],
+          )
+        },
+      },
+      1,
+    )
+    rootModel.insertInMenu(
+      'Apollo',
+      {
+        label: 'Import Features',
+        onClick: (session: ApolloSessionModel) => {
+          ;(session as unknown as AbstractSessionModel).queueDialog(
+            (doneCallback) => [
+              ImportFeatures,
+              {
+                session,
+                handleClose: () => {
+                  doneCallback()
+                },
+                changeManager: (session as ApolloSessionModel).apolloDataStore
+                  .changeManager,
+              },
+            ],
+          )
+        },
+      },
+      2,
+    )
+    rootModel.insertInMenu(
+      'Apollo',
+      {
+        label: 'Manage Users',
+        onClick: (session: ApolloSessionModel) => {
+          ;(session as unknown as AbstractSessionModel).queueDialog(
+            (doneCallback) => [
+              ManageUsers,
+              {
+                session,
+                handleClose: () => {
+                  doneCallback()
+                },
+                changeManager: (session as ApolloSessionModel).apolloDataStore
+                  .changeManager,
+              },
+            ],
+          )
+        },
+      },
+      9,
+    )
+    rootModel.insertInMenu(
+      'Apollo',
+      {
+        label: 'Undo',
+        onClick: (session: ApolloSessionModel) => {
+          const { apolloDataStore } = session
+          const { notify } = session as unknown as AbstractSessionModel
+          if (apolloDataStore.changeManager.recentChanges.length > 0) {
+            void apolloDataStore.changeManager.revertLastChange()
+          } else {
+            notify('No changes to undo', 'info')
+          }
+        },
+      },
+      10,
+    )
+  }
+}

--- a/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/addMenuItems.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/addMenuItems.ts
@@ -1,6 +1,4 @@
-import PluginManager from '@jbrowse/core/PluginManager'
-import { MenuItem } from '@jbrowse/core/ui'
-import { AbstractSessionModel, isAbstractMenuManager } from '@jbrowse/core/util'
+import { AbstractMenuManager, AbstractSessionModel } from '@jbrowse/core/util'
 
 import {
   AddAssembly,
@@ -10,133 +8,87 @@ import {
 } from '../components'
 import { ApolloSessionModel } from '../session'
 
-interface Menu {
-  label: string
-  menuItems: MenuItem[]
-}
-
-export type Role = 'admin' | 'user' | 'readOnly'
-
-export function addMenuItems(pluginManager: PluginManager, role: Role) {
-  if (!(role === 'admin' && isAbstractMenuManager(pluginManager.rootModel))) {
-    return
-  }
-  const { rootModel } = pluginManager
-  const { menus } = rootModel as unknown as { menus: Menu[] }
-  // Find 'Apollo' menu and its items
-  const apolloMenu = menus.find((menu) => {
-    return menu.label === 'Apollo'
+export function addMenuItems(rootModel: AbstractMenuManager) {
+  rootModel.appendToMenu('Apollo', {
+    label: 'Add Assembly',
+    onClick: (session: ApolloSessionModel) => {
+      ;(session as unknown as AbstractSessionModel).queueDialog(
+        (doneCallback) => [
+          AddAssembly,
+          {
+            session,
+            handleClose: () => {
+              doneCallback()
+            },
+            changeManager: session.apolloDataStore.changeManager,
+          },
+        ],
+      )
+    },
   })
-  if (!apolloMenu) {
-    return
-  }
-  const { menuItems } = apolloMenu
-  if (
-    !menuItems.some(
-      (menuItem) => 'label' in menuItem && menuItem.label === 'Add Assembly',
-    )
-  ) {
-    rootModel.insertInMenu(
-      'Apollo',
-      {
-        label: 'Add Assembly',
-        onClick: (session: ApolloSessionModel) => {
-          ;(session as unknown as AbstractSessionModel).queueDialog(
-            (doneCallback) => [
-              AddAssembly,
-              {
-                session,
-                handleClose: () => {
-                  doneCallback()
-                },
-                changeManager: session.apolloDataStore.changeManager,
-              },
-            ],
-          )
-        },
-      },
-      0,
-    )
-    rootModel.insertInMenu(
-      'Apollo',
-      {
-        label: 'Delete Assembly',
-        onClick: (session: ApolloSessionModel) => {
-          ;(session as unknown as AbstractSessionModel).queueDialog(
-            (doneCallback) => [
-              DeleteAssembly,
-              {
-                session,
-                handleClose: () => {
-                  doneCallback()
-                },
-                changeManager: session.apolloDataStore.changeManager,
-              },
-            ],
-          )
-        },
-      },
-      1,
-    )
-    rootModel.insertInMenu(
-      'Apollo',
-      {
-        label: 'Import Features',
-        onClick: (session: ApolloSessionModel) => {
-          ;(session as unknown as AbstractSessionModel).queueDialog(
-            (doneCallback) => [
-              ImportFeatures,
-              {
-                session,
-                handleClose: () => {
-                  doneCallback()
-                },
-                changeManager: (session as ApolloSessionModel).apolloDataStore
-                  .changeManager,
-              },
-            ],
-          )
-        },
-      },
-      2,
-    )
-    rootModel.insertInMenu(
-      'Apollo',
-      {
-        label: 'Manage Users',
-        onClick: (session: ApolloSessionModel) => {
-          ;(session as unknown as AbstractSessionModel).queueDialog(
-            (doneCallback) => [
-              ManageUsers,
-              {
-                session,
-                handleClose: () => {
-                  doneCallback()
-                },
-                changeManager: (session as ApolloSessionModel).apolloDataStore
-                  .changeManager,
-              },
-            ],
-          )
-        },
-      },
-      9,
-    )
-    rootModel.insertInMenu(
-      'Apollo',
-      {
-        label: 'Undo',
-        onClick: (session: ApolloSessionModel) => {
-          const { apolloDataStore } = session
-          const { notify } = session as unknown as AbstractSessionModel
-          if (apolloDataStore.changeManager.recentChanges.length > 0) {
-            void apolloDataStore.changeManager.revertLastChange()
-          } else {
-            notify('No changes to undo', 'info')
-          }
-        },
-      },
-      10,
-    )
-  }
+  rootModel.appendToMenu('Apollo', {
+    label: 'Delete Assembly',
+    onClick: (session: ApolloSessionModel) => {
+      ;(session as unknown as AbstractSessionModel).queueDialog(
+        (doneCallback) => [
+          DeleteAssembly,
+          {
+            session,
+            handleClose: () => {
+              doneCallback()
+            },
+            changeManager: session.apolloDataStore.changeManager,
+          },
+        ],
+      )
+    },
+  })
+  rootModel.appendToMenu('Apollo', {
+    label: 'Import Features',
+    onClick: (session: ApolloSessionModel) => {
+      ;(session as unknown as AbstractSessionModel).queueDialog(
+        (doneCallback) => [
+          ImportFeatures,
+          {
+            session,
+            handleClose: () => {
+              doneCallback()
+            },
+            changeManager: (session as ApolloSessionModel).apolloDataStore
+              .changeManager,
+          },
+        ],
+      )
+    },
+  })
+  rootModel.appendToMenu('Apollo', {
+    label: 'Manage Users',
+    onClick: (session: ApolloSessionModel) => {
+      ;(session as unknown as AbstractSessionModel).queueDialog(
+        (doneCallback) => [
+          ManageUsers,
+          {
+            session,
+            handleClose: () => {
+              doneCallback()
+            },
+            changeManager: (session as ApolloSessionModel).apolloDataStore
+              .changeManager,
+          },
+        ],
+      )
+    },
+  })
+  rootModel.appendToMenu('Apollo', {
+    label: 'Undo',
+    onClick: (session: ApolloSessionModel) => {
+      const { apolloDataStore } = session
+      const { notify } = session as unknown as AbstractSessionModel
+      if (apolloDataStore.changeManager.recentChanges.length > 0) {
+        void apolloDataStore.changeManager.revertLastChange()
+      } else {
+        notify('No changes to undo', 'info')
+      }
+    },
+  })
 }

--- a/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/configSchema.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/configSchema.ts
@@ -26,20 +26,10 @@ const ApolloConfigSchema = ConfigurationSchema(
         type: 'string',
         defaultValue: '',
       },
-      clientId: {
-        description: 'id for the OAuth application',
-        type: 'string',
-        defaultValue: '',
-      },
     }),
     microsoft: ConfigurationSchema('ApolloMicrosoftInternetAccount', {
       authEndpoint: {
         description: 'the authorization code endpoint of the internet account',
-        type: 'string',
-        defaultValue: '',
-      },
-      clientId: {
-        description: 'id for the OAuth application',
         type: 'string',
         defaultValue: '',
       },

--- a/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/configSchema.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/configSchema.ts
@@ -15,25 +15,6 @@ const ApolloConfigSchema = ConfigurationSchema(
       type: 'string',
       defaultValue: 'Bearer',
     },
-    allowGuestUser: {
-      description: 'Whether to allow a guest user who does not have to log in',
-      type: 'boolean',
-      defaultValue: true,
-    },
-    google: ConfigurationSchema('ApolloGoogleInternetAccount', {
-      authEndpoint: {
-        description: 'the authorization code endpoint of the internet account',
-        type: 'string',
-        defaultValue: '',
-      },
-    }),
-    microsoft: ConfigurationSchema('ApolloMicrosoftInternetAccount', {
-      authEndpoint: {
-        description: 'the authorization code endpoint of the internet account',
-        type: 'string',
-        defaultValue: '',
-      },
-    }),
   },
   { baseConfiguration: BaseInternetAccountConfig, explicitlyTyped: true },
 )

--- a/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
@@ -63,14 +63,8 @@ const stateModelFactory = (
       configuration: ConfigurationReference(configSchema),
     })
     .views((self) => ({
-      get googleClientId(): string {
-        return getConf(self, ['google', 'clientId'])
-      },
       get googleAuthEndpoint(): string {
         return getConf(self, ['google', 'authEndpoint'])
-      },
-      get microsoftClientId(): string {
-        return getConf(self, ['microsoft', 'clientId'])
       },
       get microsoftAuthEndpoint(): string {
         return getConf(self, ['microsoft', 'authEndpoint'])
@@ -502,13 +496,6 @@ const stateModelFactory = (
       googleAuthInternetAccount: OAuthInternetAccountModelFactory(
         OAuthConfigSchema,
       )
-        .views(() => ({
-          state() {
-            return (
-              window.location.origin + window.location.pathname.slice(0, -1)
-            )
-          },
-        }))
         .actions((s) => {
           const superStoreToken = s.storeToken
           return {
@@ -527,19 +514,11 @@ const stateModelFactory = (
             description: `${self.description}-apolloGoogle`,
             domains: self.domains,
             authEndpoint: self.googleAuthEndpoint,
-            clientId: self.googleClientId,
           },
         }),
       microsoftAuthInternetAccount: OAuthInternetAccountModelFactory(
         OAuthConfigSchema,
       )
-        .views(() => ({
-          state() {
-            return (
-              window.location.origin + window.location.pathname.slice(0, -1)
-            )
-          },
-        }))
         .actions((s) => {
           const superStoreToken = s.storeToken
           return {
@@ -558,7 +537,6 @@ const stateModelFactory = (
             description: `${self.description}-apolloMicrosoft`,
             domains: self.domains,
             authEndpoint: self.microsoftAuthEndpoint,
-            clientId: self.microsoftClientId,
           },
         }),
     }))
@@ -612,10 +590,10 @@ const stateModelFactory = (
           ): Promise<Response> => {
             let { authType } = self
             const {
+              googleAuthEndpoint,
               googleAuthInternetAccount,
-              googleClientId,
+              microsoftAuthEndpoint,
               microsoftAuthInternetAccount,
-              microsoftClientId,
             } = self
             if (!authType) {
               if (!authTypePromise) {
@@ -649,8 +627,8 @@ const stateModelFactory = (
                             }
                             doneCallback()
                           },
-                          google: Boolean(googleClientId),
-                          microsoft: Boolean(microsoftClientId),
+                          google: Boolean(googleAuthEndpoint),
+                          microsoft: Boolean(microsoftAuthEndpoint),
                           allowGuestUser,
                         },
                       ],

--- a/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
@@ -1,13 +1,7 @@
 import { ConfigurationReference, getConf } from '@jbrowse/core/configuration'
 import { InternetAccount } from '@jbrowse/core/pluggableElementTypes'
 import PluginManager from '@jbrowse/core/PluginManager'
-import { MenuItem } from '@jbrowse/core/ui'
-import {
-  AbstractSessionModel,
-  UriLocation,
-  isAbstractMenuManager,
-} from '@jbrowse/core/util'
-import type AuthenticationPlugin from '@jbrowse/plugin-authentication'
+import { AbstractSessionModel, isElectron } from '@jbrowse/core/util'
 import { Change } from 'apollo-common'
 import {
   ChangeMessage,
@@ -22,26 +16,14 @@ import { autorun } from 'mobx'
 import { Instance, flow, getRoot, types } from 'mobx-state-tree'
 import { io } from 'socket.io-client'
 
-import {
-  AddAssembly,
-  DeleteAssembly,
-  ImportFeatures,
-  ManageUsers,
-} from '../components'
 import { ApolloSessionModel, Collaborator } from '../session'
 import { ApolloRootModel } from '../types'
 import { createFetchErrorMessage } from '../util'
+import { Role, addMenuItems } from './addMenuItems'
 import { AuthTypeSelector } from './components/AuthTypeSelector'
 import { ApolloInternetAccountConfigModel } from './configSchema'
 
-interface Menu {
-  label: string
-  menuItems: MenuItem[]
-}
-
 type AuthType = 'google' | 'microsoft' | 'guest'
-
-type Role = 'admin' | 'user' | 'readOnly'
 
 const inWebWorker = typeof sessionStorage === 'undefined'
 
@@ -49,34 +31,14 @@ const stateModelFactory = (
   configSchema: ApolloInternetAccountConfigModel,
   pluginManager: PluginManager,
 ) => {
-  const AuthPlugin = pluginManager.getPlugin('AuthenticationPlugin') as
-    | AuthenticationPlugin
-    | undefined
-  if (!AuthPlugin) {
-    throw new Error('Authentication plugin not found')
-  }
-  const { OAuthConfigSchema, OAuthInternetAccountModelFactory } =
-    AuthPlugin.exports
   return InternetAccount.named('ApolloInternetAccount')
     .props({
       type: types.literal('ApolloInternetAccount'),
       configuration: ConfigurationReference(configSchema),
     })
     .views((self) => ({
-      get googleAuthEndpoint(): string {
-        return getConf(self, ['google', 'authEndpoint'])
-      },
-      get microsoftAuthEndpoint(): string {
-        return getConf(self, ['microsoft', 'authEndpoint'])
-      },
-      get internetAccountType() {
-        return 'ApolloInternetAccount'
-      },
       get baseURL(): string {
         return getConf(self, 'baseURL')
-      },
-      get allowGuestUser(): boolean {
-        return getConf(self, 'allowGuestUser')
       },
       getUserId() {
         const token = self.retrieveToken()
@@ -88,31 +50,135 @@ const stateModelFactory = (
       },
     }))
     .actions((self) => {
-      let roleNotificationSent = false
+      let listener: (event: MessageEvent) => void
       return {
-        getRole() {
-          const token = self.retrieveToken()
+        addMessageChannel(
+          resolve: (token: string) => void,
+          reject: (error: Error) => void,
+        ) {
+          listener = (event) => {
+            // this should probably get better handling, but ignored for now
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
+            this.finishOAuthWindow(event, resolve, reject)
+          }
+          window.addEventListener('message', listener)
+        },
+        deleteMessageChannel() {
+          window.removeEventListener('message', listener)
+        },
+        async finishOAuthWindow(
+          event: MessageEvent,
+          resolve: (token: string) => void,
+          reject: (error: Error) => void,
+        ) {
+          if (
+            event.data.name !== `JBrowseAuthWindow-${self.internetAccountId}`
+          ) {
+            return this.deleteMessageChannel()
+          }
+          const redirectUriWithInfo = event.data.redirectUri
+          const fixedQueryString = redirectUriWithInfo.replace('#', '?')
+          const redirectUrl = new URL(fixedQueryString)
+          const queryStringSearch = redirectUrl.search
+          const urlParams = new URLSearchParams(queryStringSearch)
+          const token = urlParams.get('access_token')
+          this.deleteMessageChannel()
           if (!token) {
-            return
+            return reject(new Error('Error with token endpoint'))
           }
-          const dec = getDecodedToken(token)
-          const { role } = dec
-          if (!role && !roleNotificationSent) {
-            const { session } = getRoot<ApolloRootModel>(self)
-            ;(session as unknown as AbstractSessionModel).notify(
-              'You have registered as a user but have not been given access. Ask your administrator to enable access for your account.',
-              'warning',
+          self.storeToken(token)
+          return resolve(token)
+        },
+        async openAuthWindow(
+          type: string,
+          resolve: (token: string) => void,
+          reject: (error: Error) => void,
+        ) {
+          const redirectUri = isElectron
+            ? 'http://localhost/auth'
+            : window.location.origin + window.location.pathname
+          const url = new URL('auth/login', self.baseURL)
+          const params = new URLSearchParams({
+            type,
+            redirect_uri: redirectUri,
+          })
+          url.search = params.toString()
+          const eventName = `JBrowseAuthWindow-${self.internetAccountId}`
+          if (isElectron) {
+            const { ipcRenderer } = window.require('electron')
+            const redirectUriFromElectron = await ipcRenderer.invoke(
+              'openAuthWindow',
+              {
+                internetAccountId: self.internetAccountId,
+                data: { redirect_uri: redirectUri },
+                url: url.toString(),
+              },
             )
-            // notify
-            roleNotificationSent = true
+            const eventFromDesktop = new MessageEvent('message', {
+              data: { name: eventName, redirectUri: redirectUriFromElectron },
+            })
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
+            this.finishOAuthWindow(eventFromDesktop, resolve, reject)
+          } else {
+            this.addMessageChannel(resolve, reject)
+            window.open(url, eventName, 'width=500,height=600')
           }
-          return role
         },
       }
     })
-    .volatile((self) => ({
-      authType: undefined as AuthType | undefined,
-      socket: io(self.baseURL),
+    .actions((self) => ({
+      async getTokenFromUser(
+        resolve: (token: string) => void,
+        reject: (error: Error) => void,
+      ): Promise<void> {
+        const { baseURL } = self
+        const authType = await new Promise(
+          (resolve: (authType: AuthType) => void, reject) => {
+            const { session } = getRoot<ApolloRootModel>(self)
+            const { baseURL, name } = self
+            ;(session as unknown as AbstractSessionModel).queueDialog(
+              (doneCallback: () => void) => [
+                AuthTypeSelector,
+                {
+                  name,
+                  handleClose: (newAuthType?: AuthType | Error) => {
+                    if (!newAuthType) {
+                      reject(new Error('user cancelled entry'))
+                    } else if (newAuthType instanceof Error) {
+                      reject(newAuthType)
+                    } else {
+                      resolve(newAuthType)
+                    }
+                    doneCallback()
+                  },
+                  baseURL,
+                },
+              ],
+            )
+          },
+        )
+        if (authType !== 'guest') {
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
+          self.openAuthWindow(authType, resolve, reject)
+          return
+        }
+        const url = new URL('auth/login', baseURL)
+        const searchParams = new URLSearchParams({ type: authType })
+        url.search = searchParams.toString()
+        const uri = url.toString()
+        const response = await fetch(uri)
+        if (!response.ok) {
+          const errorMessage = await createFetchErrorMessage(
+            response,
+            'Error when logging in',
+          )
+          return reject(new Error(errorMessage))
+        }
+        const { token } = await response.json()
+        resolve(token)
+      },
+    }))
+    .volatile(() => ({
       lastChangeSequenceNumber: undefined as number | undefined,
     }))
     .actions((self) => ({
@@ -121,88 +187,6 @@ const stateModelFactory = (
       },
     }))
     .actions((self) => ({
-      async getTokenFromUser(
-        resolve: (token: string) => void,
-        reject: (error: Error) => void,
-      ): Promise<void> {
-        const { baseURL } = self
-        const url = new URL('auth/guest', baseURL)
-        const response = await fetch(url)
-        if (!response.ok) {
-          const errorMessage = await createFetchErrorMessage(
-            response,
-            'Error when logging in as guest',
-          )
-          return reject(new Error(errorMessage))
-        }
-        const { token } = await response.json()
-        resolve(token)
-      },
-      addSocketListeners() {
-        const { session } = getRoot<ApolloRootModel>(self)
-        const { notify } = session as unknown as AbstractSessionModel
-        const token = self.retrieveToken()
-        if (!token) {
-          throw new Error('No Token found')
-        }
-        const { socket } = self
-        const { addCheckResult, changeManager, deleteCheckResult } = (
-          session as ApolloSessionModel
-        ).apolloDataStore
-        socket.on('connect', async () => {
-          await this.getMissingChanges()
-        })
-        socket.on('connect_error', () => {
-          notify('Could not connect to the Apollo server.', 'error')
-        })
-        socket.on('COMMON', (message: ChangeMessage | CheckResultUpdate) => {
-          if ('checkResult' in message) {
-            if (message.deleted) {
-              deleteCheckResult(message.checkResult._id.toString())
-            } else {
-              addCheckResult(message.checkResult)
-            }
-            return
-          }
-          // Save server last change sequence into session storage
-          sessionStorage.setItem(
-            'LastChangeSequence',
-            String(message.changeSequence),
-          )
-          if (message.userSessionId === token) {
-            return // we did this change, no need to apply it again
-          }
-          const change = Change.fromJSON(message.changeInfo)
-          void changeManager?.submit(change, { submitToBackend: false })
-        })
-        socket.on('USER_LOCATION', (message: UserLocationMessage) => {
-          const { channel, locations, userName, userSessionId } = message
-          const user = getDecodedToken(token)
-          const localSessionId = makeUserSessionId(user)
-          if (channel === 'USER_LOCATION' && userSessionId !== localSessionId) {
-            const collaborator: Collaborator = {
-              name: userName,
-              id: userSessionId,
-              locations,
-            }
-            session.addOrUpdateCollaborator(collaborator)
-          }
-        })
-        socket.on(
-          'REQUEST_INFORMATION',
-          (message: RequestUserInformationMessage) => {
-            const { channel, reqType, userSessionId } = message
-            if (channel === 'REQUEST_INFORMATION' && userSessionId !== token) {
-              switch (reqType) {
-                case 'CURRENT_LOCATION': {
-                  session.broadcastLocations()
-                  break
-                }
-              }
-            }
-          },
-        )
-      },
       updateLastChangeSequenceNumber: flow(
         function* updateLastChangeSequenceNumber() {
           const { baseURL } = self
@@ -265,6 +249,76 @@ const stateModelFactory = (
         }
       }),
     }))
+    .volatile((self) => ({
+      socket: io(self.baseURL),
+    }))
+    .actions((self) => ({
+      addSocketListeners() {
+        const { session } = getRoot<ApolloRootModel>(self)
+        const { notify } = session as unknown as AbstractSessionModel
+        const token = self.retrieveToken()
+        if (!token) {
+          throw new Error('No Token found')
+        }
+        const { socket } = self
+        const { addCheckResult, changeManager, deleteCheckResult } = (
+          session as ApolloSessionModel
+        ).apolloDataStore
+        socket.on('connect', async () => {
+          await self.getMissingChanges()
+        })
+        socket.on('connect_error', () => {
+          notify('Could not connect to the Apollo server.', 'error')
+        })
+        socket.on('COMMON', (message: ChangeMessage | CheckResultUpdate) => {
+          if ('checkResult' in message) {
+            if (message.deleted) {
+              deleteCheckResult(message.checkResult._id.toString())
+            } else {
+              addCheckResult(message.checkResult)
+            }
+            return
+          }
+          // Save server last change sequence into session storage
+          sessionStorage.setItem(
+            'LastChangeSequence',
+            String(message.changeSequence),
+          )
+          if (message.userSessionId === token) {
+            return // we did this change, no need to apply it again
+          }
+          const change = Change.fromJSON(message.changeInfo)
+          void changeManager?.submit(change, { submitToBackend: false })
+        })
+        socket.on('USER_LOCATION', (message: UserLocationMessage) => {
+          const { channel, locations, userName, userSessionId } = message
+          const user = getDecodedToken(token)
+          const localSessionId = makeUserSessionId(user)
+          if (channel === 'USER_LOCATION' && userSessionId !== localSessionId) {
+            const collaborator: Collaborator = {
+              name: userName,
+              id: userSessionId,
+              locations,
+            }
+            session.addOrUpdateCollaborator(collaborator)
+          }
+        })
+        socket.on(
+          'REQUEST_INFORMATION',
+          (message: RequestUserInformationMessage) => {
+            const { channel, reqType, userSessionId } = message
+            if (channel === 'REQUEST_INFORMATION' && userSessionId !== token) {
+              switch (reqType) {
+                case 'CURRENT_LOCATION': {
+                  session.broadcastLocations()
+                  break
+                }
+              }
+            }
+          },
+        )
+      },
+    }))
     .actions((self) => {
       async function postUserLocation(userLoc: UserLocation[]) {
         const { baseURL } = self
@@ -299,141 +353,13 @@ const stateModelFactory = (
       }
       return { postUserLocation: debouncePostUserLocation(postUserLocation) }
     })
-    .actions(() => ({
-      addMenuItems(role: Role) {
-        if (
-          !(role === 'admin' && isAbstractMenuManager(pluginManager.rootModel))
-        ) {
-          return
-        }
-        const { rootModel } = pluginManager
-        const { menus } = rootModel as unknown as { menus: Menu[] }
-        // Find 'Apollo' menu and its items
-        const apolloMenu = menus.find((menu) => {
-          return menu.label === 'Apollo'
-        })
-        if (!apolloMenu) {
-          return
-        }
-        const { menuItems } = apolloMenu
-        if (
-          !menuItems.some(
-            (menuItem) =>
-              'label' in menuItem && menuItem.label === 'Add Assembly',
-          )
-        ) {
-          rootModel.insertInMenu(
-            'Apollo',
-            {
-              label: 'Add Assembly',
-              onClick: (session: ApolloSessionModel) => {
-                ;(session as unknown as AbstractSessionModel).queueDialog(
-                  (doneCallback) => [
-                    AddAssembly,
-                    {
-                      session,
-                      handleClose: () => {
-                        doneCallback()
-                      },
-                      changeManager: session.apolloDataStore.changeManager,
-                    },
-                  ],
-                )
-              },
-            },
-            0,
-          )
-          rootModel.insertInMenu(
-            'Apollo',
-            {
-              label: 'Delete Assembly',
-              onClick: (session: ApolloSessionModel) => {
-                ;(session as unknown as AbstractSessionModel).queueDialog(
-                  (doneCallback) => [
-                    DeleteAssembly,
-                    {
-                      session,
-                      handleClose: () => {
-                        doneCallback()
-                      },
-                      changeManager: session.apolloDataStore.changeManager,
-                    },
-                  ],
-                )
-              },
-            },
-            1,
-          )
-          rootModel.insertInMenu(
-            'Apollo',
-            {
-              label: 'Import Features',
-              onClick: (session: ApolloSessionModel) => {
-                ;(session as unknown as AbstractSessionModel).queueDialog(
-                  (doneCallback) => [
-                    ImportFeatures,
-                    {
-                      session,
-                      handleClose: () => {
-                        doneCallback()
-                      },
-                      changeManager: (session as ApolloSessionModel)
-                        .apolloDataStore.changeManager,
-                    },
-                  ],
-                )
-              },
-            },
-            2,
-          )
-          rootModel.insertInMenu(
-            'Apollo',
-            {
-              label: 'Manage Users',
-              onClick: (session: ApolloSessionModel) => {
-                ;(session as unknown as AbstractSessionModel).queueDialog(
-                  (doneCallback) => [
-                    ManageUsers,
-                    {
-                      session,
-                      handleClose: () => {
-                        doneCallback()
-                      },
-                      changeManager: (session as ApolloSessionModel)
-                        .apolloDataStore.changeManager,
-                    },
-                  ],
-                )
-              },
-            },
-            9,
-          )
-          rootModel.insertInMenu(
-            'Apollo',
-            {
-              label: 'Undo',
-              onClick: (session: ApolloSessionModel) => {
-                const { apolloDataStore } = session
-                const { notify } = session as unknown as AbstractSessionModel
-                if (apolloDataStore.changeManager.recentChanges.length > 0) {
-                  void apolloDataStore.changeManager.revertLastChange()
-                } else {
-                  notify('No changes to undo', 'info')
-                }
-              },
-            },
-            10,
-          )
-        }
-      },
-    }))
     .actions((self) => ({
       initialize: flow(function* initialize(role?: Role) {
         if (!role) {
           return
         }
         if (role === 'admin') {
-          self.addMenuItems(role)
+          addMenuItems(pluginManager, role)
         }
         // Get and set server last change sequence into session storage
         yield self.updateLastChangeSequenceNumber()
@@ -463,6 +389,29 @@ const stateModelFactory = (
         })
       }),
     }))
+    .actions((self) => {
+      let roleNotificationSent = false
+      return {
+        getRole() {
+          const token = self.retrieveToken()
+          if (!token) {
+            return
+          }
+          const dec = getDecodedToken(token)
+          const { role } = dec
+          if (!role && !roleNotificationSent) {
+            const { session } = getRoot<ApolloRootModel>(self)
+            ;(session as unknown as AbstractSessionModel).notify(
+              'You have registered as a user but have not been given access. Ask your administrator to enable access for your account.',
+              'warning',
+            )
+            // notify
+            roleNotificationSent = true
+          }
+          return role
+        },
+      }
+    })
     .actions((self) => ({
       afterAttach() {
         autorun(
@@ -471,10 +420,7 @@ const stateModelFactory = (
               return
             }
             try {
-              const { authType, getRole } = self
-              if (!authType) {
-                return
-              }
+              const { getRole } = self
               const role = getRole()
               if (role) {
                 await self.initialize(role)
@@ -487,198 +433,7 @@ const stateModelFactory = (
           { name: 'ApolloInternetAccount' },
         )
       },
-      initializeFromToken: flow(function* initializeFromToken(token: string) {
-        const payload = getDecodedToken(token)
-        yield self.initialize(payload.role)
-      }),
     }))
-    .volatile((self) => ({
-      googleAuthInternetAccount: OAuthInternetAccountModelFactory(
-        OAuthConfigSchema,
-      )
-        .actions((s) => {
-          const superStoreToken = s.storeToken
-          return {
-            storeToken: flow(function* storeToken(token: string) {
-              superStoreToken(token)
-              yield self.initializeFromToken(token)
-            }),
-          }
-        })
-        .create({
-          type: 'OAuthInternetAccount',
-          configuration: {
-            type: 'OAuthInternetAccount',
-            internetAccountId: `${self.internetAccountId}-apolloGoogle`,
-            name: `${self.name}-apolloGoogle`,
-            description: `${self.description}-apolloGoogle`,
-            domains: self.domains,
-            authEndpoint: self.googleAuthEndpoint,
-          },
-        }),
-      microsoftAuthInternetAccount: OAuthInternetAccountModelFactory(
-        OAuthConfigSchema,
-      )
-        .actions((s) => {
-          const superStoreToken = s.storeToken
-          return {
-            storeToken: flow(function* storeToken(token: string) {
-              superStoreToken(token)
-              yield self.initializeFromToken(token)
-            }),
-          }
-        })
-        .create({
-          type: 'OAuthInternetAccount',
-          configuration: {
-            type: 'OAuthInternetAccount',
-            internetAccountId: `${self.internetAccountId}-apolloMicrosoft`,
-            name: `${self.name}-apolloMicrosoft`,
-            description: `${self.description}-apolloMicrosoft`,
-            domains: self.domains,
-            authEndpoint: self.microsoftAuthEndpoint,
-          },
-        }),
-    }))
-    .actions((self) => ({
-      setAuthType(authType: AuthType) {
-        self.authType = authType
-      },
-    }))
-    .actions((self) => {
-      const {
-        getFetcher: superGetFetcher,
-        getPreAuthorizationInformation: superGetPreAuthorizationInformation,
-        retrieveToken: superRetrieveToken,
-      } = self
-      let authTypePromise: Promise<AuthType> | undefined
-      return {
-        async getPreAuthorizationInformation(location: UriLocation) {
-          const preAuthInfo =
-            await superGetPreAuthorizationInformation(location)
-          return {
-            ...preAuthInfo,
-            authInfo: {
-              ...preAuthInfo.authInfo,
-              authType: await authTypePromise,
-            },
-          }
-        },
-        retrieveToken() {
-          const {
-            authType,
-            googleAuthInternetAccount,
-            microsoftAuthInternetAccount,
-          } = self
-          if (authType === 'google') {
-            return googleAuthInternetAccount.retrieveToken()
-          }
-          if (authType === 'microsoft') {
-            return microsoftAuthInternetAccount.retrieveToken()
-          }
-          if (authType === 'guest') {
-            return superRetrieveToken()
-          }
-          throw new Error(`Unknown authType "${authType}"`)
-        },
-        getFetcher(
-          location?: UriLocation,
-        ): (input: RequestInfo, init?: RequestInit) => Promise<Response> {
-          return async (
-            input: RequestInfo,
-            init?: RequestInit,
-          ): Promise<Response> => {
-            let { authType } = self
-            const {
-              googleAuthEndpoint,
-              googleAuthInternetAccount,
-              microsoftAuthEndpoint,
-              microsoftAuthInternetAccount,
-            } = self
-            if (!authType) {
-              if (!authTypePromise) {
-                if (location?.internetAccountPreAuthorization) {
-                  authTypePromise = Promise.resolve(
-                    location.internetAccountPreAuthorization.authInfo.authType,
-                  )
-                } else if (googleAuthInternetAccount.retrieveToken()) {
-                  authTypePromise = Promise.resolve('google')
-                } else if (microsoftAuthInternetAccount.retrieveToken()) {
-                  authTypePromise = Promise.resolve('microsoft')
-                } else if (superRetrieveToken()) {
-                  authTypePromise = Promise.resolve('guest')
-                } else {
-                  authTypePromise = new Promise((resolve, reject) => {
-                    const { session } = getRoot<ApolloRootModel>(self)
-                    const { allowGuestUser, baseURL, name } = self
-                    ;(session as unknown as AbstractSessionModel).queueDialog(
-                      (doneCallback: () => void) => [
-                        AuthTypeSelector,
-                        {
-                          baseURL,
-                          name,
-                          handleClose: (newAuthType?: AuthType | Error) => {
-                            if (!newAuthType) {
-                              reject(new Error('user cancelled entry'))
-                            } else if (newAuthType instanceof Error) {
-                              reject(newAuthType)
-                            } else {
-                              resolve(newAuthType)
-                            }
-                            doneCallback()
-                          },
-                          google: Boolean(googleAuthEndpoint),
-                          microsoft: Boolean(microsoftAuthEndpoint),
-                          allowGuestUser,
-                        },
-                      ],
-                    )
-                  })
-                }
-              }
-              authType = await authTypePromise
-            }
-            self.setAuthType(authType)
-            let fetchToUse: (
-              input: RequestInfo,
-              init?: RequestInit,
-            ) => Promise<Response>
-            switch (authType) {
-              case 'google': {
-                fetchToUse = self.googleAuthInternetAccount.getFetcher(location)
-
-                break
-              }
-              case 'microsoft': {
-                fetchToUse =
-                  self.microsoftAuthInternetAccount.getFetcher(location)
-
-                break
-              }
-              case 'guest': {
-                fetchToUse = superGetFetcher(location)
-
-                break
-              }
-              default: {
-                throw new Error(`Unknown authType "${authType}"`)
-              }
-            }
-            const response = await fetchToUse(input, init)
-            if (response.status === 401) {
-              if (authType === 'google') {
-                self.googleAuthInternetAccount.removeToken()
-              } else if (authType === 'microsoft') {
-                self.microsoftAuthInternetAccount.removeToken()
-              } else {
-                self.removeToken()
-              }
-            }
-            return response
-          }
-        },
-      }
-    })
 }
 
 export default stateModelFactory

--- a/packages/jbrowse-plugin-apollo/src/ApolloSixFrameRenderer/components/ApolloRendering.tsx
+++ b/packages/jbrowse-plugin-apollo/src/ApolloSixFrameRenderer/components/ApolloRendering.tsx
@@ -143,16 +143,16 @@ function ApolloRendering(props: ApolloRenderingProps) {
     return matchingAccount
   }, [displayModel, region, session])
 
-  const { getRole } = apolloInternetAccount
+  const { role } = apolloInternetAccount
 
   useEffect(() => {
-    if (getRole()?.includes('admin')) {
+    if (role?.includes('admin')) {
       setIsAdmin(true)
     }
-    if (getRole()?.includes('admin') ?? getRole()?.includes('user')) {
+    if (role?.includes('admin') ?? role?.includes('user')) {
       setIsReadOnly(false)
     }
-  }, [getRole])
+  }, [role])
 
   useEffect(() => {
     // if (!isAlive(region)) {

--- a/packages/jbrowse-plugin-apollo/src/ApolloSixFrameRenderer/components/ApolloRendering.tsx
+++ b/packages/jbrowse-plugin-apollo/src/ApolloSixFrameRenderer/components/ApolloRendering.tsx
@@ -143,19 +143,16 @@ function ApolloRendering(props: ApolloRenderingProps) {
     return matchingAccount
   }, [displayModel, region, session])
 
-  const { authType, getRole } = apolloInternetAccount
+  const { getRole } = apolloInternetAccount
 
   useEffect(() => {
-    if (!authType) {
-      return
-    }
     if (getRole()?.includes('admin')) {
       setIsAdmin(true)
     }
     if (getRole()?.includes('admin') ?? getRole()?.includes('user')) {
       setIsReadOnly(false)
     }
-  }, [authType, getRole])
+  }, [getRole])
 
   useEffect(() => {
     // if (!isAlive(region)) {

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
@@ -283,7 +283,7 @@ export abstract class Glyph {
       setSelectedFeature,
     } = display
     const { feature: sourceFeature } = apolloHover ?? {}
-    const role = internetAccount ? internetAccount.getRole() : 'admin'
+    const role = internetAccount ? internetAccount.role : 'admin'
     const admin = role === 'admin'
     const readOnly = !(role && ['admin', 'user'].includes(role))
     const menuItems: MenuItem[] = []

--- a/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/featureContextMenuItems.ts
+++ b/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/featureContextMenuItems.ts
@@ -22,7 +22,7 @@ export function featureContextMenuItems(
   changeManager: ChangeManager,
 ) {
   const internetAccount = getApolloInternetAccount(session)
-  const role = internetAccount ? internetAccount.getRole() : 'admin'
+  const role = internetAccount ? internetAccount.role : 'admin'
   const admin = role === 'admin'
   const readOnly = !(role && ['admin', 'user'].includes(role))
   const menuItems: MenuItem[] = []

--- a/packages/jbrowse-plugin-apollo/src/components/ManageUsers.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/ManageUsers.tsx
@@ -53,8 +53,7 @@ export function ManageUsers({
 }: ManageUsersProps) {
   const { internetAccounts } = getRoot<ApolloRootModel>(session)
   const apolloInternetAccounts = internetAccounts.filter(
-    (ia) =>
-      ia.type === 'ApolloInternetAccount' && ia.getRole()?.includes('admin'),
+    (ia) => ia.type === 'ApolloInternetAccount' && ia.role?.includes('admin'),
   )
   if (apolloInternetAccounts.length === 0) {
     throw new Error('No Apollo internet account found')

--- a/packages/jbrowse-plugin-apollo/src/components/ModifyFeatureAttribute.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/ModifyFeatureAttribute.tsx
@@ -123,7 +123,7 @@ export function ModifyFeatureAttribute({
       (ia) => ia.type === 'ApolloInternetAccount',
     ) as ApolloInternetAccountModel | undefined
   }, [internetAccounts])
-  const role = internetAccount ? internetAccount.getRole() : 'admin'
+  const role = internetAccount ? internetAccount.role : 'admin'
   const editable = ['admin', 'user'].includes(role ?? '')
 
   const [errorMessage, setErrorMessage] = useState('')

--- a/packages/jbrowse-plugin-apollo/src/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/index.ts
@@ -132,7 +132,6 @@ export default class ApolloPlugin extends Plugin {
         configSchema: apolloInternetAccountConfigSchema,
         stateModel: apolloInternetAccountModelFactory(
           apolloInternetAccountConfigSchema,
-          pluginManager,
         ),
       })
     })
@@ -305,7 +304,6 @@ export default class ApolloPlugin extends Plugin {
 
   configure(pluginManager: PluginManager) {
     if (isAbstractMenuManager(pluginManager.rootModel)) {
-      pluginManager.rootModel.insertMenu('Apollo', -1)
       pluginManager.rootModel.appendToMenu('Apollo', {
         label: 'Download GFF3',
         onClick: (session: ApolloSessionModel) => {


### PR DESCRIPTION
Previously each login method had a different endpoint on the backend and a different internet account type on the frontend. This simplifies things by using only one internet account type and one login endpoint.