### PR TITLE
Update devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,14 +1,14 @@
-# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
-ARG VARIANT=18-buster
-FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+FROM mcr.microsoft.com/devcontainers/javascript-node:1-20-bullseye
 
-# Install MongoDB command line tools if on buster and x86_64 (arm64 not supported)
-ARG MONGO_TOOLS_VERSION=5.0
-RUN curl -sSL "https://www.mongodb.org/static/pgp/server-${MONGO_TOOLS_VERSION}.asc" | gpg --dearmor > /usr/share/keyrings/mongodb-archive-keyring.gpg \
-        && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/mongodb-archive-keyring.gpg] http://repo.mongodb.org/apt/debian $(lsb_release -cs)/mongodb-org/${MONGO_TOOLS_VERSION} main" | tee /etc/apt/sources.list.d/mongodb-org-${MONGO_TOOLS_VERSION}.list \
-        && apt-get update && export DEBIAN_FRONTEND=noninteractive \
-        && apt-get install -y mongodb-database-tools mongodb-mongosh \
-        && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+# Install MongoDB command line tools - though mongo-database-tools not available on arm64
+ARG MONGO_TOOLS_VERSION=6.0
+RUN . /etc/os-release \
+    && curl -sSL "https://www.mongodb.org/static/pgp/server-${MONGO_TOOLS_VERSION}.asc" | gpg --dearmor > /usr/share/keyrings/mongodb-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/mongodb-archive-keyring.gpg] http://repo.mongodb.org/apt/debian ${VERSION_CODENAME}/mongodb-org/${MONGO_TOOLS_VERSION} main" | tee /etc/apt/sources.list.d/mongodb-org-${MONGO_TOOLS_VERSION}.list \
+    && apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get install -y mongodb-mongosh \
+    && if [ "$(dpkg --print-architecture)" = "amd64" ]; then apt-get install -y mongodb-database-tools; fi \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,29 +1,35 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.224.2/containers/javascript-node-mongo
-// Update the VARIANT arg in docker-compose.yml to pick a Node.js version
+// For format details, see https://aka.ms/devcontainer.json.
+// For config options, see the README at:
+// https://github.com/devcontainers/templates/tree/main/src/javascript-node-mongo
 {
   "name": "Apollo",
   "dockerComposeFile": "docker-compose.yml",
   "service": "app",
-  "workspaceFolder": "/workspace",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
 
-  // Set *default* container specific settings.json values on container create.
-  "settings": {},
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  // "features": {},
+  // Configure tool-specific properties.
+  "customizations": {
+    // Configure properties specific to VS Code.
+    "vscode": {
+      // Add the IDs of extensions you want installed when the container is created.
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "mongodb.mongodb-vscode",
+        "arcanis.vscode-zipfs",
+        "eamodio.gitlens",
+      ],
+    },
+  },
 
-  // Add the IDs of extensions you want installed when the container is created.
-  "extensions": [
-    "dbaeumer.vscode-eslint",
-    "mongodb.mongodb-vscode",
-    "arcanis.vscode-zipfs",
-    "eamodio.gitlens",
-  ],
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   "forwardPorts": [3999, 27017],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "yarn install && mongosh --eval 'try {rs.initiate();} catch {}'",
+  "postCreateCommand": "yarn install --immutable && mongosh --eval 'try {rs.initiate();} catch {}'",
 
-  // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-  "remoteUser": "node"
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,9 @@
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
 
   // Features to add to the dev container. More info: https://containers.dev/features.
-  // "features": {},
+  "features": {
+    "./git-autocomplete": "1.0.0",
+  },
   // Configure tool-specific properties.
   "customizations": {
     // Configure properties specific to VS Code.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,23 +5,14 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      args:
-        # Update 'VARIANT' to pick an LTS version of Node.js: 16, 14, 12.
-        # Append -bullseye or -buster to pin to an OS version.
-        # Use -bullseye variants on local arm64/Apple Silicon.
-        VARIANT: 18-buster
-
     volumes:
-      - ..:/workspace:cached
+      - ../..:/workspaces:cached
 
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
 
     # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
     network_mode: service:db
-
-    # Uncomment the next line to use a non-root user for all processes.
-    # user: node
 
     # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)

--- a/.devcontainer/git-autocomplete/devcontainer-feature.json
+++ b/.devcontainer/git-autocomplete/devcontainer-feature.json
@@ -1,0 +1,6 @@
+{
+  "name": "Git Autocomplete",
+  "id": "git-autocomplete",
+  "version": "1.0.0",
+  "description": "Enable git autocomplete in the shell",
+}

--- a/.devcontainer/git-autocomplete/install.sh
+++ b/.devcontainer/git-autocomplete/install.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+UPDATE_RC="${UPDATE_RC:-"true"}"
+AUTOCOMPLETE_SOURCE="source /usr/share/bash-completion/completions/git"
+
+if [ "${UPDATE_RC}" = "true" ]; then
+    echo "Updating /etc/bash.bashrc and /etc/zsh/zshrc..."
+    if [[ "$(cat /etc/bash.bashrc)" != *"${AUTOCOMPLETE_SOURCE}"* ]]; then
+        echo -e "${AUTOCOMPLETE_SOURCE}" >> /etc/bash.bashrc
+    fi
+    if [ -f "/etc/zsh/zshrc" ] && [[ "$(cat /etc/zsh/zshrc)" != *"${AUTOCOMPLETE_SOURCE}"* ]]; then
+        echo -e "${AUTOCOMPLETE_SOURCE}" >> /etc/zsh/zshrc
+    fi
+fi


### PR DESCRIPTION
For those who use VS Code's devcontainer feature for development, you'll want to run the "Rebuild container" command in VS Code after this is merged and you've pulled the changes.

This updates the devcontainer config files to use the latest spec, and upgrades the base Debian image from 18 to 20. It also makes git autocomplete work in the container, too, as a convenience. If anyone has any other things they think might be nice to have in the container by default, let me know.