### PR TITLE
Deploy to demo server on version tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,9 @@ on:
       environment:
         required: true
         type: string
+    secrets:
+      GITHUB_TOKEN:
+        required: true
 
 jobs:
   deploy:
@@ -19,21 +22,21 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.aws_access_key_id }}
-          aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - name: Get instance address
         id: ec2-describe-instances
         run: |
           INSTANCE_ADDRESS=$(aws ec2 describe-instances \
-            --instance-ids ${{ vars.instance_id }} \
+            --instance-ids ${{ vars.INSTANCE_ID }} \
             --query "Reservations[*].Instances[*].[PublicDnsName]" \
             --output text)
           echo "INSTANCE_ADDRESS=$INSTANCE_ADDRESS" >> "$GITHUB_OUTPUT"
       - name: Set up SSH
         run: |
           mkdir --parents ~/.ssh
-          echo "${{ secrets.ssh_private_key  }}" >  ~/.ssh/staging
+          echo "${{ secrets.SSH_PRIVATE_KEY  }}" >  ~/.ssh/staging
           chmod 600 ~/.ssh/staging
           cat >>~/.ssh/config <<END
           Host staging
@@ -52,14 +55,14 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.github_token }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy
         env:
-          JWT_SECRET: ${{ secrets.jwt_secret }}
-          SESSION_SECRET: ${{ secrets.session_secret }}
-          GOOGLE_CLIENT_ID: ${{ secrets.google_client_id }}
-          GOOGLE_CLIENT_SECRET: ${{ secrets.google_client_secret }}
-          URL: ${{ vars.url }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          URL: ${{ vars.URL }}
         working-directory: .github/workflows/deploy
         run: |
           docker --context staging compose down

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,23 +6,6 @@ on:
       environment:
         required: true
         type: string
-    secrets:
-      aws_access_key_id:
-        required: true
-      aws_secret_access_key:
-        required: true
-      ssh_private_key:
-        required: true
-      jwt_secret:
-        required: true
-      session_secret:
-        required: true
-      google_client_id:
-        required: true
-      google_client_secret:
-        required: true
-      github_token:
-        required: true
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,84 @@
+name: Deploy
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+    secrets:
+      aws_access_key_id:
+        required: true
+      aws_secret_access_key:
+        required: true
+      ssh_private_key:
+        required: true
+      jwt_secret:
+        required: true
+      session_secret:
+        required: true
+      google_client_id:
+        required: true
+      google_client_secret:
+        required: true
+      github_token:
+        required: true
+
+jobs:
+  deploy:
+    name: Deploy to demo staging server
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    needs: build-and-push-docker
+    steps:
+      - name: Check out
+        uses: actions/checkout@v3
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.aws_access_key_id }}
+          aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
+          aws-region: us-east-1
+      - name: Get instance address
+        id: ec2-describe-instances
+        run: |
+          INSTANCE_ADDRESS=$(aws ec2 describe-instances \
+            --instance-ids ${{ vars.instance_id }} \
+            --query "Reservations[*].Instances[*].[PublicDnsName]" \
+            --output text)
+          echo "INSTANCE_ADDRESS=$INSTANCE_ADDRESS" >> "$GITHUB_OUTPUT"
+      - name: Set up SSH
+        run: |
+          mkdir --parents ~/.ssh
+          echo "${{ secrets.ssh_private_key  }}" >  ~/.ssh/staging
+          chmod 600 ~/.ssh/staging
+          cat >>~/.ssh/config <<END
+          Host staging
+            HostName ${{ steps.ec2-describe-instances.outputs.INSTANCE_ADDRESS }}
+            User ec2-user
+            IdentityFile ~/.ssh/staging
+          END
+          ssh-keyscan -H ${{ steps.ec2-describe-instances.outputs.INSTANCE_ADDRESS }} >> ~/.ssh/known_hosts
+      - name: Create Docker context
+        run: |
+          docker context create staging \
+            --docker host=ssh://staging \
+            --description "Staging server"
+      - name: Log in to the GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.github_token }}
+      - name: Deploy
+        env:
+          JWT_SECRET: ${{ secrets.jwt_secret }}
+          SESSION_SECRET: ${{ secrets.session_secret }}
+          GOOGLE_CLIENT_ID: ${{ secrets.google_client_id }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.google_client_secret }}
+          URL: ${{ vars.url }}
+        working-directory: .github/workflows/deploy
+        run: |
+          docker --context staging compose down
+          docker --context staging compose pull
+          docker --context staging compose up --build --detach

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -96,9 +96,11 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     with:
       environment: 'staging'
+    secrets: inherit
   deploy-demo:
     name: Deploy to demo server
     if: ${{ github.event_name == 'release' }}
     uses: ./.github/workflows/deploy.yml
     with:
       environment: 'demo'
+    secrets: inherit

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,7 +1,12 @@
 name: Push
 
 on:
-  push: null
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - created
   workflow_dispatch:
     inputs:
       publish:
@@ -85,63 +90,21 @@ jobs:
             collaboration server
           cache-from: type=registry,ref=user/app:latest
           cache-to: type=inline
-  deploy:
-    name: Deploy to demo staging server
-    runs-on: ubuntu-latest
-    environment: staging
-    needs: build-and-push-docker
-    if:
-      ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      ( inputs.deploy  &&  always()) }}
-    steps:
-      - name: Check out
-        uses: actions/checkout@v3
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-      - name: Get instance address
-        id: ec2-describe-instances
-        run: |
-          INSTANCE_ADDRESS=$(aws ec2 describe-instances \
-            --instance-ids ${{ vars.INSTANCE_ID }} \
-            --query "Reservations[*].Instances[*].[PublicDnsName]" \
-            --output text)
-          echo "INSTANCE_ADDRESS=$INSTANCE_ADDRESS" >> "$GITHUB_OUTPUT"
-      - name: Set up SSH
-        run: |
-          mkdir --parents ~/.ssh
-          echo "${{ secrets.SSH_PRIVATE_KEY  }}" >  ~/.ssh/staging
-          chmod 600 ~/.ssh/staging
-          cat >>~/.ssh/config <<END
-          Host staging
-            HostName ${{ steps.ec2-describe-instances.outputs.INSTANCE_ADDRESS }}
-            User ec2-user
-            IdentityFile ~/.ssh/staging
-          END
-          ssh-keyscan -H ${{ steps.ec2-describe-instances.outputs.INSTANCE_ADDRESS }} >> ~/.ssh/known_hosts
-      - name: Create Docker context
-        run: |
-          docker context create staging \
-            --docker host=ssh://staging \
-            --description "Staging server"
-      - name: Log in to the GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Deploy
-        env:
-          JWT_SECRET: ${{ secrets.JWT_SECRET }}
-          SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
-          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
-          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
-          URL: ${{ vars.URL }}
-        working-directory: .github/workflows/deploy
-        run: |
-          docker --context staging compose down
-          docker --context staging compose pull
-          docker --context staging compose up --build --detach
+  deploy-staging:
+    name: Deploy to staging server
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    uses: ./.github/workflows/deploy.yml
+    with:
+      environment: 'staging'
+      url: ${{ vars.URL }}
+      instance_id: ${{ vars.INSTANCE_ID }}
+    secrets: inherit
+  deploy-demo:
+    name: Deploy to demo server
+    if: ${{ github.event_name == 'release' }}
+    uses: ./.github/workflows/deploy.yml
+    with:
+      environment: 'demo'
+      url: ${{ vars.URL }}
+      instance_id: ${{ vars.INSTANCE_ID }}
+    secrets: inherit

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -96,15 +96,9 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     with:
       environment: 'staging'
-      url: ${{ vars.URL }}
-      instance_id: ${{ vars.INSTANCE_ID }}
-    secrets: inherit
   deploy-demo:
     name: Deploy to demo server
     if: ${{ github.event_name == 'release' }}
     uses: ./.github/workflows/deploy.yml
     with:
       environment: 'demo'
-      url: ${{ vars.URL }}
-      instance_id: ${{ vars.INSTANCE_ID }}
-    secrets: inherit


### PR DESCRIPTION
Fixes https://github.com/GMOD/Apollo3/issues/377

Create repo level secret
GITHUB_TOKEN

Create 2 environments:
- staging
- demo

Under each environment create following variables/secrets
Variables:
- INSTANCE_ID
- URL
Secrets:
- AWS_ACCESS_KEY_ID
- AWS_SECRET_ACCESS_KEY
- SSH_PRIVATE_KEY
- JWT_SECRET
- SESSION_SECRET
- GOOGLE_CLIENT_ID
- GOOGLE_CLIENT_SECRET

example - https://github.com/shashankbrgowda/github-workflow-test/blob/main/.github/workflows/main.yml