### PR TITLE
Rename packages for publishing

### DIFF
--- a/.husky/pre-commit.js
+++ b/.husky/pre-commit.js
@@ -23,12 +23,20 @@ function main() {
         fileName.includes('apollo-cli') && !fileName.includes('test'),
     )
   ) {
-    spawn.sync('yarn', ['workspace', 'apollo-cli', 'build'], {
-      stdio: 'inherit',
-    })
-    spawn.sync('yarn', ['workspace', 'apollo-cli', 'oclif', 'readme'], {
-      stdio: 'inherit',
-    })
+    spawn.sync(
+      'yarn',
+      ['workspace', '@apollo-annotation/apollo-cli', 'build'],
+      {
+        stdio: 'inherit',
+      },
+    )
+    spawn.sync(
+      'yarn',
+      ['workspace', '@apollo-annotation/apollo-cli', 'oclif', 'readme'],
+      {
+        stdio: 'inherit',
+      },
+    )
     spawn.sync('git', ['add', 'packages/apollo-cli/README.md'], {
       stdio: 'inherit',
     })

--- a/.husky/pre-commit.js
+++ b/.husky/pre-commit.js
@@ -23,16 +23,12 @@ function main() {
         fileName.includes('apollo-cli') && !fileName.includes('test'),
     )
   ) {
+    spawn.sync('yarn', ['workspace', '@apollo-annotation/cli', 'build'], {
+      stdio: 'inherit',
+    })
     spawn.sync(
       'yarn',
-      ['workspace', '@apollo-annotation/apollo-cli', 'build'],
-      {
-        stdio: 'inherit',
-      },
-    )
-    spawn.sync(
-      'yarn',
-      ['workspace', '@apollo-annotation/apollo-cli', 'oclif', 'readme'],
+      ['workspace', '@apollo-annotation/cli', 'oclif', 'readme'],
       {
         stdio: 'inherit',
       },

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   ],
   "scripts": {
     "lint": "eslint --report-unused-disable-directives --max-warnings 0 --ext .js,.ts,.jsx,.tsx .",
-    "build:shared": "yarn workspace apollo-shared run build",
-    "start:shared": "yarn workspace apollo-shared run start",
-    "start:server": "yarn workspace apollo-collaboration-server run start",
-    "start:plugin": "yarn workspace jbrowse-plugin-apollo run start",
+    "build:shared": "yarn workspace @apollo-annotation/shared run build",
+    "start:shared": "yarn workspace @apollo-annotation/shared run start",
+    "start:server": "yarn workspace @apollo-annotation/collaboration-server run start",
+    "start:plugin": "yarn workspace @apollo-annotation/jbrowse-plugin-apollo run start",
     "start": "npm-run-all --print-label --parallel start:shared start:server start:plugin",
     "test": "yarn workspaces foreach --all run test:ci"
   },

--- a/packages/apollo-cli/README.md
+++ b/packages/apollo-cli/README.md
@@ -12,11 +12,11 @@
 <!-- usage -->
 
 ```sh-session
-$ npm install -g apollo-cli
+$ npm install -g @apollo-annotation/apollo-cli
 $ apollo COMMAND
 running command...
 $ apollo (--version)
-apollo-cli/0.0.0 linux-x64 node-v20.13.0
+@apollo-annotation/apollo-cli/0.1.1 linux-x64 node-v18.19.0
 $ apollo --help [COMMAND]
 USAGE
   $ apollo COMMAND
@@ -87,7 +87,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/assembly/add-fasta.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/assembly/add-fasta.ts)_
+[src/commands/assembly/add-fasta.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/assembly/add-fasta.ts)_
 
 ## `apollo assembly add-gff`
 
@@ -122,7 +122,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/assembly/add-gff.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/assembly/add-gff.ts)_
+[src/commands/assembly/add-gff.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/assembly/add-gff.ts)_
 
 ## `apollo assembly check`
 
@@ -165,7 +165,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/assembly/check.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/assembly/check.ts)_
+[src/commands/assembly/check.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/assembly/check.ts)_
 
 ## `apollo assembly delete`
 
@@ -193,7 +193,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/assembly/delete.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/assembly/delete.ts)_
+[src/commands/assembly/delete.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/assembly/delete.ts)_
 
 ## `apollo assembly get`
 
@@ -215,7 +215,7 @@ DESCRIPTION
 ```
 
 _See code:
-[src/commands/assembly/get.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/assembly/get.ts)_
+[src/commands/assembly/get.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/assembly/get.ts)_
 
 ## `apollo assembly sequence`
 
@@ -250,7 +250,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/assembly/sequence.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/assembly/sequence.ts)_
+[src/commands/assembly/sequence.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/assembly/sequence.ts)_
 
 ## `apollo change get`
 
@@ -275,7 +275,7 @@ DESCRIPTION
 ```
 
 _See code:
-[src/commands/change/get.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/change/get.ts)_
+[src/commands/change/get.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/change/get.ts)_
 
 ## `apollo config [KEY] [VALUE]`
 
@@ -331,7 +331,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/config.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/config.ts)_
+[src/commands/config.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/config.ts)_
 
 ## `apollo feature add-child`
 
@@ -362,7 +362,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/feature/add-child.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/feature/add-child.ts)_
+[src/commands/feature/add-child.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/feature/add-child.ts)_
 
 ## `apollo feature check`
 
@@ -396,7 +396,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/feature/check.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/feature/check.ts)_
+[src/commands/feature/check.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/feature/check.ts)_
 
 ## `apollo feature copy`
 
@@ -428,7 +428,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/feature/copy.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/feature/copy.ts)_
+[src/commands/feature/copy.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/feature/copy.ts)_
 
 ## `apollo feature delete`
 
@@ -453,7 +453,7 @@ DESCRIPTION
 ```
 
 _See code:
-[src/commands/feature/delete.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/feature/delete.ts)_
+[src/commands/feature/delete.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/feature/delete.ts)_
 
 ## `apollo feature edit`
 
@@ -496,7 +496,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/feature/edit.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/feature/edit.ts)_
+[src/commands/feature/edit.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/feature/edit.ts)_
 
 ## `apollo feature edit-attribute`
 
@@ -537,7 +537,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/feature/edit-attribute.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/feature/edit-attribute.ts)_
+[src/commands/feature/edit-attribute.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/feature/edit-attribute.ts)_
 
 ## `apollo feature edit-coords`
 
@@ -572,7 +572,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/feature/edit-coords.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/feature/edit-coords.ts)_
+[src/commands/feature/edit-coords.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/feature/edit-coords.ts)_
 
 ## `apollo feature edit-type`
 
@@ -596,7 +596,7 @@ DESCRIPTION
 ```
 
 _See code:
-[src/commands/feature/edit-type.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/feature/edit-type.ts)_
+[src/commands/feature/edit-type.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/feature/edit-type.ts)_
 
 ## `apollo feature get`
 
@@ -630,7 +630,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/feature/get.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/feature/get.ts)_
+[src/commands/feature/get.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/feature/get.ts)_
 
 ## `apollo feature get-id`
 
@@ -660,7 +660,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/feature/get-id.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/feature/get-id.ts)_
+[src/commands/feature/get-id.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/feature/get-id.ts)_
 
 ## `apollo feature import`
 
@@ -689,7 +689,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/feature/import.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/feature/import.ts)_
+[src/commands/feature/import.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/feature/import.ts)_
 
 ## `apollo feature search`
 
@@ -741,7 +741,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/feature/search.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/feature/search.ts)_
+[src/commands/feature/search.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/feature/search.ts)_
 
 ## `apollo help [COMMANDS]`
 
@@ -803,7 +803,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/login.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/login.ts)_
+[src/commands/login.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/login.ts)_
 
 ## `apollo logout`
 
@@ -833,7 +833,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/logout.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/logout.ts)_
+[src/commands/logout.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/logout.ts)_
 
 ## `apollo refseq get`
 
@@ -866,7 +866,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/refseq/get.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/refseq/get.ts)_
+[src/commands/refseq/get.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/refseq/get.ts)_
 
 ## `apollo status`
 
@@ -889,7 +889,7 @@ DESCRIPTION
 ```
 
 _See code:
-[src/commands/status.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/status.ts)_
+[src/commands/status.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/status.ts)_
 
 ## `apollo user get`
 
@@ -925,6 +925,6 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/user/get.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/user/get.ts)_
+[src/commands/user/get.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/user/get.ts)_
 
 <!-- commandsstop -->

--- a/packages/apollo-cli/README.md
+++ b/packages/apollo-cli/README.md
@@ -12,11 +12,11 @@
 <!-- usage -->
 
 ```sh-session
-$ npm install -g @apollo-annotation/apollo-cli
+$ npm install -g @apollo-annotation/cli
 $ apollo COMMAND
 running command...
 $ apollo (--version)
-@apollo-annotation/apollo-cli/0.1.1 linux-x64 node-v18.19.0
+@apollo-annotation/cli/0.1.1 linux-x64 node-v18.19.0
 $ apollo --help [COMMAND]
 USAGE
   $ apollo COMMAND

--- a/packages/apollo-cli/README.md
+++ b/packages/apollo-cli/README.md
@@ -16,7 +16,7 @@ $ npm install -g @apollo-annotation/cli
 $ apollo COMMAND
 running command...
 $ apollo (--version)
-@apollo-annotation/cli/0.1.1 linux-x64 node-v18.19.0
+@apollo-annotation/cli/0.0.0 linux-x64 node-v18.19.0
 $ apollo --help [COMMAND]
 USAGE
   $ apollo COMMAND
@@ -87,7 +87,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/assembly/add-fasta.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/assembly/add-fasta.ts)_
+[src/commands/assembly/add-fasta.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/assembly/add-fasta.ts)_
 
 ## `apollo assembly add-gff`
 
@@ -122,7 +122,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/assembly/add-gff.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/assembly/add-gff.ts)_
+[src/commands/assembly/add-gff.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/assembly/add-gff.ts)_
 
 ## `apollo assembly check`
 
@@ -165,7 +165,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/assembly/check.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/assembly/check.ts)_
+[src/commands/assembly/check.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/assembly/check.ts)_
 
 ## `apollo assembly delete`
 
@@ -193,7 +193,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/assembly/delete.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/assembly/delete.ts)_
+[src/commands/assembly/delete.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/assembly/delete.ts)_
 
 ## `apollo assembly get`
 
@@ -215,7 +215,7 @@ DESCRIPTION
 ```
 
 _See code:
-[src/commands/assembly/get.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/assembly/get.ts)_
+[src/commands/assembly/get.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/assembly/get.ts)_
 
 ## `apollo assembly sequence`
 
@@ -250,7 +250,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/assembly/sequence.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/assembly/sequence.ts)_
+[src/commands/assembly/sequence.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/assembly/sequence.ts)_
 
 ## `apollo change get`
 
@@ -275,7 +275,7 @@ DESCRIPTION
 ```
 
 _See code:
-[src/commands/change/get.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/change/get.ts)_
+[src/commands/change/get.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/change/get.ts)_
 
 ## `apollo config [KEY] [VALUE]`
 
@@ -331,7 +331,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/config.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/config.ts)_
+[src/commands/config.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/config.ts)_
 
 ## `apollo feature add-child`
 
@@ -362,7 +362,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/feature/add-child.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/feature/add-child.ts)_
+[src/commands/feature/add-child.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/feature/add-child.ts)_
 
 ## `apollo feature check`
 
@@ -396,7 +396,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/feature/check.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/feature/check.ts)_
+[src/commands/feature/check.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/feature/check.ts)_
 
 ## `apollo feature copy`
 
@@ -428,7 +428,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/feature/copy.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/feature/copy.ts)_
+[src/commands/feature/copy.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/feature/copy.ts)_
 
 ## `apollo feature delete`
 
@@ -453,7 +453,7 @@ DESCRIPTION
 ```
 
 _See code:
-[src/commands/feature/delete.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/feature/delete.ts)_
+[src/commands/feature/delete.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/feature/delete.ts)_
 
 ## `apollo feature edit`
 
@@ -496,7 +496,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/feature/edit.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/feature/edit.ts)_
+[src/commands/feature/edit.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/feature/edit.ts)_
 
 ## `apollo feature edit-attribute`
 
@@ -537,7 +537,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/feature/edit-attribute.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/feature/edit-attribute.ts)_
+[src/commands/feature/edit-attribute.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/feature/edit-attribute.ts)_
 
 ## `apollo feature edit-coords`
 
@@ -572,7 +572,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/feature/edit-coords.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/feature/edit-coords.ts)_
+[src/commands/feature/edit-coords.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/feature/edit-coords.ts)_
 
 ## `apollo feature edit-type`
 
@@ -596,7 +596,7 @@ DESCRIPTION
 ```
 
 _See code:
-[src/commands/feature/edit-type.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/feature/edit-type.ts)_
+[src/commands/feature/edit-type.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/feature/edit-type.ts)_
 
 ## `apollo feature get`
 
@@ -630,7 +630,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/feature/get.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/feature/get.ts)_
+[src/commands/feature/get.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/feature/get.ts)_
 
 ## `apollo feature get-id`
 
@@ -660,7 +660,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/feature/get-id.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/feature/get-id.ts)_
+[src/commands/feature/get-id.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/feature/get-id.ts)_
 
 ## `apollo feature import`
 
@@ -689,7 +689,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/feature/import.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/feature/import.ts)_
+[src/commands/feature/import.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/feature/import.ts)_
 
 ## `apollo feature search`
 
@@ -741,7 +741,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/feature/search.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/feature/search.ts)_
+[src/commands/feature/search.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/feature/search.ts)_
 
 ## `apollo help [COMMANDS]`
 
@@ -803,7 +803,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/login.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/login.ts)_
+[src/commands/login.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/login.ts)_
 
 ## `apollo logout`
 
@@ -833,7 +833,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/logout.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/logout.ts)_
+[src/commands/logout.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/logout.ts)_
 
 ## `apollo refseq get`
 
@@ -866,7 +866,7 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/refseq/get.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/refseq/get.ts)_
+[src/commands/refseq/get.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/refseq/get.ts)_
 
 ## `apollo status`
 
@@ -889,7 +889,7 @@ DESCRIPTION
 ```
 
 _See code:
-[src/commands/status.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/status.ts)_
+[src/commands/status.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/status.ts)_
 
 ## `apollo user get`
 
@@ -925,6 +925,6 @@ EXAMPLES
 ```
 
 _See code:
-[src/commands/user/get.ts](https://github.com/GMOD/Apollo3/blob/v0.1.1/packages/apollo-cli/src/commands/user/get.ts)_
+[src/commands/user/get.ts](https://github.com/GMOD/Apollo3/blob/v0.0.0/packages/apollo-cli/src/commands/user/get.ts)_
 
 <!-- commandsstop -->

--- a/packages/apollo-cli/package.json
+++ b/packages/apollo-cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@apollo-annotation/apollo-cli",
+  "name": "@apollo-annotation/cli",
   "description": "Command line interface for the Apollo annotation server",
   "version": "0.1.1",
   "author": "Apollo Team",

--- a/packages/apollo-cli/package.json
+++ b/packages/apollo-cli/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "apollo-cli",
+  "name": "@apollo-annotation/apollo-cli",
   "description": "Command line interface for the Apollo annotation server",
-  "version": "0.0.0",
+  "version": "0.1.1",
   "author": "Apollo Team",
   "repository": {
     "type": "git",
@@ -93,5 +93,8 @@
         "description": "Commands to handle users"
       }
     }
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/apollo-cli/package.json
+++ b/packages/apollo-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apollo-annotation/cli",
   "description": "Command line interface for the Apollo annotation server",
-  "version": "0.1.1",
+  "version": "0.0.0",
   "author": "Apollo Team",
   "repository": {
     "type": "git",

--- a/packages/apollo-collaboration-server/package.json
+++ b/packages/apollo-collaboration-server/package.json
@@ -24,6 +24,9 @@
     "cypress:start": "GUEST_USER_ROLE=admin MONGODB_URI=\"mongodb://localhost:27017/apolloTestDb?directConnection=true\" LOG_LEVELS=error,warn yarn start"
   },
   "dependencies": {
+    "@apollo-annotation/apollo-common": "workspace:^",
+    "@apollo-annotation/apollo-schemas": "workspace:^",
+    "@apollo-annotation/apollo-shared": "workspace:^",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
     "@gmod/gff": "1.2.0",
@@ -43,9 +46,6 @@
     "@nestjs/serve-static": "^4.0.0",
     "@nestjs/terminus": "^10.0.1",
     "@nestjs/websockets": "^10.1.0",
-    "apollo-common": "workspace:^",
-    "apollo-schemas": "workspace:^",
-    "apollo-shared": "workspace:^",
     "connect-mongodb-session": "^3.1.1",
     "express": "^4.18.0",
     "express-session": "^1.17.3",
@@ -76,6 +76,7 @@
     "tss-react": "^4.6.1"
   },
   "devDependencies": {
+    "@apollo-annotation/apollo-mst": "workspace:^",
     "@nestjs/cli": "^10.1.10",
     "@nestjs/schematics": "^10.0.1",
     "@nestjs/testing": "^10.1.0",
@@ -91,7 +92,6 @@
     "@types/passport-microsoft": "^0.0.0",
     "@types/react": "^17.0.34",
     "@types/supertest": "^2.0.11",
-    "apollo-mst": "workspace:^",
     "jest": "^29.6.2",
     "mongodb": "^4.7.0",
     "prettier": "^3.2.5",

--- a/packages/apollo-collaboration-server/package.json
+++ b/packages/apollo-collaboration-server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "apollo-collaboration-server",
+  "name": "@apollo-annotation/collaboration-server",
   "version": "1.0.0-alpha.0",
   "description": "",
   "author": "",
@@ -24,9 +24,9 @@
     "cypress:start": "GUEST_USER_ROLE=admin MONGODB_URI=\"mongodb://localhost:27017/apolloTestDb?directConnection=true\" LOG_LEVELS=error,warn yarn start"
   },
   "dependencies": {
-    "@apollo-annotation/apollo-common": "workspace:^",
-    "@apollo-annotation/apollo-schemas": "workspace:^",
-    "@apollo-annotation/apollo-shared": "workspace:^",
+    "@apollo-annotation/common": "workspace:^",
+    "@apollo-annotation/schemas": "workspace:^",
+    "@apollo-annotation/shared": "workspace:^",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
     "@gmod/gff": "1.2.0",
@@ -76,7 +76,7 @@
     "tss-react": "^4.6.1"
   },
   "devDependencies": {
-    "@apollo-annotation/apollo-mst": "workspace:^",
+    "@apollo-annotation/mst": "workspace:^",
     "@nestjs/cli": "^10.1.10",
     "@nestjs/schematics": "^10.0.1",
     "@nestjs/testing": "^10.1.0",

--- a/packages/apollo-collaboration-server/src/assemblies/assemblies.module.ts
+++ b/packages/apollo-collaboration-server/src/assemblies/assemblies.module.ts
@@ -1,4 +1,4 @@
-import { Assembly, AssemblySchema } from '@apollo-annotation/apollo-schemas'
+import { Assembly, AssemblySchema } from '@apollo-annotation/schemas'
 import { Module } from '@nestjs/common'
 import { MongooseModule } from '@nestjs/mongoose'
 

--- a/packages/apollo-collaboration-server/src/assemblies/assemblies.module.ts
+++ b/packages/apollo-collaboration-server/src/assemblies/assemblies.module.ts
@@ -1,6 +1,6 @@
+import { Assembly, AssemblySchema } from '@apollo-annotation/apollo-schemas'
 import { Module } from '@nestjs/common'
 import { MongooseModule } from '@nestjs/mongoose'
-import { Assembly, AssemblySchema } from 'apollo-schemas'
 
 import { OperationsModule } from '../operations/operations.module'
 import { AssembliesController } from './assemblies.controller'

--- a/packages/apollo-collaboration-server/src/assemblies/assemblies.service.ts
+++ b/packages/apollo-collaboration-server/src/assemblies/assemblies.service.ts
@@ -1,3 +1,5 @@
+import { Assembly, AssemblyDocument } from '@apollo-annotation/apollo-schemas'
+import { GetAssembliesOperation } from '@apollo-annotation/apollo-shared'
 import {
   Injectable,
   Logger,
@@ -5,8 +7,6 @@ import {
   UnprocessableEntityException,
 } from '@nestjs/common'
 import { InjectModel } from '@nestjs/mongoose'
-import { Assembly, AssemblyDocument } from 'apollo-schemas'
-import { GetAssembliesOperation } from 'apollo-shared'
 import { Model } from 'mongoose'
 
 import { OperationsService } from '../operations/operations.service'

--- a/packages/apollo-collaboration-server/src/assemblies/assemblies.service.ts
+++ b/packages/apollo-collaboration-server/src/assemblies/assemblies.service.ts
@@ -1,5 +1,5 @@
-import { Assembly, AssemblyDocument } from '@apollo-annotation/apollo-schemas'
-import { GetAssembliesOperation } from '@apollo-annotation/apollo-shared'
+import { Assembly, AssemblyDocument } from '@apollo-annotation/schemas'
+import { GetAssembliesOperation } from '@apollo-annotation/shared'
 import {
   Injectable,
   Logger,

--- a/packages/apollo-collaboration-server/src/authentication/authentication.service.ts
+++ b/packages/apollo-collaboration-server/src/authentication/authentication.service.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import fs from 'node:fs/promises'
 
+import { JWTPayload } from '@apollo-annotation/apollo-shared'
 import {
   BadRequestException,
   Injectable,
@@ -10,7 +11,6 @@ import {
 } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { JwtService } from '@nestjs/jwt'
-import { JWTPayload } from 'apollo-shared'
 import { Request } from 'express'
 import { Profile as GoogleProfile } from 'passport-google-oauth20'
 

--- a/packages/apollo-collaboration-server/src/authentication/authentication.service.ts
+++ b/packages/apollo-collaboration-server/src/authentication/authentication.service.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import fs from 'node:fs/promises'
 
-import { JWTPayload } from '@apollo-annotation/apollo-shared'
+import { JWTPayload } from '@apollo-annotation/shared'
 import {
   BadRequestException,
   Injectable,

--- a/packages/apollo-collaboration-server/src/changes/changes.controller.ts
+++ b/packages/apollo-collaboration-server/src/changes/changes.controller.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-import { Change } from '@apollo-annotation/apollo-common'
-import { DecodedJWT } from '@apollo-annotation/apollo-shared'
+import { Change } from '@apollo-annotation/common'
+import { DecodedJWT } from '@apollo-annotation/shared'
 import { Body, Controller, Get, Logger, Post, Query, Req } from '@nestjs/common'
 import { Request } from 'express'
 

--- a/packages/apollo-collaboration-server/src/changes/changes.controller.ts
+++ b/packages/apollo-collaboration-server/src/changes/changes.controller.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
+import { Change } from '@apollo-annotation/apollo-common'
+import { DecodedJWT } from '@apollo-annotation/apollo-shared'
 import { Body, Controller, Get, Logger, Post, Query, Req } from '@nestjs/common'
-import { Change } from 'apollo-common'
-import { DecodedJWT } from 'apollo-shared'
 import { Request } from 'express'
 
 import { ParseChangePipe } from '../utils/parse-change.pipe'

--- a/packages/apollo-collaboration-server/src/changes/changes.module.ts
+++ b/packages/apollo-collaboration-server/src/changes/changes.module.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { Change, ChangeSchema } from '@apollo-annotation/apollo-schemas'
+import { Change, ChangeSchema } from '@apollo-annotation/schemas'
 import { Module } from '@nestjs/common'
 import { MongooseModule, getConnectionToken } from '@nestjs/mongoose'
 import idValidator from 'mongoose-id-validator'

--- a/packages/apollo-collaboration-server/src/changes/changes.module.ts
+++ b/packages/apollo-collaboration-server/src/changes/changes.module.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { Change, ChangeSchema } from '@apollo-annotation/apollo-schemas'
 import { Module } from '@nestjs/common'
 import { MongooseModule, getConnectionToken } from '@nestjs/mongoose'
-import { Change, ChangeSchema } from 'apollo-schemas'
 import idValidator from 'mongoose-id-validator'
 
 import { AssembliesModule } from '../assemblies/assemblies.module'

--- a/packages/apollo-collaboration-server/src/changes/changes.service.ts
+++ b/packages/apollo-collaboration-server/src/changes/changes.service.ts
@@ -1,15 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import {
-  Logger,
-  NotFoundException,
-  UnprocessableEntityException,
-} from '@nestjs/common'
-import { InjectModel } from '@nestjs/mongoose'
-import {
   Change as BaseChange,
   isAssemblySpecificChange,
   isFeatureChange,
-} from 'apollo-common'
+} from '@apollo-annotation/apollo-common'
 import {
   Assembly,
   AssemblyDocument,
@@ -25,13 +19,19 @@ import {
   RefSeqDocument,
   User,
   UserDocument,
-} from 'apollo-schemas'
+} from '@apollo-annotation/apollo-schemas'
 import {
   ChangeMessage,
   DecodedJWT,
   makeUserSessionId,
   validationRegistry,
-} from 'apollo-shared'
+} from '@apollo-annotation/apollo-shared'
+import {
+  Logger,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common'
+import { InjectModel } from '@nestjs/mongoose'
 import { FilterQuery, Model } from 'mongoose'
 
 import { CountersService } from '../counters/counters.service'

--- a/packages/apollo-collaboration-server/src/changes/changes.service.ts
+++ b/packages/apollo-collaboration-server/src/changes/changes.service.ts
@@ -3,7 +3,7 @@ import {
   Change as BaseChange,
   isAssemblySpecificChange,
   isFeatureChange,
-} from '@apollo-annotation/apollo-common'
+} from '@apollo-annotation/common'
 import {
   Assembly,
   AssemblyDocument,
@@ -19,13 +19,13 @@ import {
   RefSeqDocument,
   User,
   UserDocument,
-} from '@apollo-annotation/apollo-schemas'
+} from '@apollo-annotation/schemas'
 import {
   ChangeMessage,
   DecodedJWT,
   makeUserSessionId,
   validationRegistry,
-} from '@apollo-annotation/apollo-shared'
+} from '@apollo-annotation/shared'
 import {
   Logger,
   NotFoundException,

--- a/packages/apollo-collaboration-server/src/checks/checks.module.ts
+++ b/packages/apollo-collaboration-server/src/checks/checks.module.ts
@@ -1,14 +1,14 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
-import { CheckResultSnapshot } from '@apollo-annotation/apollo-mst'
+import { CheckResultSnapshot } from '@apollo-annotation/mst'
 import {
   Check,
   CheckResult,
   CheckResultDocument,
   CheckResultSchema,
   CheckSchema,
-} from '@apollo-annotation/apollo-schemas'
-import { CheckResultUpdate } from '@apollo-annotation/apollo-shared'
+} from '@apollo-annotation/schemas'
+import { CheckResultUpdate } from '@apollo-annotation/shared'
 import { Module } from '@nestjs/common'
 import { MongooseModule, getConnectionToken } from '@nestjs/mongoose'
 import idValidator from 'mongoose-id-validator'

--- a/packages/apollo-collaboration-server/src/checks/checks.module.ts
+++ b/packages/apollo-collaboration-server/src/checks/checks.module.ts
@@ -1,16 +1,16 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
-import { Module } from '@nestjs/common'
-import { MongooseModule, getConnectionToken } from '@nestjs/mongoose'
-import { CheckResultSnapshot } from 'apollo-mst'
+import { CheckResultSnapshot } from '@apollo-annotation/apollo-mst'
 import {
   Check,
   CheckResult,
   CheckResultDocument,
   CheckResultSchema,
   CheckSchema,
-} from 'apollo-schemas'
-import { CheckResultUpdate } from 'apollo-shared'
+} from '@apollo-annotation/apollo-schemas'
+import { CheckResultUpdate } from '@apollo-annotation/apollo-shared'
+import { Module } from '@nestjs/common'
+import { MongooseModule, getConnectionToken } from '@nestjs/mongoose'
 import idValidator from 'mongoose-id-validator'
 
 import { MessagesGateway } from '../messages/messages.gateway'

--- a/packages/apollo-collaboration-server/src/checks/checks.service.ts
+++ b/packages/apollo-collaboration-server/src/checks/checks.service.ts
@@ -2,11 +2,8 @@
 /* eslint-disable @typescript-eslint/no-base-to-string */
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-import { BgzipIndexedFasta, IndexedFasta } from '@gmod/indexedfasta'
-import { Injectable, Logger } from '@nestjs/common'
-import { InjectModel } from '@nestjs/mongoose'
-import { checkRegistry } from 'apollo-common'
-import { AnnotationFeatureSnapshot } from 'apollo-mst'
+import { checkRegistry } from '@apollo-annotation/apollo-common'
+import { AnnotationFeatureSnapshot } from '@apollo-annotation/apollo-mst'
 import {
   Assembly,
   AssemblyDocument,
@@ -19,7 +16,10 @@ import {
   RefSeqChunk,
   RefSeqChunkDocument,
   RefSeqDocument,
-} from 'apollo-schemas'
+} from '@apollo-annotation/apollo-schemas'
+import { BgzipIndexedFasta, IndexedFasta } from '@gmod/indexedfasta'
+import { Injectable, Logger } from '@nestjs/common'
+import { InjectModel } from '@nestjs/mongoose'
 import { RemoteFile } from 'generic-filehandle'
 import { Model } from 'mongoose'
 

--- a/packages/apollo-collaboration-server/src/checks/checks.service.ts
+++ b/packages/apollo-collaboration-server/src/checks/checks.service.ts
@@ -2,8 +2,8 @@
 /* eslint-disable @typescript-eslint/no-base-to-string */
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-import { checkRegistry } from '@apollo-annotation/apollo-common'
-import { AnnotationFeatureSnapshot } from '@apollo-annotation/apollo-mst'
+import { checkRegistry } from '@apollo-annotation/common'
+import { AnnotationFeatureSnapshot } from '@apollo-annotation/mst'
 import {
   Assembly,
   AssemblyDocument,
@@ -16,7 +16,7 @@ import {
   RefSeqChunk,
   RefSeqChunkDocument,
   RefSeqDocument,
-} from '@apollo-annotation/apollo-schemas'
+} from '@apollo-annotation/schemas'
 import { BgzipIndexedFasta, IndexedFasta } from '@gmod/indexedfasta'
 import { Injectable, Logger } from '@nestjs/common'
 import { InjectModel } from '@nestjs/mongoose'

--- a/packages/apollo-collaboration-server/src/counters/counters.module.ts
+++ b/packages/apollo-collaboration-server/src/counters/counters.module.ts
@@ -1,6 +1,6 @@
+import { Counter, CounterSchema } from '@apollo-annotation/apollo-schemas'
 import { Module } from '@nestjs/common'
 import { MongooseModule } from '@nestjs/mongoose'
-import { Counter, CounterSchema } from 'apollo-schemas'
 
 import { CountersService } from './counters.service'
 

--- a/packages/apollo-collaboration-server/src/counters/counters.module.ts
+++ b/packages/apollo-collaboration-server/src/counters/counters.module.ts
@@ -1,4 +1,4 @@
-import { Counter, CounterSchema } from '@apollo-annotation/apollo-schemas'
+import { Counter, CounterSchema } from '@apollo-annotation/schemas'
 import { Module } from '@nestjs/common'
 import { MongooseModule } from '@nestjs/mongoose'
 

--- a/packages/apollo-collaboration-server/src/counters/counters.service.ts
+++ b/packages/apollo-collaboration-server/src/counters/counters.service.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-import { Counter, CounterDocument } from '@apollo-annotation/apollo-schemas'
+import { Counter, CounterDocument } from '@apollo-annotation/schemas'
 import { Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { InjectModel } from '@nestjs/mongoose'
 import { Model } from 'mongoose'

--- a/packages/apollo-collaboration-server/src/counters/counters.service.ts
+++ b/packages/apollo-collaboration-server/src/counters/counters.service.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
+import { Counter, CounterDocument } from '@apollo-annotation/apollo-schemas'
 import { Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { InjectModel } from '@nestjs/mongoose'
-import { Counter, CounterDocument } from 'apollo-schemas'
 import { Model } from 'mongoose'
 
 @Injectable()

--- a/packages/apollo-collaboration-server/src/export/export.module.ts
+++ b/packages/apollo-collaboration-server/src/export/export.module.ts
@@ -1,4 +1,4 @@
-import { Export, ExportSchema } from '@apollo-annotation/apollo-schemas'
+import { Export, ExportSchema } from '@apollo-annotation/schemas'
 import { Module } from '@nestjs/common'
 import { MongooseModule } from '@nestjs/mongoose'
 

--- a/packages/apollo-collaboration-server/src/export/export.module.ts
+++ b/packages/apollo-collaboration-server/src/export/export.module.ts
@@ -1,6 +1,6 @@
+import { Export, ExportSchema } from '@apollo-annotation/apollo-schemas'
 import { Module } from '@nestjs/common'
 import { MongooseModule } from '@nestjs/mongoose'
-import { Export, ExportSchema } from 'apollo-schemas'
 
 import { AssembliesModule } from '../assemblies/assemblies.module'
 import { FeaturesModule } from '../features/features.module'

--- a/packages/apollo-collaboration-server/src/export/export.service.ts
+++ b/packages/apollo-collaboration-server/src/export/export.service.ts
@@ -11,10 +11,7 @@ import {
   pipeline,
 } from 'node:stream'
 
-import gff from '@gmod/gff'
-import { Injectable, Logger, NotFoundException } from '@nestjs/common'
-import { InjectModel } from '@nestjs/mongoose'
-import { AnnotationFeatureSnapshot } from 'apollo-mst'
+import { AnnotationFeatureSnapshot } from '@apollo-annotation/apollo-mst'
 import {
   Assembly,
   AssemblyDocument,
@@ -26,8 +23,14 @@ import {
   RefSeqChunk,
   RefSeqChunkDocument,
   RefSeqDocument,
-} from 'apollo-schemas'
-import { makeGFF3Feature, splitStringIntoChunks } from 'apollo-shared'
+} from '@apollo-annotation/apollo-schemas'
+import {
+  makeGFF3Feature,
+  splitStringIntoChunks,
+} from '@apollo-annotation/apollo-shared'
+import gff from '@gmod/gff'
+import { Injectable, Logger, NotFoundException } from '@nestjs/common'
+import { InjectModel } from '@nestjs/mongoose'
 import { Model } from 'mongoose'
 import StreamConcat from 'stream-concat'
 

--- a/packages/apollo-collaboration-server/src/export/export.service.ts
+++ b/packages/apollo-collaboration-server/src/export/export.service.ts
@@ -11,7 +11,7 @@ import {
   pipeline,
 } from 'node:stream'
 
-import { AnnotationFeatureSnapshot } from '@apollo-annotation/apollo-mst'
+import { AnnotationFeatureSnapshot } from '@apollo-annotation/mst'
 import {
   Assembly,
   AssemblyDocument,
@@ -23,11 +23,11 @@ import {
   RefSeqChunk,
   RefSeqChunkDocument,
   RefSeqDocument,
-} from '@apollo-annotation/apollo-schemas'
+} from '@apollo-annotation/schemas'
 import {
   makeGFF3Feature,
   splitStringIntoChunks,
-} from '@apollo-annotation/apollo-shared'
+} from '@apollo-annotation/shared'
 import gff from '@gmod/gff'
 import { Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { InjectModel } from '@nestjs/mongoose'

--- a/packages/apollo-collaboration-server/src/features/features.module.ts
+++ b/packages/apollo-collaboration-server/src/features/features.module.ts
@@ -3,7 +3,7 @@ import {
   Feature,
   FeatureDocument,
   FeatureSchema,
-} from '@apollo-annotation/apollo-schemas'
+} from '@apollo-annotation/schemas'
 import { Module, forwardRef } from '@nestjs/common'
 import { MongooseModule, getConnectionToken } from '@nestjs/mongoose'
 import { Connection } from 'mongoose'

--- a/packages/apollo-collaboration-server/src/features/features.module.ts
+++ b/packages/apollo-collaboration-server/src/features/features.module.ts
@@ -1,7 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
+import {
+  Feature,
+  FeatureDocument,
+  FeatureSchema,
+} from '@apollo-annotation/apollo-schemas'
 import { Module, forwardRef } from '@nestjs/common'
 import { MongooseModule, getConnectionToken } from '@nestjs/mongoose'
-import { Feature, FeatureDocument, FeatureSchema } from 'apollo-schemas'
 import { Connection } from 'mongoose'
 import idValidator from 'mongoose-id-validator'
 

--- a/packages/apollo-collaboration-server/src/features/features.service.ts
+++ b/packages/apollo-collaboration-server/src/features/features.service.ts
@@ -1,14 +1,14 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
-import { Injectable, Logger, NotFoundException } from '@nestjs/common'
-import { InjectModel } from '@nestjs/mongoose'
 import {
   Feature,
   FeatureDocument,
   RefSeq,
   RefSeqDocument,
-} from 'apollo-schemas'
-import { GetFeaturesOperation } from 'apollo-shared'
+} from '@apollo-annotation/apollo-schemas'
+import { GetFeaturesOperation } from '@apollo-annotation/apollo-shared'
+import { Injectable, Logger, NotFoundException } from '@nestjs/common'
+import { InjectModel } from '@nestjs/mongoose'
 import { Model } from 'mongoose'
 
 import { ChecksService } from '../checks/checks.service'

--- a/packages/apollo-collaboration-server/src/features/features.service.ts
+++ b/packages/apollo-collaboration-server/src/features/features.service.ts
@@ -5,8 +5,8 @@ import {
   FeatureDocument,
   RefSeq,
   RefSeqDocument,
-} from '@apollo-annotation/apollo-schemas'
-import { GetFeaturesOperation } from '@apollo-annotation/apollo-shared'
+} from '@apollo-annotation/schemas'
+import { GetFeaturesOperation } from '@apollo-annotation/shared'
 import { Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { InjectModel } from '@nestjs/mongoose'
 import { Model } from 'mongoose'

--- a/packages/apollo-collaboration-server/src/files/files.module.ts
+++ b/packages/apollo-collaboration-server/src/files/files.module.ts
@@ -1,6 +1,6 @@
+import { File, FileSchema } from '@apollo-annotation/apollo-schemas'
 import { Module } from '@nestjs/common'
 import { MongooseModule } from '@nestjs/mongoose'
-import { File, FileSchema } from 'apollo-schemas'
 
 import { FilesController } from './files.controller'
 import { FilesService } from './files.service'

--- a/packages/apollo-collaboration-server/src/files/files.module.ts
+++ b/packages/apollo-collaboration-server/src/files/files.module.ts
@@ -1,4 +1,4 @@
-import { File, FileSchema } from '@apollo-annotation/apollo-schemas'
+import { File, FileSchema } from '@apollo-annotation/schemas'
 import { Module } from '@nestjs/common'
 import { MongooseModule } from '@nestjs/mongoose'
 

--- a/packages/apollo-collaboration-server/src/files/files.service.ts
+++ b/packages/apollo-collaboration-server/src/files/files.service.ts
@@ -3,7 +3,7 @@ import { unlink } from 'node:fs/promises'
 import { join } from 'node:path'
 import { Gunzip, createGunzip } from 'node:zlib'
 
-import { File, FileDocument } from '@apollo-annotation/apollo-schemas'
+import { File, FileDocument } from '@apollo-annotation/schemas'
 import gff from '@gmod/gff'
 import {
   Injectable,

--- a/packages/apollo-collaboration-server/src/files/files.service.ts
+++ b/packages/apollo-collaboration-server/src/files/files.service.ts
@@ -3,6 +3,7 @@ import { unlink } from 'node:fs/promises'
 import { join } from 'node:path'
 import { Gunzip, createGunzip } from 'node:zlib'
 
+import { File, FileDocument } from '@apollo-annotation/apollo-schemas'
 import gff from '@gmod/gff'
 import {
   Injectable,
@@ -12,7 +13,6 @@ import {
 } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { InjectModel } from '@nestjs/mongoose'
-import { File, FileDocument } from 'apollo-schemas'
 import { Model } from 'mongoose'
 
 import { CreateFileDto } from './dto/create-file.dto'

--- a/packages/apollo-collaboration-server/src/main.ts
+++ b/packages/apollo-collaboration-server/src/main.ts
@@ -3,15 +3,13 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 import fs from 'node:fs'
 
-import { LogLevel } from '@nestjs/common'
-import { HttpAdapterHost, NestFactory } from '@nestjs/core'
 import {
   Check,
   changeRegistry,
   checkRegistry,
   operationRegistry,
-} from 'apollo-common'
-import { CheckSchema } from 'apollo-schemas'
+} from '@apollo-annotation/apollo-common'
+import { CheckSchema } from '@apollo-annotation/apollo-schemas'
 import {
   CDSCheck,
   CoreValidation,
@@ -19,7 +17,9 @@ import {
   changes,
   operations,
   validationRegistry,
-} from 'apollo-shared'
+} from '@apollo-annotation/apollo-shared'
+import { LogLevel } from '@nestjs/common'
+import { HttpAdapterHost, NestFactory } from '@nestjs/core'
 import connectMongoDBSession from 'connect-mongodb-session'
 import session from 'express-session'
 import mongoose from 'mongoose'

--- a/packages/apollo-collaboration-server/src/main.ts
+++ b/packages/apollo-collaboration-server/src/main.ts
@@ -8,8 +8,8 @@ import {
   changeRegistry,
   checkRegistry,
   operationRegistry,
-} from '@apollo-annotation/apollo-common'
-import { CheckSchema } from '@apollo-annotation/apollo-schemas'
+} from '@apollo-annotation/common'
+import { CheckSchema } from '@apollo-annotation/schemas'
 import {
   CDSCheck,
   CoreValidation,
@@ -17,7 +17,7 @@ import {
   changes,
   operations,
   validationRegistry,
-} from '@apollo-annotation/apollo-shared'
+} from '@apollo-annotation/shared'
 import { LogLevel } from '@nestjs/common'
 import { HttpAdapterHost, NestFactory } from '@nestjs/core'
 import connectMongoDBSession from 'connect-mongodb-session'

--- a/packages/apollo-collaboration-server/src/operations/operations.service.ts
+++ b/packages/apollo-collaboration-server/src/operations/operations.service.ts
@@ -1,4 +1,4 @@
-import { Operation, operationRegistry } from '@apollo-annotation/apollo-common'
+import { Operation, operationRegistry } from '@apollo-annotation/common'
 import {
   Assembly,
   AssemblyDocument,
@@ -12,7 +12,7 @@ import {
   RefSeqDocument,
   User,
   UserDocument,
-} from '@apollo-annotation/apollo-schemas'
+} from '@apollo-annotation/schemas'
 import { Injectable, Logger } from '@nestjs/common'
 import { InjectConnection, InjectModel } from '@nestjs/mongoose'
 import { Connection, Model } from 'mongoose'

--- a/packages/apollo-collaboration-server/src/operations/operations.service.ts
+++ b/packages/apollo-collaboration-server/src/operations/operations.service.ts
@@ -1,6 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common'
-import { InjectConnection, InjectModel } from '@nestjs/mongoose'
-import { Operation, operationRegistry } from 'apollo-common'
+import { Operation, operationRegistry } from '@apollo-annotation/apollo-common'
 import {
   Assembly,
   AssemblyDocument,
@@ -14,7 +12,9 @@ import {
   RefSeqDocument,
   User,
   UserDocument,
-} from 'apollo-schemas'
+} from '@apollo-annotation/apollo-schemas'
+import { Injectable, Logger } from '@nestjs/common'
+import { InjectConnection, InjectModel } from '@nestjs/mongoose'
 import { Connection, Model } from 'mongoose'
 
 import { CountersService } from '../counters/counters.service'

--- a/packages/apollo-collaboration-server/src/plugins/plugins.module.ts
+++ b/packages/apollo-collaboration-server/src/plugins/plugins.module.ts
@@ -8,7 +8,7 @@ import path from 'node:path'
 import {
   ApolloPlugin,
   ApolloPluginConstructor,
-} from '@apollo-annotation/apollo-common'
+} from '@apollo-annotation/common'
 import { DynamicModule, Logger, Module, Provider } from '@nestjs/common'
 import fetch from 'node-fetch'
 import sanitize from 'sanitize-filename'

--- a/packages/apollo-collaboration-server/src/plugins/plugins.module.ts
+++ b/packages/apollo-collaboration-server/src/plugins/plugins.module.ts
@@ -5,8 +5,11 @@ import fs from 'node:fs'
 import fsPromises from 'node:fs/promises'
 import path from 'node:path'
 
+import {
+  ApolloPlugin,
+  ApolloPluginConstructor,
+} from '@apollo-annotation/apollo-common'
 import { DynamicModule, Logger, Module, Provider } from '@nestjs/common'
-import { ApolloPlugin, ApolloPluginConstructor } from 'apollo-common'
 import fetch from 'node-fetch'
 import sanitize from 'sanitize-filename'
 

--- a/packages/apollo-collaboration-server/src/plugins/plugins.service.ts
+++ b/packages/apollo-collaboration-server/src/plugins/plugins.service.ts
@@ -1,4 +1,4 @@
-import { ApolloPlugin } from '@apollo-annotation/apollo-common'
+import { ApolloPlugin } from '@apollo-annotation/common'
 import { Inject, Injectable } from '@nestjs/common'
 
 import { APOLLO_PLUGINS } from './plugins.constants'

--- a/packages/apollo-collaboration-server/src/plugins/plugins.service.ts
+++ b/packages/apollo-collaboration-server/src/plugins/plugins.service.ts
@@ -1,5 +1,5 @@
+import { ApolloPlugin } from '@apollo-annotation/apollo-common'
 import { Inject, Injectable } from '@nestjs/common'
-import { ApolloPlugin } from 'apollo-common'
 
 import { APOLLO_PLUGINS } from './plugins.constants'
 

--- a/packages/apollo-collaboration-server/src/refSeqChunks/refSeqChunks.module.ts
+++ b/packages/apollo-collaboration-server/src/refSeqChunks/refSeqChunks.module.ts
@@ -1,7 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import {
+  RefSeqChunk,
+  RefSeqChunkSchema,
+} from '@apollo-annotation/apollo-schemas'
 import { Module } from '@nestjs/common'
 import { MongooseModule, getConnectionToken } from '@nestjs/mongoose'
-import { RefSeqChunk, RefSeqChunkSchema } from 'apollo-schemas'
 import idValidator from 'mongoose-id-validator'
 
 @Module({

--- a/packages/apollo-collaboration-server/src/refSeqChunks/refSeqChunks.module.ts
+++ b/packages/apollo-collaboration-server/src/refSeqChunks/refSeqChunks.module.ts
@@ -1,8 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import {
-  RefSeqChunk,
-  RefSeqChunkSchema,
-} from '@apollo-annotation/apollo-schemas'
+import { RefSeqChunk, RefSeqChunkSchema } from '@apollo-annotation/schemas'
 import { Module } from '@nestjs/common'
 import { MongooseModule, getConnectionToken } from '@nestjs/mongoose'
 import idValidator from 'mongoose-id-validator'

--- a/packages/apollo-collaboration-server/src/refSeqs/refSeqs.module.ts
+++ b/packages/apollo-collaboration-server/src/refSeqs/refSeqs.module.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { RefSeq, RefSeqSchema } from '@apollo-annotation/apollo-schemas'
+import { RefSeq, RefSeqSchema } from '@apollo-annotation/schemas'
 import { Module } from '@nestjs/common'
 import { MongooseModule, getConnectionToken } from '@nestjs/mongoose'
 import idValidator from 'mongoose-id-validator'

--- a/packages/apollo-collaboration-server/src/refSeqs/refSeqs.module.ts
+++ b/packages/apollo-collaboration-server/src/refSeqs/refSeqs.module.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { RefSeq, RefSeqSchema } from '@apollo-annotation/apollo-schemas'
 import { Module } from '@nestjs/common'
 import { MongooseModule, getConnectionToken } from '@nestjs/mongoose'
-import { RefSeq, RefSeqSchema } from 'apollo-schemas'
 import idValidator from 'mongoose-id-validator'
 
 import { RefSeqsController } from './refSeqs.controller'

--- a/packages/apollo-collaboration-server/src/refSeqs/refSeqs.service.ts
+++ b/packages/apollo-collaboration-server/src/refSeqs/refSeqs.service.ts
@@ -1,4 +1,4 @@
-import { RefSeq, RefSeqDocument } from '@apollo-annotation/apollo-schemas'
+import { RefSeq, RefSeqDocument } from '@apollo-annotation/schemas'
 import { Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { InjectModel } from '@nestjs/mongoose'
 import { Model } from 'mongoose'

--- a/packages/apollo-collaboration-server/src/refSeqs/refSeqs.service.ts
+++ b/packages/apollo-collaboration-server/src/refSeqs/refSeqs.service.ts
@@ -1,6 +1,6 @@
+import { RefSeq, RefSeqDocument } from '@apollo-annotation/apollo-schemas'
 import { Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { InjectModel } from '@nestjs/mongoose'
-import { RefSeq, RefSeqDocument } from 'apollo-schemas'
 import { Model } from 'mongoose'
 
 import { CreateRefSeqDto } from './dto/create-refSeq.dto'

--- a/packages/apollo-collaboration-server/src/sequence/sequence.service.ts
+++ b/packages/apollo-collaboration-server/src/sequence/sequence.service.ts
@@ -5,7 +5,7 @@ import {
   RefSeqChunk,
   RefSeqChunkDocument,
   RefSeqDocument,
-} from '@apollo-annotation/apollo-schemas'
+} from '@apollo-annotation/schemas'
 import { BgzipIndexedFasta, IndexedFasta } from '@gmod/indexedfasta'
 import { Injectable, Logger } from '@nestjs/common'
 import { InjectModel } from '@nestjs/mongoose'

--- a/packages/apollo-collaboration-server/src/sequence/sequence.service.ts
+++ b/packages/apollo-collaboration-server/src/sequence/sequence.service.ts
@@ -1,14 +1,14 @@
 /* eslint-disable @typescript-eslint/no-base-to-string */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-import { BgzipIndexedFasta, IndexedFasta } from '@gmod/indexedfasta'
-import { Injectable, Logger } from '@nestjs/common'
-import { InjectModel } from '@nestjs/mongoose'
 import {
   RefSeq,
   RefSeqChunk,
   RefSeqChunkDocument,
   RefSeqDocument,
-} from 'apollo-schemas'
+} from '@apollo-annotation/apollo-schemas'
+import { BgzipIndexedFasta, IndexedFasta } from '@gmod/indexedfasta'
+import { Injectable, Logger } from '@nestjs/common'
+import { InjectModel } from '@nestjs/mongoose'
 import { RemoteFile } from 'generic-filehandle'
 import { Model } from 'mongoose'
 

--- a/packages/apollo-collaboration-server/src/users/users.controller.ts
+++ b/packages/apollo-collaboration-server/src/users/users.controller.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { DecodedJWT } from '@apollo-annotation/apollo-shared'
+import { DecodedJWT } from '@apollo-annotation/shared'
 import { Body, Controller, Get, Logger, Param, Post, Req } from '@nestjs/common'
 import { Request } from 'express'
 

--- a/packages/apollo-collaboration-server/src/users/users.controller.ts
+++ b/packages/apollo-collaboration-server/src/users/users.controller.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { DecodedJWT } from '@apollo-annotation/apollo-shared'
 import { Body, Controller, Get, Logger, Param, Post, Req } from '@nestjs/common'
-import { DecodedJWT } from 'apollo-shared'
 import { Request } from 'express'
 
 import { Role } from '../utils/role/role.enum'

--- a/packages/apollo-collaboration-server/src/users/users.module.ts
+++ b/packages/apollo-collaboration-server/src/users/users.module.ts
@@ -1,6 +1,6 @@
+import { User, UserSchema } from '@apollo-annotation/apollo-schemas'
 import { Module, OnApplicationBootstrap } from '@nestjs/common'
 import { MongooseModule } from '@nestjs/mongoose'
-import { User, UserSchema } from 'apollo-schemas'
 
 import { MessagesModule } from '../messages/messages.module'
 import { UsersController } from './users.controller'

--- a/packages/apollo-collaboration-server/src/users/users.module.ts
+++ b/packages/apollo-collaboration-server/src/users/users.module.ts
@@ -1,4 +1,4 @@
-import { User, UserSchema } from '@apollo-annotation/apollo-schemas'
+import { User, UserSchema } from '@apollo-annotation/schemas'
 import { Module, OnApplicationBootstrap } from '@nestjs/common'
 import { MongooseModule } from '@nestjs/mongoose'
 

--- a/packages/apollo-collaboration-server/src/users/users.service.ts
+++ b/packages/apollo-collaboration-server/src/users/users.service.ts
@@ -1,13 +1,16 @@
-import { Injectable, Logger } from '@nestjs/common'
-import { ConfigService } from '@nestjs/config'
-import { InjectModel } from '@nestjs/mongoose'
-import { UserDocument, User as UserSchema } from 'apollo-schemas'
+import {
+  UserDocument,
+  User as UserSchema,
+} from '@apollo-annotation/apollo-schemas'
 import {
   DecodedJWT,
   RequestUserInformationMessage,
   UserLocationMessage,
   makeUserSessionId,
-} from 'apollo-shared'
+} from '@apollo-annotation/apollo-shared'
+import { Injectable, Logger } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { InjectModel } from '@nestjs/mongoose'
 import { Model } from 'mongoose'
 
 import { MessagesGateway } from '../messages/messages.gateway'

--- a/packages/apollo-collaboration-server/src/users/users.service.ts
+++ b/packages/apollo-collaboration-server/src/users/users.service.ts
@@ -1,13 +1,10 @@
-import {
-  UserDocument,
-  User as UserSchema,
-} from '@apollo-annotation/apollo-schemas'
+import { UserDocument, User as UserSchema } from '@apollo-annotation/schemas'
 import {
   DecodedJWT,
   RequestUserInformationMessage,
   UserLocationMessage,
   makeUserSessionId,
-} from '@apollo-annotation/apollo-shared'
+} from '@apollo-annotation/shared'
 import { Injectable, Logger } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { InjectModel } from '@nestjs/mongoose'

--- a/packages/apollo-collaboration-server/src/utils/parse-change.pipe.ts
+++ b/packages/apollo-collaboration-server/src/utils/parse-change.pipe.ts
@@ -1,3 +1,4 @@
+import { Change, SerializedChange } from '@apollo-annotation/apollo-common'
 import {
   ArgumentMetadata,
   BadRequestException,
@@ -5,7 +6,6 @@ import {
   Logger,
   PipeTransform,
 } from '@nestjs/common'
-import { Change, SerializedChange } from 'apollo-common'
 
 @Injectable()
 export class ParseChangePipe

--- a/packages/apollo-collaboration-server/src/utils/parse-change.pipe.ts
+++ b/packages/apollo-collaboration-server/src/utils/parse-change.pipe.ts
@@ -1,4 +1,4 @@
-import { Change, SerializedChange } from '@apollo-annotation/apollo-common'
+import { Change, SerializedChange } from '@apollo-annotation/common'
 import {
   ArgumentMetadata,
   BadRequestException,

--- a/packages/apollo-collaboration-server/src/utils/strategies/jwt.strategy.ts
+++ b/packages/apollo-collaboration-server/src/utils/strategies/jwt.strategy.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 
-import { DecodedJWT } from '@apollo-annotation/apollo-shared'
+import { DecodedJWT } from '@apollo-annotation/shared'
 import { Injectable, Logger } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { PassportStrategy } from '@nestjs/passport'

--- a/packages/apollo-collaboration-server/src/utils/strategies/jwt.strategy.ts
+++ b/packages/apollo-collaboration-server/src/utils/strategies/jwt.strategy.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs'
 
+import { DecodedJWT } from '@apollo-annotation/apollo-shared'
 import { Injectable, Logger } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { PassportStrategy } from '@nestjs/passport'
-import { DecodedJWT } from 'apollo-shared'
 import { ExtractJwt, Strategy } from 'passport-jwt'
 
 interface JWTSecretConfig {

--- a/packages/apollo-collaboration-server/src/utils/validation/AuthorizationValidation.ts
+++ b/packages/apollo-collaboration-server/src/utils/validation/AuthorizationValidation.ts
@@ -1,14 +1,14 @@
 /* eslint-disable @typescript-eslint/require-await */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { Change, SerializedChange } from '@apollo-annotation/apollo-common'
+import { Change, SerializedChange } from '@apollo-annotation/common'
 import {
   Context,
   JWTPayload,
   Validation,
   ValidationResult,
   isContext,
-} from '@apollo-annotation/apollo-shared'
+} from '@apollo-annotation/shared'
 import { Logger } from '@nestjs/common'
 import { Request } from 'express'
 

--- a/packages/apollo-collaboration-server/src/utils/validation/AuthorizationValidation.ts
+++ b/packages/apollo-collaboration-server/src/utils/validation/AuthorizationValidation.ts
@@ -1,15 +1,15 @@
 /* eslint-disable @typescript-eslint/require-await */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { Logger } from '@nestjs/common'
-import { Change, SerializedChange } from 'apollo-common'
+import { Change, SerializedChange } from '@apollo-annotation/apollo-common'
 import {
   Context,
   JWTPayload,
   Validation,
   ValidationResult,
   isContext,
-} from 'apollo-shared'
+} from '@apollo-annotation/apollo-shared'
+import { Logger } from '@nestjs/common'
 import { Request } from 'express'
 
 import { Role, RoleInheritance } from '../role/role.enum'

--- a/packages/apollo-collaboration-server/src/utils/validation/validation.guards.ts
+++ b/packages/apollo-collaboration-server/src/utils/validation/validation.guards.ts
@@ -1,4 +1,4 @@
-import { validationRegistry } from '@apollo-annotation/apollo-shared'
+import { validationRegistry } from '@apollo-annotation/shared'
 import {
   CanActivate,
   ExecutionContext,

--- a/packages/apollo-collaboration-server/src/utils/validation/validation.guards.ts
+++ b/packages/apollo-collaboration-server/src/utils/validation/validation.guards.ts
@@ -1,3 +1,4 @@
+import { validationRegistry } from '@apollo-annotation/apollo-shared'
 import {
   CanActivate,
   ExecutionContext,
@@ -6,7 +7,6 @@ import {
   UnprocessableEntityException,
 } from '@nestjs/common'
 import { Reflector } from '@nestjs/core'
-import { validationRegistry } from 'apollo-shared'
 
 @Injectable()
 export class ValidationGuard implements CanActivate {

--- a/packages/apollo-common/package.json
+++ b/packages/apollo-common/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "apollo-common",
-  "version": "1.0.0-alpha.0",
+  "name": "@apollo-annotation/apollo-common",
+  "version": "0.1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/GMOD/Apollo3.git",
@@ -11,9 +11,9 @@
     "build": "tsc"
   },
   "dependencies": {
+    "@apollo-annotation/apollo-schemas": "workspace:^",
     "@gmod/gff": "1.2.0",
     "@jbrowse/core": "^2.7.0",
-    "apollo-schemas": "workspace:^",
     "bson-objectid": "^2.0.4",
     "tslib": "^2.3.1"
   },
@@ -30,12 +30,14 @@
     "tss-react": "^4.6.1"
   },
   "devDependencies": {
+    "@apollo-annotation/apollo-mst": "workspace:^",
     "@nestjs/common": "^10.1.0",
     "@nestjs/core": "^10.1.0",
     "@types/node": "^18.14.2",
-    "apollo-mst": "workspace:^",
     "mongoose": "^6.12.0",
     "typescript": "^5.1.6"
   },
-  "private": true
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/apollo-common/package.json
+++ b/packages/apollo-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo-annotation/common",
-  "version": "0.1.1",
+  "version": "1.0.0-alpha.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/GMOD/Apollo3.git",

--- a/packages/apollo-common/package.json
+++ b/packages/apollo-common/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@apollo-annotation/apollo-common",
+  "name": "@apollo-annotation/common",
   "version": "0.1.1",
   "repository": {
     "type": "git",
@@ -11,7 +11,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@apollo-annotation/apollo-schemas": "workspace:^",
+    "@apollo-annotation/schemas": "workspace:^",
     "@gmod/gff": "1.2.0",
     "@jbrowse/core": "^2.7.0",
     "bson-objectid": "^2.0.4",
@@ -30,7 +30,7 @@
     "tss-react": "^4.6.1"
   },
   "devDependencies": {
-    "@apollo-annotation/apollo-mst": "workspace:^",
+    "@apollo-annotation/mst": "workspace:^",
     "@nestjs/common": "^10.1.0",
     "@nestjs/core": "^10.1.0",
     "@types/node": "^18.14.2",

--- a/packages/apollo-common/src/AssemblySpecificChange.ts
+++ b/packages/apollo-common/src/AssemblySpecificChange.ts
@@ -4,8 +4,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
-import type { AnnotationFeatureSnapshot } from '@apollo-annotation/apollo-mst'
-import { FileDocument, RefSeqDocument } from '@apollo-annotation/apollo-schemas'
+import type { AnnotationFeatureSnapshot } from '@apollo-annotation/mst'
+import { FileDocument, RefSeqDocument } from '@apollo-annotation/schemas'
 import { GFF3Feature } from '@gmod/gff'
 import ObjectID from 'bson-objectid'
 

--- a/packages/apollo-common/src/AssemblySpecificChange.ts
+++ b/packages/apollo-common/src/AssemblySpecificChange.ts
@@ -4,9 +4,9 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
+import type { AnnotationFeatureSnapshot } from '@apollo-annotation/apollo-mst'
+import { FileDocument, RefSeqDocument } from '@apollo-annotation/apollo-schemas'
 import { GFF3Feature } from '@gmod/gff'
-import type { AnnotationFeatureSnapshot } from 'apollo-mst'
-import { FileDocument, RefSeqDocument } from 'apollo-schemas'
 import ObjectID from 'bson-objectid'
 
 import { Change, ChangeOptions, SerializedChange, isChange } from './Change'

--- a/packages/apollo-common/src/Change.ts
+++ b/packages/apollo-common/src/Change.ts
@@ -1,13 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
-import { AppRootModel, Region } from '@jbrowse/core/util'
 import {
   AnnotationFeatureI,
   AnnotationFeatureSnapshot,
   ApolloAssemblyI,
   CheckResultI,
   CheckResultSnapshot,
-} from 'apollo-mst'
+} from '@apollo-annotation/apollo-mst'
+import { AppRootModel, Region } from '@jbrowse/core/util'
 
 import { changeRegistry } from './ChangeTypeRegistry'
 import {

--- a/packages/apollo-common/src/Change.ts
+++ b/packages/apollo-common/src/Change.ts
@@ -6,7 +6,7 @@ import {
   ApolloAssemblyI,
   CheckResultI,
   CheckResultSnapshot,
-} from '@apollo-annotation/apollo-mst'
+} from '@apollo-annotation/mst'
 import { AppRootModel, Region } from '@jbrowse/core/util'
 
 import { changeRegistry } from './ChangeTypeRegistry'

--- a/packages/apollo-common/src/Check.ts
+++ b/packages/apollo-common/src/Check.ts
@@ -1,4 +1,7 @@
-import { AnnotationFeatureSnapshot, CheckResultSnapshot } from 'apollo-mst'
+import {
+  AnnotationFeatureSnapshot,
+  CheckResultSnapshot,
+} from '@apollo-annotation/apollo-mst'
 
 export abstract class Check {
   abstract name: string

--- a/packages/apollo-common/src/Check.ts
+++ b/packages/apollo-common/src/Check.ts
@@ -1,7 +1,7 @@
 import {
   AnnotationFeatureSnapshot,
   CheckResultSnapshot,
-} from '@apollo-annotation/apollo-mst'
+} from '@apollo-annotation/mst'
 
 export abstract class Check {
   abstract name: string

--- a/packages/apollo-common/src/FeatureChange.ts
+++ b/packages/apollo-common/src/FeatureChange.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
-import type { AnnotationFeatureSnapshot } from '@apollo-annotation/apollo-mst'
-import { Feature } from '@apollo-annotation/apollo-schemas'
+import type { AnnotationFeatureSnapshot } from '@apollo-annotation/mst'
+import { Feature } from '@apollo-annotation/schemas'
 import ObjectID from 'bson-objectid'
 import type { Types } from 'mongoose'
 

--- a/packages/apollo-common/src/FeatureChange.ts
+++ b/packages/apollo-common/src/FeatureChange.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
-import type { AnnotationFeatureSnapshot } from 'apollo-mst'
-import { Feature } from 'apollo-schemas'
+import type { AnnotationFeatureSnapshot } from '@apollo-annotation/apollo-mst'
+import { Feature } from '@apollo-annotation/apollo-schemas'
 import ObjectID from 'bson-objectid'
 import type { Types } from 'mongoose'
 

--- a/packages/apollo-common/src/Operation.ts
+++ b/packages/apollo-common/src/Operation.ts
@@ -4,7 +4,6 @@
 import type { ReadStream } from 'node:fs'
 import type { FileHandle } from 'node:fs/promises'
 
-import type { LoggerService } from '@nestjs/common'
 import {
   AssemblyDocument,
   FeatureDocument,
@@ -12,7 +11,8 @@ import {
   RefSeqChunkDocument,
   RefSeqDocument,
   UserDocument,
-} from 'apollo-schemas'
+} from '@apollo-annotation/apollo-schemas'
+import type { LoggerService } from '@nestjs/common'
 import type { ClientSession, Model } from 'mongoose'
 
 export interface LocalGFF3DataStore {

--- a/packages/apollo-common/src/Operation.ts
+++ b/packages/apollo-common/src/Operation.ts
@@ -11,7 +11,7 @@ import {
   RefSeqChunkDocument,
   RefSeqDocument,
   UserDocument,
-} from '@apollo-annotation/apollo-schemas'
+} from '@apollo-annotation/schemas'
 import type { LoggerService } from '@nestjs/common'
 import type { ClientSession, Model } from 'mongoose'
 

--- a/packages/apollo-common/src/Validation.ts
+++ b/packages/apollo-common/src/Validation.ts
@@ -12,10 +12,7 @@ export interface Context {
 }
 
 export function isContext(thing: Change | Context): thing is Context {
-  return (
-    (thing as Context).context !== undefined &&
-    (thing as Context).reflector !== undefined
-  )
+  return 'context' in thing && 'reflector' in thing
 }
 
 export interface ValidationResult {

--- a/packages/apollo-common/src/Validation.ts
+++ b/packages/apollo-common/src/Validation.ts
@@ -1,8 +1,7 @@
-/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/require-await */
+import { FeatureDocument } from '@apollo-annotation/apollo-schemas'
 import type { ExecutionContext } from '@nestjs/common'
 import type { Reflector } from '@nestjs/core'
-import { FeatureDocument } from 'apollo-schemas'
 import { ClientSession, Model } from 'mongoose'
 
 import { Change, ClientDataStore } from './Change'

--- a/packages/apollo-common/src/Validation.ts
+++ b/packages/apollo-common/src/Validation.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/require-await */
-import { FeatureDocument } from '@apollo-annotation/apollo-schemas'
+import { FeatureDocument } from '@apollo-annotation/schemas'
 import type { ExecutionContext } from '@nestjs/common'
 import type { Reflector } from '@nestjs/core'
 import { ClientSession, Model } from 'mongoose'

--- a/packages/apollo-mst/package.json
+++ b/packages/apollo-mst/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "apollo-mst",
-  "version": "1.0.0-alpha.0",
+  "name": "@apollo-annotation/apollo-mst",
+  "version": "0.1.1",
   "main": "./dist/index.js",
   "scripts": {
     "build": "tsc"
@@ -15,5 +15,7 @@
   "devDependencies": {
     "typescript": "^5.1.6"
   },
-  "private": true
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/apollo-mst/package.json
+++ b/packages/apollo-mst/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@apollo-annotation/apollo-mst",
+  "name": "@apollo-annotation/mst",
   "version": "0.1.1",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/apollo-mst/package.json
+++ b/packages/apollo-mst/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo-annotation/mst",
-  "version": "0.1.1",
+  "version": "1.0.0-alpha.0",
   "main": "./dist/index.js",
   "scripts": {
     "build": "tsc"

--- a/packages/apollo-schemas/package.json
+++ b/packages/apollo-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo-annotation/schemas",
-  "version": "0.1.1",
+  "version": "1.0.0-alpha.0",
   "main": "./dist/index.js",
   "scripts": {
     "build": "tsc"

--- a/packages/apollo-schemas/package.json
+++ b/packages/apollo-schemas/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "apollo-schemas",
-  "version": "1.0.0-alpha.0",
+  "name": "@apollo-annotation/apollo-schemas",
+  "version": "0.1.1",
   "main": "./dist/index.js",
   "scripts": {
     "build": "tsc"
@@ -16,9 +16,11 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
+    "@apollo-annotation/apollo-mst": "workspace:^",
     "@types/node": "^18.14.2",
-    "apollo-mst": "workspace:^",
     "typescript": "^5.1.6"
   },
-  "private": true
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/apollo-schemas/package.json
+++ b/packages/apollo-schemas/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@apollo-annotation/apollo-schemas",
+  "name": "@apollo-annotation/schemas",
   "version": "0.1.1",
   "main": "./dist/index.js",
   "scripts": {
@@ -16,7 +16,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@apollo-annotation/apollo-mst": "workspace:^",
+    "@apollo-annotation/mst": "workspace:^",
     "@types/node": "^18.14.2",
     "typescript": "^5.1.6"
   },

--- a/packages/apollo-schemas/src/checkResult.schema.ts
+++ b/packages/apollo-schemas/src/checkResult.schema.ts
@@ -1,4 +1,4 @@
-import type { CheckResultSnapshot } from '@apollo-annotation/apollo-mst'
+import type { CheckResultSnapshot } from '@apollo-annotation/mst'
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose'
 import { HydratedDocument, Schema as MongooseSchema, Types } from 'mongoose'
 

--- a/packages/apollo-schemas/src/checkResult.schema.ts
+++ b/packages/apollo-schemas/src/checkResult.schema.ts
@@ -1,5 +1,5 @@
+import type { CheckResultSnapshot } from '@apollo-annotation/apollo-mst'
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose'
-import type { CheckResultSnapshot } from 'apollo-mst'
 import { HydratedDocument, Schema as MongooseSchema, Types } from 'mongoose'
 
 export type CheckResultDocument = HydratedDocument<CheckResult>

--- a/packages/apollo-schemas/src/feature.schema.ts
+++ b/packages/apollo-schemas/src/feature.schema.ts
@@ -1,4 +1,4 @@
-import type { AnnotationFeatureSnapshot } from '@apollo-annotation/apollo-mst'
+import type { AnnotationFeatureSnapshot } from '@apollo-annotation/mst'
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose'
 import { HydratedDocument, Schema as MongooseSchema, Types } from 'mongoose'
 

--- a/packages/apollo-schemas/src/feature.schema.ts
+++ b/packages/apollo-schemas/src/feature.schema.ts
@@ -1,5 +1,5 @@
+import type { AnnotationFeatureSnapshot } from '@apollo-annotation/apollo-mst'
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose'
-import type { AnnotationFeatureSnapshot } from 'apollo-mst'
 import { HydratedDocument, Schema as MongooseSchema, Types } from 'mongoose'
 
 export interface FeatureDocument extends HydratedDocument<Feature> {

--- a/packages/apollo-shared/package.json
+++ b/packages/apollo-shared/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@apollo-annotation/apollo-shared",
+  "name": "@apollo-annotation/shared",
   "version": "0.1.1",
   "main": "./dist/index.js",
   "scripts": {
@@ -8,9 +8,9 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
-    "@apollo-annotation/apollo-common": "workspace:^",
-    "@apollo-annotation/apollo-mst": "workspace:^",
-    "@apollo-annotation/apollo-schemas": "workspace:^",
+    "@apollo-annotation/common": "workspace:^",
+    "@apollo-annotation/mst": "workspace:^",
+    "@apollo-annotation/schemas": "workspace:^",
     "@gmod/gff": "1.2.0",
     "@gmod/indexedfasta": "^2.0.4",
     "@jbrowse/core": "^2.7.0",

--- a/packages/apollo-shared/package.json
+++ b/packages/apollo-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo-annotation/shared",
-  "version": "0.1.1",
+  "version": "1.0.0-alpha.0",
   "main": "./dist/index.js",
   "scripts": {
     "start": "tsc --build --watch",

--- a/packages/apollo-shared/package.json
+++ b/packages/apollo-shared/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "apollo-shared",
-  "version": "1.0.0-alpha.0",
+  "name": "@apollo-annotation/apollo-shared",
+  "version": "0.1.1",
   "main": "./dist/index.js",
   "scripts": {
     "start": "tsc --build --watch",
@@ -8,12 +8,12 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
+    "@apollo-annotation/apollo-common": "workspace:^",
+    "@apollo-annotation/apollo-mst": "workspace:^",
+    "@apollo-annotation/apollo-schemas": "workspace:^",
     "@gmod/gff": "1.2.0",
     "@gmod/indexedfasta": "^2.0.4",
     "@jbrowse/core": "^2.7.0",
-    "apollo-common": "workspace:^",
-    "apollo-mst": "workspace:^",
-    "apollo-schemas": "workspace:^",
     "bson-objectid": "^2.0.4",
     "generic-filehandle": "^3.0.0",
     "jwt-decode": "^3.1.2",
@@ -43,5 +43,7 @@
     "react-dom": "^18.2.0",
     "rxjs": "^7.4.0"
   },
-  "private": true
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/apollo-shared/src/Changes/AddAssemblyAndFeaturesFromFileChange.ts
+++ b/packages/apollo-shared/src/Changes/AddAssemblyAndFeaturesFromFileChange.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/require-await */
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
-import { GFF3Feature } from '@gmod/gff'
+
 import {
   AssemblySpecificChange,
   ChangeOptions,
@@ -8,7 +7,8 @@ import {
   LocalGFF3DataStore,
   SerializedAssemblySpecificChange,
   ServerDataStore,
-} from 'apollo-common'
+} from '@apollo-annotation/apollo-common'
+import { GFF3Feature } from '@gmod/gff'
 
 export interface SerializedAddAssemblyAndFeaturesFromFileChangeBase
   extends SerializedAssemblySpecificChange {

--- a/packages/apollo-shared/src/Changes/AddAssemblyAndFeaturesFromFileChange.ts
+++ b/packages/apollo-shared/src/Changes/AddAssemblyAndFeaturesFromFileChange.ts
@@ -7,7 +7,7 @@ import {
   LocalGFF3DataStore,
   SerializedAssemblySpecificChange,
   ServerDataStore,
-} from '@apollo-annotation/apollo-common'
+} from '@apollo-annotation/common'
 import { GFF3Feature } from '@gmod/gff'
 
 export interface SerializedAddAssemblyAndFeaturesFromFileChangeBase

--- a/packages/apollo-shared/src/Changes/AddAssemblyAndFeaturesFromFileChange.ts
+++ b/packages/apollo-shared/src/Changes/AddAssemblyAndFeaturesFromFileChange.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/require-await */
 
 import {

--- a/packages/apollo-shared/src/Changes/AddAssemblyFromExternalChange.ts
+++ b/packages/apollo-shared/src/Changes/AddAssemblyFromExternalChange.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
+
 /* eslint-disable @typescript-eslint/require-await */
-import { BgzipIndexedFasta, IndexedFasta } from '@gmod/indexedfasta'
 import {
   AssemblySpecificChange,
   ChangeOptions,
@@ -9,7 +8,8 @@ import {
   LocalGFF3DataStore,
   SerializedAssemblySpecificChange,
   ServerDataStore,
-} from 'apollo-common'
+} from '@apollo-annotation/apollo-common'
+import { BgzipIndexedFasta, IndexedFasta } from '@gmod/indexedfasta'
 import { RemoteFile } from 'generic-filehandle'
 
 export interface SerializedAddAssemblyFromExternalChangeBase

--- a/packages/apollo-shared/src/Changes/AddAssemblyFromExternalChange.ts
+++ b/packages/apollo-shared/src/Changes/AddAssemblyFromExternalChange.ts
@@ -8,7 +8,7 @@ import {
   LocalGFF3DataStore,
   SerializedAssemblySpecificChange,
   ServerDataStore,
-} from '@apollo-annotation/apollo-common'
+} from '@apollo-annotation/common'
 import { BgzipIndexedFasta, IndexedFasta } from '@gmod/indexedfasta'
 import { RemoteFile } from 'generic-filehandle'
 

--- a/packages/apollo-shared/src/Changes/AddAssemblyFromExternalChange.ts
+++ b/packages/apollo-shared/src/Changes/AddAssemblyFromExternalChange.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 
 /* eslint-disable @typescript-eslint/require-await */

--- a/packages/apollo-shared/src/Changes/AddAssemblyFromFileChange.ts
+++ b/packages/apollo-shared/src/Changes/AddAssemblyFromFileChange.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/require-await */
 import {
   AssemblySpecificChange,

--- a/packages/apollo-shared/src/Changes/AddAssemblyFromFileChange.ts
+++ b/packages/apollo-shared/src/Changes/AddAssemblyFromFileChange.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/require-await */
 import {
   AssemblySpecificChange,
@@ -7,7 +6,7 @@ import {
   LocalGFF3DataStore,
   SerializedAssemblySpecificChange,
   ServerDataStore,
-} from 'apollo-common'
+} from '@apollo-annotation/apollo-common'
 
 export interface SerializedAddAssemblyFromFileChangeBase
   extends SerializedAssemblySpecificChange {

--- a/packages/apollo-shared/src/Changes/AddAssemblyFromFileChange.ts
+++ b/packages/apollo-shared/src/Changes/AddAssemblyFromFileChange.ts
@@ -6,7 +6,7 @@ import {
   LocalGFF3DataStore,
   SerializedAssemblySpecificChange,
   ServerDataStore,
-} from '@apollo-annotation/apollo-common'
+} from '@apollo-annotation/common'
 
 export interface SerializedAddAssemblyFromFileChangeBase
   extends SerializedAssemblySpecificChange {

--- a/packages/apollo-shared/src/Changes/AddFeatureChange.ts
+++ b/packages/apollo-shared/src/Changes/AddFeatureChange.ts
@@ -8,8 +8,8 @@ import {
   LocalGFF3DataStore,
   SerializedFeatureChange,
   ServerDataStore,
-} from '@apollo-annotation/apollo-common'
-import { AnnotationFeatureSnapshot } from '@apollo-annotation/apollo-mst'
+} from '@apollo-annotation/common'
+import { AnnotationFeatureSnapshot } from '@apollo-annotation/mst'
 
 import { DeleteFeatureChange } from './DeleteFeatureChange'
 

--- a/packages/apollo-shared/src/Changes/AddFeatureChange.ts
+++ b/packages/apollo-shared/src/Changes/AddFeatureChange.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/require-await */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */

--- a/packages/apollo-shared/src/Changes/AddFeatureChange.ts
+++ b/packages/apollo-shared/src/Changes/AddFeatureChange.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/require-await */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
@@ -9,8 +8,8 @@ import {
   LocalGFF3DataStore,
   SerializedFeatureChange,
   ServerDataStore,
-} from 'apollo-common'
-import { AnnotationFeatureSnapshot } from 'apollo-mst'
+} from '@apollo-annotation/apollo-common'
+import { AnnotationFeatureSnapshot } from '@apollo-annotation/apollo-mst'
 
 import { DeleteFeatureChange } from './DeleteFeatureChange'
 

--- a/packages/apollo-shared/src/Changes/AddFeaturesFromFileChange.ts
+++ b/packages/apollo-shared/src/Changes/AddFeaturesFromFileChange.ts
@@ -6,7 +6,7 @@ import {
   LocalGFF3DataStore,
   SerializedAssemblySpecificChange,
   ServerDataStore,
-} from '@apollo-annotation/apollo-common'
+} from '@apollo-annotation/common'
 import { GFF3Feature } from '@gmod/gff'
 
 export interface SerializedAddFeaturesFromFileChangeBase

--- a/packages/apollo-shared/src/Changes/AddFeaturesFromFileChange.ts
+++ b/packages/apollo-shared/src/Changes/AddFeaturesFromFileChange.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/require-await */
-import { GFF3Feature } from '@gmod/gff'
 import {
   AssemblySpecificChange,
   ChangeOptions,
@@ -7,7 +6,8 @@ import {
   LocalGFF3DataStore,
   SerializedAssemblySpecificChange,
   ServerDataStore,
-} from 'apollo-common'
+} from '@apollo-annotation/apollo-common'
+import { GFF3Feature } from '@gmod/gff'
 
 export interface SerializedAddFeaturesFromFileChangeBase
   extends SerializedAssemblySpecificChange {

--- a/packages/apollo-shared/src/Changes/DeleteAssemblyChange.ts
+++ b/packages/apollo-shared/src/Changes/DeleteAssemblyChange.ts
@@ -8,7 +8,7 @@ import {
   LocalGFF3DataStore,
   SerializedAssemblySpecificChange,
   ServerDataStore,
-} from '@apollo-annotation/apollo-common'
+} from '@apollo-annotation/common'
 import { getSession } from '@jbrowse/core/util'
 
 interface SerializedDeleteAssemblyChange

--- a/packages/apollo-shared/src/Changes/DeleteAssemblyChange.ts
+++ b/packages/apollo-shared/src/Changes/DeleteAssemblyChange.ts
@@ -2,14 +2,14 @@
 /* eslint-disable @typescript-eslint/require-await */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
-import { getSession } from '@jbrowse/core/util'
 import {
   AssemblySpecificChange,
   ClientDataStore,
   LocalGFF3DataStore,
   SerializedAssemblySpecificChange,
   ServerDataStore,
-} from 'apollo-common'
+} from '@apollo-annotation/apollo-common'
+import { getSession } from '@jbrowse/core/util'
 
 interface SerializedDeleteAssemblyChange
   extends SerializedAssemblySpecificChange {

--- a/packages/apollo-shared/src/Changes/DeleteFeatureChange.ts
+++ b/packages/apollo-shared/src/Changes/DeleteFeatureChange.ts
@@ -8,9 +8,9 @@ import {
   LocalGFF3DataStore,
   SerializedFeatureChange,
   ServerDataStore,
-} from '@apollo-annotation/apollo-common'
-import { AnnotationFeatureSnapshot } from '@apollo-annotation/apollo-mst'
-import { Feature } from '@apollo-annotation/apollo-schemas'
+} from '@apollo-annotation/common'
+import { AnnotationFeatureSnapshot } from '@apollo-annotation/mst'
+import { Feature } from '@apollo-annotation/schemas'
 
 import { AddFeatureChange } from './AddFeatureChange'
 

--- a/packages/apollo-shared/src/Changes/DeleteFeatureChange.ts
+++ b/packages/apollo-shared/src/Changes/DeleteFeatureChange.ts
@@ -8,9 +8,9 @@ import {
   LocalGFF3DataStore,
   SerializedFeatureChange,
   ServerDataStore,
-} from 'apollo-common'
-import { AnnotationFeatureSnapshot } from 'apollo-mst'
-import { Feature } from 'apollo-schemas'
+} from '@apollo-annotation/apollo-common'
+import { AnnotationFeatureSnapshot } from '@apollo-annotation/apollo-mst'
+import { Feature } from '@apollo-annotation/apollo-schemas'
 
 import { AddFeatureChange } from './AddFeatureChange'
 

--- a/packages/apollo-shared/src/Changes/DeleteUserChange.ts
+++ b/packages/apollo-shared/src/Changes/DeleteUserChange.ts
@@ -6,7 +6,7 @@ import {
   LocalGFF3DataStore,
   SerializedChange,
   ServerDataStore,
-} from '@apollo-annotation/apollo-common'
+} from '@apollo-annotation/common'
 
 export interface SerializedDeleteUserChangeBase extends SerializedChange {
   typeName: 'DeleteUserChange'

--- a/packages/apollo-shared/src/Changes/DeleteUserChange.ts
+++ b/packages/apollo-shared/src/Changes/DeleteUserChange.ts
@@ -6,7 +6,7 @@ import {
   LocalGFF3DataStore,
   SerializedChange,
   ServerDataStore,
-} from 'apollo-common'
+} from '@apollo-annotation/apollo-common'
 
 export interface SerializedDeleteUserChangeBase extends SerializedChange {
   typeName: 'DeleteUserChange'

--- a/packages/apollo-shared/src/Changes/DiscontinuousLocationEndChange.ts
+++ b/packages/apollo-shared/src/Changes/DiscontinuousLocationEndChange.ts
@@ -8,7 +8,7 @@ import {
   LocalGFF3DataStore,
   SerializedFeatureChange,
   ServerDataStore,
-} from '@apollo-annotation/apollo-common'
+} from '@apollo-annotation/common'
 
 interface SerializedDiscontinuousLocationEndChangeBase
   extends SerializedFeatureChange {

--- a/packages/apollo-shared/src/Changes/DiscontinuousLocationEndChange.ts
+++ b/packages/apollo-shared/src/Changes/DiscontinuousLocationEndChange.ts
@@ -8,7 +8,7 @@ import {
   LocalGFF3DataStore,
   SerializedFeatureChange,
   ServerDataStore,
-} from 'apollo-common'
+} from '@apollo-annotation/apollo-common'
 
 interface SerializedDiscontinuousLocationEndChangeBase
   extends SerializedFeatureChange {

--- a/packages/apollo-shared/src/Changes/DiscontinuousLocationStartChange.ts
+++ b/packages/apollo-shared/src/Changes/DiscontinuousLocationStartChange.ts
@@ -8,7 +8,7 @@ import {
   LocalGFF3DataStore,
   SerializedFeatureChange,
   ServerDataStore,
-} from 'apollo-common'
+} from '@apollo-annotation/apollo-common'
 
 interface SerializedDiscontinuousLocationStartChangeBase
   extends SerializedFeatureChange {

--- a/packages/apollo-shared/src/Changes/DiscontinuousLocationStartChange.ts
+++ b/packages/apollo-shared/src/Changes/DiscontinuousLocationStartChange.ts
@@ -8,7 +8,7 @@ import {
   LocalGFF3DataStore,
   SerializedFeatureChange,
   ServerDataStore,
-} from '@apollo-annotation/apollo-common'
+} from '@apollo-annotation/common'
 
 interface SerializedDiscontinuousLocationStartChangeBase
   extends SerializedFeatureChange {

--- a/packages/apollo-shared/src/Changes/FeatureAttributeChange.ts
+++ b/packages/apollo-shared/src/Changes/FeatureAttributeChange.ts
@@ -8,8 +8,8 @@ import {
   LocalGFF3DataStore,
   SerializedFeatureChange,
   ServerDataStore,
-} from '@apollo-annotation/apollo-common'
-import { Feature, FeatureDocument } from '@apollo-annotation/apollo-schemas'
+} from '@apollo-annotation/common'
+import { Feature, FeatureDocument } from '@apollo-annotation/schemas'
 
 interface SerializedFeatureAttributeChangeBase extends SerializedFeatureChange {
   typeName: 'FeatureAttributeChange'

--- a/packages/apollo-shared/src/Changes/FeatureAttributeChange.ts
+++ b/packages/apollo-shared/src/Changes/FeatureAttributeChange.ts
@@ -8,8 +8,8 @@ import {
   LocalGFF3DataStore,
   SerializedFeatureChange,
   ServerDataStore,
-} from 'apollo-common'
-import { Feature, FeatureDocument } from 'apollo-schemas'
+} from '@apollo-annotation/apollo-common'
+import { Feature, FeatureDocument } from '@apollo-annotation/apollo-schemas'
 
 interface SerializedFeatureAttributeChangeBase extends SerializedFeatureChange {
   typeName: 'FeatureAttributeChange'

--- a/packages/apollo-shared/src/Changes/LocationEndChange.ts
+++ b/packages/apollo-shared/src/Changes/LocationEndChange.ts
@@ -8,8 +8,8 @@ import {
   LocalGFF3DataStore,
   SerializedFeatureChange,
   ServerDataStore,
-} from 'apollo-common'
-import { Feature, FeatureDocument } from 'apollo-schemas'
+} from '@apollo-annotation/apollo-common'
+import { Feature, FeatureDocument } from '@apollo-annotation/apollo-schemas'
 
 interface SerializedLocationEndChangeBase extends SerializedFeatureChange {
   typeName: 'LocationEndChange'

--- a/packages/apollo-shared/src/Changes/LocationEndChange.ts
+++ b/packages/apollo-shared/src/Changes/LocationEndChange.ts
@@ -8,8 +8,8 @@ import {
   LocalGFF3DataStore,
   SerializedFeatureChange,
   ServerDataStore,
-} from '@apollo-annotation/apollo-common'
-import { Feature, FeatureDocument } from '@apollo-annotation/apollo-schemas'
+} from '@apollo-annotation/common'
+import { Feature, FeatureDocument } from '@apollo-annotation/schemas'
 
 interface SerializedLocationEndChangeBase extends SerializedFeatureChange {
   typeName: 'LocationEndChange'

--- a/packages/apollo-shared/src/Changes/LocationStartChange.ts
+++ b/packages/apollo-shared/src/Changes/LocationStartChange.ts
@@ -8,8 +8,8 @@ import {
   LocalGFF3DataStore,
   SerializedFeatureChange,
   ServerDataStore,
-} from '@apollo-annotation/apollo-common'
-import { Feature, FeatureDocument } from '@apollo-annotation/apollo-schemas'
+} from '@apollo-annotation/common'
+import { Feature, FeatureDocument } from '@apollo-annotation/schemas'
 
 interface SerializedLocationStartChangeBase extends SerializedFeatureChange {
   typeName: 'LocationStartChange'

--- a/packages/apollo-shared/src/Changes/LocationStartChange.ts
+++ b/packages/apollo-shared/src/Changes/LocationStartChange.ts
@@ -8,8 +8,8 @@ import {
   LocalGFF3DataStore,
   SerializedFeatureChange,
   ServerDataStore,
-} from 'apollo-common'
-import { Feature, FeatureDocument } from 'apollo-schemas'
+} from '@apollo-annotation/apollo-common'
+import { Feature, FeatureDocument } from '@apollo-annotation/apollo-schemas'
 
 interface SerializedLocationStartChangeBase extends SerializedFeatureChange {
   typeName: 'LocationStartChange'

--- a/packages/apollo-shared/src/Changes/StrandChange.ts
+++ b/packages/apollo-shared/src/Changes/StrandChange.ts
@@ -8,8 +8,8 @@ import {
   LocalGFF3DataStore,
   SerializedFeatureChange,
   ServerDataStore,
-} from '@apollo-annotation/apollo-common'
-import { Feature, FeatureDocument } from '@apollo-annotation/apollo-schemas'
+} from '@apollo-annotation/common'
+import { Feature, FeatureDocument } from '@apollo-annotation/schemas'
 
 interface SerializedStrandChangeBase extends SerializedFeatureChange {
   typeName: 'StrandChange'

--- a/packages/apollo-shared/src/Changes/StrandChange.ts
+++ b/packages/apollo-shared/src/Changes/StrandChange.ts
@@ -8,8 +8,8 @@ import {
   LocalGFF3DataStore,
   SerializedFeatureChange,
   ServerDataStore,
-} from 'apollo-common'
-import { Feature, FeatureDocument } from 'apollo-schemas'
+} from '@apollo-annotation/apollo-common'
+import { Feature, FeatureDocument } from '@apollo-annotation/apollo-schemas'
 
 interface SerializedStrandChangeBase extends SerializedFeatureChange {
   typeName: 'StrandChange'

--- a/packages/apollo-shared/src/Changes/TypeChange.ts
+++ b/packages/apollo-shared/src/Changes/TypeChange.ts
@@ -8,8 +8,8 @@ import {
   LocalGFF3DataStore,
   SerializedFeatureChange,
   ServerDataStore,
-} from '@apollo-annotation/apollo-common'
-import { Feature, FeatureDocument } from '@apollo-annotation/apollo-schemas'
+} from '@apollo-annotation/common'
+import { Feature, FeatureDocument } from '@apollo-annotation/schemas'
 
 interface SerializedTypeChangeBase extends SerializedFeatureChange {
   typeName: 'TypeChange'

--- a/packages/apollo-shared/src/Changes/TypeChange.ts
+++ b/packages/apollo-shared/src/Changes/TypeChange.ts
@@ -8,8 +8,8 @@ import {
   LocalGFF3DataStore,
   SerializedFeatureChange,
   ServerDataStore,
-} from 'apollo-common'
-import { Feature, FeatureDocument } from 'apollo-schemas'
+} from '@apollo-annotation/apollo-common'
+import { Feature, FeatureDocument } from '@apollo-annotation/apollo-schemas'
 
 interface SerializedTypeChangeBase extends SerializedFeatureChange {
   typeName: 'TypeChange'

--- a/packages/apollo-shared/src/Changes/UserChange.ts
+++ b/packages/apollo-shared/src/Changes/UserChange.ts
@@ -6,7 +6,7 @@ import {
   LocalGFF3DataStore,
   SerializedChange,
   ServerDataStore,
-} from 'apollo-common'
+} from '@apollo-annotation/apollo-common'
 
 export interface SerializedUserChangeBase extends SerializedChange {
   typeName: 'UserChange'

--- a/packages/apollo-shared/src/Changes/UserChange.ts
+++ b/packages/apollo-shared/src/Changes/UserChange.ts
@@ -6,7 +6,7 @@ import {
   LocalGFF3DataStore,
   SerializedChange,
   ServerDataStore,
-} from '@apollo-annotation/apollo-common'
+} from '@apollo-annotation/common'
 
 export interface SerializedUserChangeBase extends SerializedChange {
   typeName: 'UserChange'

--- a/packages/apollo-shared/src/Checks/CDSCheck.ts
+++ b/packages/apollo-shared/src/Checks/CDSCheck.ts
@@ -1,5 +1,8 @@
-import { Check } from 'apollo-common'
-import { AnnotationFeatureSnapshot, CheckResultSnapshot } from 'apollo-mst'
+import { Check } from '@apollo-annotation/apollo-common'
+import {
+  AnnotationFeatureSnapshot,
+  CheckResultSnapshot,
+} from '@apollo-annotation/apollo-mst'
 import ObjectID from 'bson-objectid'
 
 enum STOP_CODONS {

--- a/packages/apollo-shared/src/Checks/CDSCheck.ts
+++ b/packages/apollo-shared/src/Checks/CDSCheck.ts
@@ -1,8 +1,8 @@
-import { Check } from '@apollo-annotation/apollo-common'
+import { Check } from '@apollo-annotation/common'
 import {
   AnnotationFeatureSnapshot,
   CheckResultSnapshot,
-} from '@apollo-annotation/apollo-mst'
+} from '@apollo-annotation/mst'
 import ObjectID from 'bson-objectid'
 
 enum STOP_CODONS {

--- a/packages/apollo-shared/src/Messages.ts
+++ b/packages/apollo-shared/src/Messages.ts
@@ -1,5 +1,5 @@
-import { SerializedChange } from 'apollo-common'
-import { CheckResultSnapshot } from 'apollo-mst'
+import { SerializedChange } from '@apollo-annotation/apollo-common'
+import { CheckResultSnapshot } from '@apollo-annotation/apollo-mst'
 
 interface BaseMessage {
   channel: string

--- a/packages/apollo-shared/src/Messages.ts
+++ b/packages/apollo-shared/src/Messages.ts
@@ -1,5 +1,5 @@
-import { SerializedChange } from '@apollo-annotation/apollo-common'
-import { CheckResultSnapshot } from '@apollo-annotation/apollo-mst'
+import { SerializedChange } from '@apollo-annotation/common'
+import { CheckResultSnapshot } from '@apollo-annotation/mst'
 
 interface BaseMessage {
   channel: string

--- a/packages/apollo-shared/src/Operations/GetAssembliesOperation.ts
+++ b/packages/apollo-shared/src/Operations/GetAssembliesOperation.ts
@@ -4,7 +4,7 @@ import {
   Operation,
   SerializedOperation,
   ServerDataStore,
-} from 'apollo-common'
+} from '@apollo-annotation/apollo-common'
 
 interface SerializedGetAssembliesOperation extends SerializedOperation {
   typeName: 'GetAssembliesOperation'

--- a/packages/apollo-shared/src/Operations/GetAssembliesOperation.ts
+++ b/packages/apollo-shared/src/Operations/GetAssembliesOperation.ts
@@ -4,7 +4,7 @@ import {
   Operation,
   SerializedOperation,
   ServerDataStore,
-} from '@apollo-annotation/apollo-common'
+} from '@apollo-annotation/common'
 
 interface SerializedGetAssembliesOperation extends SerializedOperation {
   typeName: 'GetAssembliesOperation'

--- a/packages/apollo-shared/src/Operations/GetFeaturesOperation.ts
+++ b/packages/apollo-shared/src/Operations/GetFeaturesOperation.ts
@@ -5,7 +5,7 @@ import {
   OperationOptions,
   SerializedOperation,
   ServerDataStore,
-} from '@apollo-annotation/apollo-common'
+} from '@apollo-annotation/common'
 
 interface SerializedGetFeaturesOperation extends SerializedOperation {
   typeName: 'GetFeaturesOperation'

--- a/packages/apollo-shared/src/Operations/GetFeaturesOperation.ts
+++ b/packages/apollo-shared/src/Operations/GetFeaturesOperation.ts
@@ -5,7 +5,7 @@ import {
   OperationOptions,
   SerializedOperation,
   ServerDataStore,
-} from 'apollo-common'
+} from '@apollo-annotation/apollo-common'
 
 interface SerializedGetFeaturesOperation extends SerializedOperation {
   typeName: 'GetFeaturesOperation'

--- a/packages/apollo-shared/src/Validations/CoreValidation.ts
+++ b/packages/apollo-shared/src/Validations/CoreValidation.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/require-await */
-import { Change } from 'apollo-common'
+import { Change } from '@apollo-annotation/apollo-common'
 
 import { TypeChange } from '../Changes'
 import soSequenceTypes from './soSequenceTypes'

--- a/packages/apollo-shared/src/Validations/CoreValidation.ts
+++ b/packages/apollo-shared/src/Validations/CoreValidation.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/require-await */
-import { Change } from '@apollo-annotation/apollo-common'
+import { Change } from '@apollo-annotation/common'
 
 import { TypeChange } from '../Changes'
 import soSequenceTypes from './soSequenceTypes'

--- a/packages/apollo-shared/src/Validations/ParentChildValidation.ts
+++ b/packages/apollo-shared/src/Validations/ParentChildValidation.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
-import { Change } from 'apollo-common'
-import { Feature, FeatureDocument } from 'apollo-schemas'
+import { Change } from '@apollo-annotation/apollo-common'
+import { Feature, FeatureDocument } from '@apollo-annotation/apollo-schemas'
 import { ClientSession, Model } from 'mongoose'
 
 import {

--- a/packages/apollo-shared/src/Validations/ParentChildValidation.ts
+++ b/packages/apollo-shared/src/Validations/ParentChildValidation.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
-import { Change } from '@apollo-annotation/apollo-common'
-import { Feature, FeatureDocument } from '@apollo-annotation/apollo-schemas'
+import { Change } from '@apollo-annotation/common'
+import { Feature, FeatureDocument } from '@apollo-annotation/schemas'
 import { ClientSession, Model } from 'mongoose'
 
 import {

--- a/packages/apollo-shared/src/Validations/Validation.ts
+++ b/packages/apollo-shared/src/Validations/Validation.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/require-await */
-import { Change, ClientDataStore } from '@apollo-annotation/apollo-common'
-import { FeatureDocument } from '@apollo-annotation/apollo-schemas'
+import { Change, ClientDataStore } from '@apollo-annotation/common'
+import { FeatureDocument } from '@apollo-annotation/schemas'
 import type { ExecutionContext } from '@nestjs/common'
 import type { Reflector } from '@nestjs/core'
 import { ClientSession, Model } from 'mongoose'

--- a/packages/apollo-shared/src/Validations/Validation.ts
+++ b/packages/apollo-shared/src/Validations/Validation.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/require-await */
+import { Change, ClientDataStore } from '@apollo-annotation/apollo-common'
+import { FeatureDocument } from '@apollo-annotation/apollo-schemas'
 import type { ExecutionContext } from '@nestjs/common'
 import type { Reflector } from '@nestjs/core'
-import { Change, ClientDataStore } from 'apollo-common'
-import { FeatureDocument } from 'apollo-schemas'
 import { ClientSession, Model } from 'mongoose'
 
 export interface Context {

--- a/packages/apollo-shared/src/Validations/ValidationSet.ts
+++ b/packages/apollo-shared/src/Validations/ValidationSet.ts
@@ -1,5 +1,5 @@
-import { Change, ClientDataStore } from '@apollo-annotation/apollo-common'
-import { FeatureDocument } from '@apollo-annotation/apollo-schemas'
+import { Change, ClientDataStore } from '@apollo-annotation/common'
+import { FeatureDocument } from '@apollo-annotation/schemas'
 import { ClientSession, Model } from 'mongoose'
 
 import { Context, Validation, ValidationResult } from './Validation'

--- a/packages/apollo-shared/src/Validations/ValidationSet.ts
+++ b/packages/apollo-shared/src/Validations/ValidationSet.ts
@@ -1,5 +1,5 @@
-import { Change, ClientDataStore } from 'apollo-common'
-import { FeatureDocument } from 'apollo-schemas'
+import { Change, ClientDataStore } from '@apollo-annotation/apollo-common'
+import { FeatureDocument } from '@apollo-annotation/apollo-schemas'
 import { ClientSession, Model } from 'mongoose'
 
 import { Context, Validation, ValidationResult } from './Validation'

--- a/packages/apollo-shared/src/util.ts
+++ b/packages/apollo-shared/src/util.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { AnnotationFeatureSnapshot } from '@apollo-annotation/mst'
 import { GFF3Feature } from '@gmod/gff'
 

--- a/packages/apollo-shared/src/util.ts
+++ b/packages/apollo-shared/src/util.ts
@@ -1,6 +1,5 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { AnnotationFeatureSnapshot } from '@apollo-annotation/apollo-mst'
 import { GFF3Feature } from '@gmod/gff'
-import { AnnotationFeatureSnapshot } from 'apollo-mst'
 
 export function makeGFF3Feature(
   feature: AnnotationFeatureSnapshot,

--- a/packages/apollo-shared/src/util.ts
+++ b/packages/apollo-shared/src/util.ts
@@ -1,4 +1,4 @@
-import { AnnotationFeatureSnapshot } from '@apollo-annotation/apollo-mst'
+import { AnnotationFeatureSnapshot } from '@apollo-annotation/mst'
 import { GFF3Feature } from '@gmod/gff'
 
 export function makeGFF3Feature(

--- a/packages/jbrowse-plugin-apollo/package.json
+++ b/packages/jbrowse-plugin-apollo/package.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.0.0-alpha.0",
-  "name": "jbrowse-plugin-apollo",
+  "name": "@apollo-annotation/jbrowse-plugin-apollo",
+  "version": "0.1.1",
   "description": "Apollo plugin for JBrowse 2",
   "repository": {
     "type": "git",
@@ -51,6 +51,9 @@
     "name": "Apollo"
   },
   "dependencies": {
+    "@apollo-annotation/apollo-common": "workspace:^",
+    "@apollo-annotation/apollo-mst": "workspace:^",
+    "@apollo-annotation/apollo-shared": "workspace:^",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
     "@gmod/gff": "1.2.0",
@@ -58,9 +61,6 @@
     "@jbrowse/plugin-linear-genome-view": "^2.0.1",
     "@mui/icons-material": "^5.8.4",
     "@types/jsonpath": "^0.2.0",
-    "apollo-common": "workspace:^",
-    "apollo-mst": "workspace:^",
-    "apollo-shared": "workspace:^",
     "autosuggest-highlight": "^3.3.4",
     "bson-objectid": "^2.0.4",
     "clsx": "^1.1.1",
@@ -123,6 +123,8 @@
     "tss-react": "^4.6.1",
     "typescript": "^5.1.6"
   },
-  "private": true,
+  "publishConfig": {
+    "access": "public"
+  },
   "stableVersion": "0.0.0"
 }

--- a/packages/jbrowse-plugin-apollo/package.json
+++ b/packages/jbrowse-plugin-apollo/package.json
@@ -37,7 +37,7 @@
     "browse": "serve --no-request-logging --listen 8999 --no-port-switching .jbrowse",
     "test": "jest",
     "test:ci": "jest --coverage",
-    "start:collab-cypress": "yarn workspace apollo-collaboration-server run cypress:start",
+    "start:collab-cypress": "yarn workspace @apollo-annotation/collaboration-server run cypress:start",
     "test:e2e": "yarn build && start-test \"npm-run-all --parallel start:server browse start:collab-cypress\" \"9000|8999|http://localhost:3999/health\" \"npm-run-all cypress:run\"",
     "test:e2e:debug": "yarn build && start-test \"npm-run-all --parallel start:server browse start:collab-cypress\" \"9000|8999|http://localhost:3999/health\" \"npm-run-all cypress:debug\"",
     "cypress:run": "cypress run --browser chrome",
@@ -51,9 +51,9 @@
     "name": "Apollo"
   },
   "dependencies": {
-    "@apollo-annotation/apollo-common": "workspace:^",
-    "@apollo-annotation/apollo-mst": "workspace:^",
-    "@apollo-annotation/apollo-shared": "workspace:^",
+    "@apollo-annotation/common": "workspace:^",
+    "@apollo-annotation/mst": "workspace:^",
+    "@apollo-annotation/shared": "workspace:^",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
     "@gmod/gff": "1.2.0",

--- a/packages/jbrowse-plugin-apollo/package.json
+++ b/packages/jbrowse-plugin-apollo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo-annotation/jbrowse-plugin-apollo",
-  "version": "0.1.1",
+  "version": "1.0.0-alpha.0",
   "description": "Apollo plugin for JBrowse 2",
   "repository": {
     "type": "git",

--- a/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
@@ -6,14 +6,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-misused-promises */
-import { ConfigurationReference, getConf } from '@jbrowse/core/configuration'
-import { InternetAccount } from '@jbrowse/core/pluggableElementTypes'
-import {
-  AbstractSessionModel,
-  isAbstractMenuManager,
-  isElectron,
-} from '@jbrowse/core/util'
-import { Change } from 'apollo-common'
+import { Change } from '@apollo-annotation/apollo-common'
 import {
   ChangeMessage,
   CheckResultUpdate,
@@ -22,7 +15,14 @@ import {
   UserLocationMessage,
   getDecodedToken,
   makeUserSessionId,
-} from 'apollo-shared'
+} from '@apollo-annotation/apollo-shared'
+import { ConfigurationReference, getConf } from '@jbrowse/core/configuration'
+import { InternetAccount } from '@jbrowse/core/pluggableElementTypes'
+import {
+  AbstractSessionModel,
+  isAbstractMenuManager,
+  isElectron,
+} from '@jbrowse/core/util'
 import { autorun } from 'mobx'
 import { Instance, flow, getRoot, types } from 'mobx-state-tree'
 import { io } from 'socket.io-client'

--- a/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
@@ -6,7 +6,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-misused-promises */
-import { Change } from '@apollo-annotation/apollo-common'
+import { Change } from '@apollo-annotation/common'
 import {
   ChangeMessage,
   CheckResultUpdate,
@@ -15,7 +15,7 @@ import {
   UserLocationMessage,
   getDecodedToken,
   makeUserSessionId,
-} from '@apollo-annotation/apollo-shared'
+} from '@apollo-annotation/shared'
 import { ConfigurationReference, getConf } from '@jbrowse/core/configuration'
 import { InternetAccount } from '@jbrowse/core/pluggableElementTypes'
 import {

--- a/packages/jbrowse-plugin-apollo/src/ApolloSixFrameRenderer/components/ApolloRendering.tsx
+++ b/packages/jbrowse-plugin-apollo/src/ApolloSixFrameRenderer/components/ApolloRendering.tsx
@@ -5,11 +5,14 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-misused-promises */
+import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
+import {
+  LocationEndChange,
+  LocationStartChange,
+} from '@apollo-annotation/apollo-shared'
 import { getConf } from '@jbrowse/core/configuration'
 import { AbstractSessionModel, Region, getSession } from '@jbrowse/core/util'
 import { Menu, MenuItem } from '@mui/material'
-import { AnnotationFeatureI } from 'apollo-mst'
-import { LocationEndChange, LocationStartChange } from 'apollo-shared'
 import { autorun, toJS } from 'mobx'
 import { observer } from 'mobx-react'
 import { getRoot, getSnapshot } from 'mobx-state-tree'

--- a/packages/jbrowse-plugin-apollo/src/ApolloSixFrameRenderer/components/ApolloRendering.tsx
+++ b/packages/jbrowse-plugin-apollo/src/ApolloSixFrameRenderer/components/ApolloRendering.tsx
@@ -5,11 +5,11 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-misused-promises */
-import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
+import { AnnotationFeatureI } from '@apollo-annotation/mst'
 import {
   LocationEndChange,
   LocationStartChange,
-} from '@apollo-annotation/apollo-shared'
+} from '@apollo-annotation/shared'
 import { getConf } from '@jbrowse/core/configuration'
 import { AbstractSessionModel, Region, getSession } from '@jbrowse/core/util'
 import { Menu, MenuItem } from '@mui/material'

--- a/packages/jbrowse-plugin-apollo/src/BackendDrivers/BackendDriver.ts
+++ b/packages/jbrowse-plugin-apollo/src/BackendDrivers/BackendDriver.ts
@@ -1,8 +1,11 @@
+import { Change, ClientDataStore } from '@apollo-annotation/apollo-common'
+import {
+  AnnotationFeatureSnapshot,
+  CheckResultSnapshot,
+} from '@apollo-annotation/apollo-mst'
+import { ValidationResultSet } from '@apollo-annotation/apollo-shared'
 import { Assembly } from '@jbrowse/core/assemblyManager/assembly'
 import { Region } from '@jbrowse/core/util'
-import { Change, ClientDataStore } from 'apollo-common'
-import { AnnotationFeatureSnapshot, CheckResultSnapshot } from 'apollo-mst'
-import { ValidationResultSet } from 'apollo-shared'
 
 import { SubmitOpts } from '../ChangeManager'
 

--- a/packages/jbrowse-plugin-apollo/src/BackendDrivers/BackendDriver.ts
+++ b/packages/jbrowse-plugin-apollo/src/BackendDrivers/BackendDriver.ts
@@ -1,9 +1,9 @@
-import { Change, ClientDataStore } from '@apollo-annotation/apollo-common'
+import { Change, ClientDataStore } from '@apollo-annotation/common'
 import {
   AnnotationFeatureSnapshot,
   CheckResultSnapshot,
-} from '@apollo-annotation/apollo-mst'
-import { ValidationResultSet } from '@apollo-annotation/apollo-shared'
+} from '@apollo-annotation/mst'
+import { ValidationResultSet } from '@apollo-annotation/shared'
 import { Assembly } from '@jbrowse/core/assemblyManager/assembly'
 import { Region } from '@jbrowse/core/util'
 

--- a/packages/jbrowse-plugin-apollo/src/BackendDrivers/CollaborationServerDriver.ts
+++ b/packages/jbrowse-plugin-apollo/src/BackendDrivers/CollaborationServerDriver.ts
@@ -4,19 +4,13 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-import {
-  AssemblySpecificChange,
-  Change,
-} from '@apollo-annotation/apollo-common'
+import { AssemblySpecificChange, Change } from '@apollo-annotation/common'
 import {
   AnnotationFeatureSnapshot,
   ApolloRefSeqI,
   CheckResultSnapshot,
-} from '@apollo-annotation/apollo-mst'
-import {
-  ChangeMessage,
-  ValidationResultSet,
-} from '@apollo-annotation/apollo-shared'
+} from '@apollo-annotation/mst'
+import { ChangeMessage, ValidationResultSet } from '@apollo-annotation/shared'
 import { getConf } from '@jbrowse/core/configuration'
 import { BaseInternetAccountModel } from '@jbrowse/core/pluggableElementTypes'
 import { Region, getSession } from '@jbrowse/core/util'

--- a/packages/jbrowse-plugin-apollo/src/BackendDrivers/CollaborationServerDriver.ts
+++ b/packages/jbrowse-plugin-apollo/src/BackendDrivers/CollaborationServerDriver.ts
@@ -4,16 +4,22 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-import { getConf } from '@jbrowse/core/configuration'
-import { BaseInternetAccountModel } from '@jbrowse/core/pluggableElementTypes'
-import { Region, getSession } from '@jbrowse/core/util'
-import { AssemblySpecificChange, Change } from 'apollo-common'
+import {
+  AssemblySpecificChange,
+  Change,
+} from '@apollo-annotation/apollo-common'
 import {
   AnnotationFeatureSnapshot,
   ApolloRefSeqI,
   CheckResultSnapshot,
-} from 'apollo-mst'
-import { ChangeMessage, ValidationResultSet } from 'apollo-shared'
+} from '@apollo-annotation/apollo-mst'
+import {
+  ChangeMessage,
+  ValidationResultSet,
+} from '@apollo-annotation/apollo-shared'
+import { getConf } from '@jbrowse/core/configuration'
+import { BaseInternetAccountModel } from '@jbrowse/core/pluggableElementTypes'
+import { Region, getSession } from '@jbrowse/core/util'
 import { Socket } from 'socket.io-client'
 
 import { ChangeManager, SubmitOpts } from '../ChangeManager'

--- a/packages/jbrowse-plugin-apollo/src/BackendDrivers/DesktopFileDriver.ts
+++ b/packages/jbrowse-plugin-apollo/src/BackendDrivers/DesktopFileDriver.ts
@@ -1,18 +1,21 @@
 /* eslint-disable @typescript-eslint/require-await */
-import gff, { GFF3Item } from '@gmod/gff'
-import { getConf } from '@jbrowse/core/configuration'
-import { Region, getSession } from '@jbrowse/core/util'
 import {
   AssemblySpecificChange,
   Change,
   isAssemblySpecificChange,
-} from 'apollo-common'
-import { AnnotationFeatureSnapshot, CheckResultSnapshot } from 'apollo-mst'
+} from '@apollo-annotation/apollo-common'
+import {
+  AnnotationFeatureSnapshot,
+  CheckResultSnapshot,
+} from '@apollo-annotation/apollo-mst'
 import {
   ValidationResultSet,
   makeGFF3Feature,
   splitStringIntoChunks,
-} from 'apollo-shared'
+} from '@apollo-annotation/apollo-shared'
+import gff, { GFF3Item } from '@gmod/gff'
+import { getConf } from '@jbrowse/core/configuration'
+import { Region, getSession } from '@jbrowse/core/util'
 import { getSnapshot } from 'mobx-state-tree'
 
 import { checkFeatures, loadAssemblyIntoClient } from '../util'

--- a/packages/jbrowse-plugin-apollo/src/BackendDrivers/DesktopFileDriver.ts
+++ b/packages/jbrowse-plugin-apollo/src/BackendDrivers/DesktopFileDriver.ts
@@ -3,16 +3,16 @@ import {
   AssemblySpecificChange,
   Change,
   isAssemblySpecificChange,
-} from '@apollo-annotation/apollo-common'
+} from '@apollo-annotation/common'
 import {
   AnnotationFeatureSnapshot,
   CheckResultSnapshot,
-} from '@apollo-annotation/apollo-mst'
+} from '@apollo-annotation/mst'
 import {
   ValidationResultSet,
   makeGFF3Feature,
   splitStringIntoChunks,
-} from '@apollo-annotation/apollo-shared'
+} from '@apollo-annotation/shared'
 import gff, { GFF3Item } from '@gmod/gff'
 import { getConf } from '@jbrowse/core/configuration'
 import { Region, getSession } from '@jbrowse/core/util'

--- a/packages/jbrowse-plugin-apollo/src/BackendDrivers/InMemoryFileDriver.ts
+++ b/packages/jbrowse-plugin-apollo/src/BackendDrivers/InMemoryFileDriver.ts
@@ -1,13 +1,10 @@
 /* eslint-disable @typescript-eslint/require-await */
-import {
-  AssemblySpecificChange,
-  Change,
-} from '@apollo-annotation/apollo-common'
+import { AssemblySpecificChange, Change } from '@apollo-annotation/common'
 import {
   AnnotationFeatureSnapshot,
   CheckResultSnapshot,
-} from '@apollo-annotation/apollo-mst'
-import { ValidationResultSet } from '@apollo-annotation/apollo-shared'
+} from '@apollo-annotation/mst'
+import { ValidationResultSet } from '@apollo-annotation/shared'
 import { getConf } from '@jbrowse/core/configuration'
 import { Region, getSession } from '@jbrowse/core/util'
 

--- a/packages/jbrowse-plugin-apollo/src/BackendDrivers/InMemoryFileDriver.ts
+++ b/packages/jbrowse-plugin-apollo/src/BackendDrivers/InMemoryFileDriver.ts
@@ -1,9 +1,15 @@
 /* eslint-disable @typescript-eslint/require-await */
+import {
+  AssemblySpecificChange,
+  Change,
+} from '@apollo-annotation/apollo-common'
+import {
+  AnnotationFeatureSnapshot,
+  CheckResultSnapshot,
+} from '@apollo-annotation/apollo-mst'
+import { ValidationResultSet } from '@apollo-annotation/apollo-shared'
 import { getConf } from '@jbrowse/core/configuration'
 import { Region, getSession } from '@jbrowse/core/util'
-import { AssemblySpecificChange, Change } from 'apollo-common'
-import { AnnotationFeatureSnapshot, CheckResultSnapshot } from 'apollo-mst'
-import { ValidationResultSet } from 'apollo-shared'
 
 import { SubmitOpts } from '../ChangeManager'
 import { BackendDriver } from './BackendDriver'

--- a/packages/jbrowse-plugin-apollo/src/ChangeManager.ts
+++ b/packages/jbrowse-plugin-apollo/src/ChangeManager.ts
@@ -5,11 +5,11 @@ import {
   Change,
   ClientDataStore,
   isAssemblySpecificChange,
-} from '@apollo-annotation/apollo-common'
+} from '@apollo-annotation/common'
 import {
   ValidationResultSet,
   validationRegistry,
-} from '@apollo-annotation/apollo-shared'
+} from '@apollo-annotation/shared'
 import { getSession } from '@jbrowse/core/util'
 import { IAnyStateTreeNode } from 'mobx-state-tree'
 

--- a/packages/jbrowse-plugin-apollo/src/ChangeManager.ts
+++ b/packages/jbrowse-plugin-apollo/src/ChangeManager.ts
@@ -1,13 +1,16 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import { getSession } from '@jbrowse/core/util'
 import {
   Change,
   ClientDataStore,
   isAssemblySpecificChange,
-} from 'apollo-common'
-import { ValidationResultSet, validationRegistry } from 'apollo-shared'
+} from '@apollo-annotation/apollo-common'
+import {
+  ValidationResultSet,
+  validationRegistry,
+} from '@apollo-annotation/apollo-shared'
+import { getSession } from '@jbrowse/core/util'
 import { IAnyStateTreeNode } from 'mobx-state-tree'
 
 import { ApolloSessionModel } from './session'

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/Attributes.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/Attributes.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-misused-promises */
-import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
-import { FeatureAttributeChange } from '@apollo-annotation/apollo-shared'
+import { AnnotationFeatureI } from '@apollo-annotation/mst'
+import { FeatureAttributeChange } from '@apollo-annotation/shared'
 import { AbstractSessionModel } from '@jbrowse/core/util'
 import DeleteIcon from '@mui/icons-material/Delete'
 import {

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/Attributes.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/Attributes.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-misused-promises */
+import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
+import { FeatureAttributeChange } from '@apollo-annotation/apollo-shared'
 import { AbstractSessionModel } from '@jbrowse/core/util'
 import DeleteIcon from '@mui/icons-material/Delete'
 import {
@@ -17,8 +19,6 @@ import {
   TextField,
   Typography,
 } from '@mui/material'
-import { AnnotationFeatureI } from 'apollo-mst'
-import { FeatureAttributeChange } from 'apollo-shared'
 import { observer } from 'mobx-react'
 import { getSnapshot } from 'mobx-state-tree'
 import React, { useState } from 'react'

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/BasicInformation.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/BasicInformation.tsx
@@ -1,4 +1,11 @@
 /* eslint-disable @typescript-eslint/no-misused-promises */
+import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
+import {
+  LocationEndChange,
+  LocationStartChange,
+  StrandChange,
+  TypeChange,
+} from '@apollo-annotation/apollo-shared'
 import { AbstractSessionModel } from '@jbrowse/core/util'
 import {
   FormControl,
@@ -9,13 +16,6 @@ import {
   TextField,
   Typography,
 } from '@mui/material'
-import { AnnotationFeatureI } from 'apollo-mst'
-import {
-  LocationEndChange,
-  LocationStartChange,
-  StrandChange,
-  TypeChange,
-} from 'apollo-shared'
 import { observer } from 'mobx-react'
 import React, { useState } from 'react'
 

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/BasicInformation.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/BasicInformation.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/no-misused-promises */
-import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
+import { AnnotationFeatureI } from '@apollo-annotation/mst'
 import {
   LocationEndChange,
   LocationStartChange,
   StrandChange,
   TypeChange,
-} from '@apollo-annotation/apollo-shared'
+} from '@apollo-annotation/shared'
 import { AbstractSessionModel } from '@jbrowse/core/util'
 import {
   FormControl,

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/RelatedFeature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/RelatedFeature.tsx
@@ -1,10 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
-import {
-  AnnotationFeature,
-  AnnotationFeatureI,
-} from '@apollo-annotation/apollo-mst'
+import { AnnotationFeature, AnnotationFeatureI } from '@apollo-annotation/mst'
 import { SessionWithWidgets } from '@jbrowse/core/util'
 import { Button, Paper, Typography } from '@mui/material'
 import { observer } from 'mobx-react'

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/RelatedFeature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/RelatedFeature.tsx
@@ -1,9 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
+import {
+  AnnotationFeature,
+  AnnotationFeatureI,
+} from '@apollo-annotation/apollo-mst'
 import { SessionWithWidgets } from '@jbrowse/core/util'
 import { Button, Paper, Typography } from '@mui/material'
-import { AnnotationFeature, AnnotationFeatureI } from 'apollo-mst'
 import { observer } from 'mobx-react'
 import { IMSTMap } from 'mobx-state-tree'
 import React from 'react'

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/Sequence.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/Sequence.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
-import { splitStringIntoChunks } from '@apollo-annotation/apollo-shared'
+import { AnnotationFeatureI } from '@apollo-annotation/mst'
+import { splitStringIntoChunks } from '@apollo-annotation/shared'
 import { Button, Typography } from '@mui/material'
 import { observer } from 'mobx-react'
 import React, { useState } from 'react'

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/Sequence.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/Sequence.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
+import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
+import { splitStringIntoChunks } from '@apollo-annotation/apollo-shared'
 import { Button, Typography } from '@mui/material'
-import { AnnotationFeatureI } from 'apollo-mst'
-import { splitStringIntoChunks } from 'apollo-shared'
 import { observer } from 'mobx-react'
 import React, { useState } from 'react'
 import { makeStyles } from 'tss-react/mui'

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/model.ts
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/model.ts
@@ -1,8 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
+import {
+  AnnotationFeature,
+  AnnotationFeatureI,
+} from '@apollo-annotation/apollo-mst'
 import { getSession } from '@jbrowse/core/util'
 import { ElementId } from '@jbrowse/core/util/types/mst'
-import { AnnotationFeature, AnnotationFeatureI } from 'apollo-mst'
 import { autorun } from 'mobx'
 import { Instance, SnapshotIn, addDisposer, types } from 'mobx-state-tree'
 

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/model.ts
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/model.ts
@@ -1,9 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-import {
-  AnnotationFeature,
-  AnnotationFeatureI,
-} from '@apollo-annotation/apollo-mst'
+import { AnnotationFeature, AnnotationFeatureI } from '@apollo-annotation/mst'
 import { getSession } from '@jbrowse/core/util'
 import { ElementId } from '@jbrowse/core/util/types/mst'
 import { autorun } from 'mobx'

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/unbound-method */
-import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
+import { AnnotationFeatureI } from '@apollo-annotation/mst'
 import {
   LocationEndChange,
   LocationStartChange,
-} from '@apollo-annotation/apollo-shared'
+} from '@apollo-annotation/shared'
 import { Theme, alpha } from '@mui/material'
 
 import { LinearApolloDisplay } from '../stateModel'

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
@@ -1,8 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/unbound-method */
+import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
+import {
+  LocationEndChange,
+  LocationStartChange,
+} from '@apollo-annotation/apollo-shared'
 import { Theme, alpha } from '@mui/material'
-import { AnnotationFeatureI } from 'apollo-mst'
-import { LocationEndChange, LocationStartChange } from 'apollo-shared'
 
 import { LinearApolloDisplay } from '../stateModel'
 import { MousePosition } from '../stateModel/mouseEvents'

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/CanonicalGeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/CanonicalGeneGlyph.ts
@@ -3,14 +3,14 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-import { alpha } from '@mui/material'
-import { AnnotationFeatureI } from 'apollo-mst'
+import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
 import {
   DiscontinuousLocationEndChange,
   DiscontinuousLocationStartChange,
   LocationEndChange,
   LocationStartChange,
-} from 'apollo-shared'
+} from '@apollo-annotation/apollo-shared'
+import { alpha } from '@mui/material'
 
 import { LinearApolloDisplay } from '../stateModel'
 import {

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/CanonicalGeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/CanonicalGeneGlyph.ts
@@ -3,13 +3,13 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
+import { AnnotationFeatureI } from '@apollo-annotation/mst'
 import {
   DiscontinuousLocationEndChange,
   DiscontinuousLocationStartChange,
   LocationEndChange,
   LocationStartChange,
-} from '@apollo-annotation/apollo-shared'
+} from '@apollo-annotation/shared'
 import { alpha } from '@mui/material'
 
 import { LinearApolloDisplay } from '../stateModel'

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GenericChildGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GenericChildGlyph.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/unbound-method */
-import { AnnotationFeatureI } from 'apollo-mst'
+import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
 
 import { LinearApolloDisplay } from '../stateModel'
 import { MousePosition } from '../stateModel/mouseEvents'

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GenericChildGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GenericChildGlyph.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/unbound-method */
-import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
+import { AnnotationFeatureI } from '@apollo-annotation/mst'
 
 import { LinearApolloDisplay } from '../stateModel'
 import { MousePosition } from '../stateModel/mouseEvents'

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
@@ -2,10 +2,10 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
+import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
 import { MenuItem } from '@jbrowse/core/ui'
 import { AbstractSessionModel, SessionWithWidgets } from '@jbrowse/core/util'
 import { alpha } from '@mui/material'
-import { AnnotationFeatureI } from 'apollo-mst'
 
 import {
   AddChildFeature,

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
-import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
+import { AnnotationFeatureI } from '@apollo-annotation/mst'
 import { MenuItem } from '@jbrowse/core/ui'
 import { AbstractSessionModel, SessionWithWidgets } from '@jbrowse/core/util'
 import { alpha } from '@mui/material'

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/ImplicitExonGeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/ImplicitExonGeneGlyph.ts
@@ -4,11 +4,11 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
+import { AnnotationFeatureI } from '@apollo-annotation/mst'
 import {
   LocationEndChange,
   LocationStartChange,
-} from '@apollo-annotation/apollo-shared'
+} from '@apollo-annotation/shared'
 import { alpha } from '@mui/material'
 
 import { LinearApolloDisplay } from '../stateModel'

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/ImplicitExonGeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/ImplicitExonGeneGlyph.ts
@@ -4,9 +4,12 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
+import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
+import {
+  LocationEndChange,
+  LocationStartChange,
+} from '@apollo-annotation/apollo-shared'
 import { alpha } from '@mui/material'
-import { AnnotationFeatureI } from 'apollo-mst'
-import { LocationEndChange, LocationStartChange } from 'apollo-shared'
 
 import { LinearApolloDisplay } from '../stateModel'
 import { MousePosition } from '../stateModel/mouseEvents'

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/base.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/base.ts
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
+import { AnnotationFeatureI } from '@apollo-annotation/mst'
 import { ConfigurationReference, getConf } from '@jbrowse/core/configuration'
 import { AnyConfigurationSchemaType } from '@jbrowse/core/configuration/configurationSchema'
 import { BaseDisplay } from '@jbrowse/core/pluggableElementTypes'

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/base.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/base.ts
@@ -3,6 +3,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
+import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
 import { ConfigurationReference, getConf } from '@jbrowse/core/configuration'
 import { AnyConfigurationSchemaType } from '@jbrowse/core/configuration/configurationSchema'
 import { BaseDisplay } from '@jbrowse/core/pluggableElementTypes'
@@ -15,7 +16,6 @@ import {
 import { getParentRenderProps } from '@jbrowse/core/util/tracks'
 // import type LinearGenomeViewPlugin from '@jbrowse/plugin-linear-genome-view'
 import type { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
-import { AnnotationFeatureI } from 'apollo-mst'
 import { autorun } from 'mobx'
 import { addDisposer, getRoot, types } from 'mobx-state-tree'
 

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/getGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/getGlyph.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
+import { AnnotationFeatureI } from '@apollo-annotation/mst'
 
 import {
   BoxGlyph,

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/getGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/getGlyph.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import { AnnotationFeatureI } from 'apollo-mst'
+import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
 
 import {
   BoxGlyph,

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/glyphs.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/glyphs.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
-import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
+import { AnnotationFeatureI } from '@apollo-annotation/mst'
 import { ObservableMap, observable } from 'mobx'
 import { types } from 'mobx-state-tree'
 

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/glyphs.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/glyphs.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
-import { AnnotationFeatureI } from 'apollo-mst'
+import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
 import { ObservableMap, observable } from 'mobx'
 import { types } from 'mobx-state-tree'
 

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/layouts.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/layouts.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
+import { AnnotationFeatureI } from '@apollo-annotation/mst'
 import { AnyConfigurationSchemaType } from '@jbrowse/core/configuration/configurationSchema'
 import PluginManager from '@jbrowse/core/PluginManager'
 import { AbstractSessionModel, doesIntersect2 } from '@jbrowse/core/util'

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/layouts.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/layouts.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
 import { AnyConfigurationSchemaType } from '@jbrowse/core/configuration/configurationSchema'
 import PluginManager from '@jbrowse/core/PluginManager'
 import { AbstractSessionModel, doesIntersect2 } from '@jbrowse/core/util'
-import { AnnotationFeatureI } from 'apollo-mst'
 import { autorun, observable } from 'mobx'
 import { addDisposer, isAlive } from 'mobx-state-tree'
 

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/mouseEvents.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/mouseEvents.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
+import { AnnotationFeatureI } from '@apollo-annotation/mst'
 import { AnyConfigurationSchemaType } from '@jbrowse/core/configuration/configurationSchema'
 import PluginManager from '@jbrowse/core/PluginManager'
 import { MenuItem } from '@jbrowse/core/ui'

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/mouseEvents.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/mouseEvents.ts
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
 import { AnyConfigurationSchemaType } from '@jbrowse/core/configuration/configurationSchema'
 import PluginManager from '@jbrowse/core/PluginManager'
 import { MenuItem } from '@jbrowse/core/ui'
 import type { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
 import { Theme } from '@mui/material'
-import { AnnotationFeatureI } from 'apollo-mst'
 import { autorun } from 'mobx'
 import { Instance, addDisposer } from 'mobx-state-tree'
 import type { CSSProperties } from 'react'

--- a/packages/jbrowse-plugin-apollo/src/OntologyManager/util.ts
+++ b/packages/jbrowse-plugin-apollo/src/OntologyManager/util.ts
@@ -1,4 +1,4 @@
-import { AnnotationFeatureI } from 'apollo-mst'
+import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
 
 import OntologyStore from './OntologyStore'
 import { isOntologyClass } from '.'

--- a/packages/jbrowse-plugin-apollo/src/OntologyManager/util.ts
+++ b/packages/jbrowse-plugin-apollo/src/OntologyManager/util.ts
@@ -1,4 +1,4 @@
-import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
+import { AnnotationFeatureI } from '@apollo-annotation/mst'
 
 import OntologyStore from './OntologyStore'
 import { isOntologyClass } from '.'

--- a/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/stateModel.ts
+++ b/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/stateModel.ts
@@ -4,7 +4,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/unbound-method */
-import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
+import { AnnotationFeatureI } from '@apollo-annotation/mst'
 import { ConfigurationReference } from '@jbrowse/core/configuration'
 import { AnyConfigurationSchemaType } from '@jbrowse/core/configuration/configurationSchema'
 import PluginManager from '@jbrowse/core/PluginManager'

--- a/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/stateModel.ts
+++ b/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/stateModel.ts
@@ -4,6 +4,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/unbound-method */
+import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
 import { ConfigurationReference } from '@jbrowse/core/configuration'
 import { AnyConfigurationSchemaType } from '@jbrowse/core/configuration/configurationSchema'
 import PluginManager from '@jbrowse/core/PluginManager'
@@ -19,7 +20,6 @@ import { BaseBlock } from '@jbrowse/core/util/blockTypes'
 import { getParentRenderProps } from '@jbrowse/core/util/tracks'
 import type LinearGenomeViewPlugin from '@jbrowse/plugin-linear-genome-view'
 import type { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
-import { AnnotationFeatureI } from 'apollo-mst'
 import { autorun } from 'mobx'
 import { Instance, addDisposer, types } from 'mobx-state-tree'
 

--- a/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/ChangeHandling.ts
+++ b/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/ChangeHandling.ts
@@ -1,11 +1,11 @@
-import type { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
+import type { AnnotationFeatureI } from '@apollo-annotation/mst'
 import {
   DiscontinuousLocationEndChange,
   DiscontinuousLocationStartChange,
   LocationEndChange,
   LocationStartChange,
   TypeChange,
-} from '@apollo-annotation/apollo-shared'
+} from '@apollo-annotation/shared'
 
 import type { ChangeManager } from '../../ChangeManager'
 

--- a/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/ChangeHandling.ts
+++ b/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/ChangeHandling.ts
@@ -1,11 +1,11 @@
-import type { AnnotationFeatureI } from 'apollo-mst'
+import type { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
 import {
   DiscontinuousLocationEndChange,
   DiscontinuousLocationStartChange,
   LocationEndChange,
   LocationStartChange,
   TypeChange,
-} from 'apollo-shared'
+} from '@apollo-annotation/apollo-shared'
 
 import type { ChangeManager } from '../../ChangeManager'
 

--- a/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/Feature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/Feature.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
-import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
+import { AnnotationFeatureI } from '@apollo-annotation/mst'
 import { AbstractSessionModel } from '@jbrowse/core/util'
 import { observer } from 'mobx-react'
 import React from 'react'

--- a/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/Feature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/Feature.tsx
@@ -2,8 +2,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
+import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
 import { AbstractSessionModel } from '@jbrowse/core/util'
-import { AnnotationFeatureI } from 'apollo-mst'
 import { observer } from 'mobx-react'
 import React from 'react'
 import { makeStyles } from 'tss-react/mui'

--- a/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/FeatureAttributes.tsx
+++ b/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/FeatureAttributes.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
-import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
+import { AnnotationFeatureI } from '@apollo-annotation/mst'
 import { observer } from 'mobx-react'
 import { getSnapshot } from 'mobx-state-tree'
 import React from 'react'

--- a/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/FeatureAttributes.tsx
+++ b/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/FeatureAttributes.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
-import { AnnotationFeatureI } from 'apollo-mst'
+import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
 import { observer } from 'mobx-react'
 import { getSnapshot } from 'mobx-state-tree'
 import React from 'react'

--- a/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/featureContextMenuItems.ts
+++ b/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/featureContextMenuItems.ts
@@ -1,6 +1,6 @@
+import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
 import { MenuItem } from '@jbrowse/core/ui'
 import { AbstractSessionModel } from '@jbrowse/core/util'
-import { AnnotationFeatureI } from 'apollo-mst'
 
 import { ChangeManager } from '../../ChangeManager'
 import {

--- a/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/featureContextMenuItems.ts
+++ b/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/featureContextMenuItems.ts
@@ -1,4 +1,4 @@
-import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
+import { AnnotationFeatureI } from '@apollo-annotation/mst'
 import { MenuItem } from '@jbrowse/core/ui'
 import { AbstractSessionModel } from '@jbrowse/core/util'
 

--- a/packages/jbrowse-plugin-apollo/src/components/AddAssembly.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/AddAssembly.tsx
@@ -8,7 +8,7 @@ import {
   AddAssemblyAndFeaturesFromFileChange,
   AddAssemblyFromExternalChange,
   AddAssemblyFromFileChange,
-} from '@apollo-annotation/apollo-shared'
+} from '@apollo-annotation/shared'
 import { readConfObject } from '@jbrowse/core/configuration'
 import { AbstractSessionModel } from '@jbrowse/core/util'
 import LinkIcon from '@mui/icons-material/Link'

--- a/packages/jbrowse-plugin-apollo/src/components/AddAssembly.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/AddAssembly.tsx
@@ -4,6 +4,11 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-misused-promises */
+import {
+  AddAssemblyAndFeaturesFromFileChange,
+  AddAssemblyFromExternalChange,
+  AddAssemblyFromFileChange,
+} from '@apollo-annotation/apollo-shared'
 import { readConfObject } from '@jbrowse/core/configuration'
 import { AbstractSessionModel } from '@jbrowse/core/util'
 import LinkIcon from '@mui/icons-material/Link'
@@ -28,11 +33,6 @@ import {
 } from '@mui/material'
 import InputAdornment from '@mui/material/InputAdornment'
 import LinearProgress from '@mui/material/LinearProgress'
-import {
-  AddAssemblyAndFeaturesFromFileChange,
-  AddAssemblyFromExternalChange,
-  AddAssemblyFromFileChange,
-} from 'apollo-shared'
 import ObjectID from 'bson-objectid'
 import { getRoot } from 'mobx-state-tree'
 import React, { useState } from 'react'

--- a/packages/jbrowse-plugin-apollo/src/components/AddChildFeature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/AddChildFeature.tsx
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-misused-promises */
+import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
+import { AddFeatureChange } from '@apollo-annotation/apollo-shared'
 import { AbstractSessionModel } from '@jbrowse/core/util'
 import {
   Button,
@@ -12,8 +14,6 @@ import {
   SelectChangeEvent,
   TextField,
 } from '@mui/material'
-import { AnnotationFeatureI } from 'apollo-mst'
-import { AddFeatureChange } from 'apollo-shared'
 import ObjectID from 'bson-objectid'
 import React, { useState } from 'react'
 

--- a/packages/jbrowse-plugin-apollo/src/components/AddChildFeature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/AddChildFeature.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-misused-promises */
-import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
-import { AddFeatureChange } from '@apollo-annotation/apollo-shared'
+import { AnnotationFeatureI } from '@apollo-annotation/mst'
+import { AddFeatureChange } from '@apollo-annotation/shared'
 import { AbstractSessionModel } from '@jbrowse/core/util'
 import {
   Button,

--- a/packages/jbrowse-plugin-apollo/src/components/AddFeature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/AddFeature.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-misused-promises */
+import { AddFeatureChange } from '@apollo-annotation/apollo-shared'
 import { AbstractSessionModel, Region } from '@jbrowse/core/util/types'
 import {
   Button,
@@ -13,7 +14,6 @@ import {
   SelectChangeEvent,
   TextField,
 } from '@mui/material'
-import { AddFeatureChange } from 'apollo-shared'
 import ObjectID from 'bson-objectid'
 import React, { useState } from 'react'
 

--- a/packages/jbrowse-plugin-apollo/src/components/AddFeature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/AddFeature.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-misused-promises */
-import { AddFeatureChange } from '@apollo-annotation/apollo-shared'
+import { AddFeatureChange } from '@apollo-annotation/shared'
 import { AbstractSessionModel, Region } from '@jbrowse/core/util/types'
 import {
   Button,

--- a/packages/jbrowse-plugin-apollo/src/components/CopyFeature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/CopyFeature.tsx
@@ -4,8 +4,8 @@
 import {
   AnnotationFeatureI,
   AnnotationFeatureSnapshot,
-} from '@apollo-annotation/apollo-mst'
-import { AddFeatureChange } from '@apollo-annotation/apollo-shared'
+} from '@apollo-annotation/mst'
+import { AddFeatureChange } from '@apollo-annotation/shared'
 import { readConfObject } from '@jbrowse/core/configuration'
 import { AbstractSessionModel } from '@jbrowse/core/util'
 import {

--- a/packages/jbrowse-plugin-apollo/src/components/CopyFeature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/CopyFeature.tsx
@@ -1,6 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-misused-promises */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import {
+  AnnotationFeatureI,
+  AnnotationFeatureSnapshot,
+} from '@apollo-annotation/apollo-mst'
+import { AddFeatureChange } from '@apollo-annotation/apollo-shared'
 import { readConfObject } from '@jbrowse/core/configuration'
 import { AbstractSessionModel } from '@jbrowse/core/util'
 import {
@@ -13,8 +18,6 @@ import {
   SelectChangeEvent,
   TextField,
 } from '@mui/material'
-import { AnnotationFeatureI, AnnotationFeatureSnapshot } from 'apollo-mst'
-import { AddFeatureChange } from 'apollo-shared'
 import ObjectID from 'bson-objectid'
 import { IKeyValueMap } from 'mobx'
 import { getSnapshot } from 'mobx-state-tree'

--- a/packages/jbrowse-plugin-apollo/src/components/DeleteAssembly.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/DeleteAssembly.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-misused-promises */
-import { DeleteAssemblyChange } from '@apollo-annotation/apollo-shared'
+import { DeleteAssemblyChange } from '@apollo-annotation/shared'
 import { Assembly } from '@jbrowse/core/assemblyManager/assembly'
 import {
   Button,

--- a/packages/jbrowse-plugin-apollo/src/components/DeleteAssembly.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/DeleteAssembly.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-misused-promises */
+import { DeleteAssemblyChange } from '@apollo-annotation/apollo-shared'
 import { Assembly } from '@jbrowse/core/assemblyManager/assembly'
 import {
   Button,
@@ -12,7 +13,6 @@ import {
   Select,
   SelectChangeEvent,
 } from '@mui/material'
-import { DeleteAssemblyChange } from 'apollo-shared'
 import { getRoot } from 'mobx-state-tree'
 import React, { useEffect, useState } from 'react'
 

--- a/packages/jbrowse-plugin-apollo/src/components/DeleteFeature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/DeleteFeature.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-misused-promises */
+import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
+import { DeleteFeatureChange } from '@apollo-annotation/apollo-shared'
 import { AbstractSessionModel } from '@jbrowse/core/util'
 import {
   Button,
@@ -8,8 +10,6 @@ import {
   DialogContent,
   DialogContentText,
 } from '@mui/material'
-import { AnnotationFeatureI } from 'apollo-mst'
-import { DeleteFeatureChange } from 'apollo-shared'
 import { getSnapshot } from 'mobx-state-tree'
 import React, { useState } from 'react'
 

--- a/packages/jbrowse-plugin-apollo/src/components/DeleteFeature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/DeleteFeature.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-misused-promises */
-import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
-import { DeleteFeatureChange } from '@apollo-annotation/apollo-shared'
+import { AnnotationFeatureI } from '@apollo-annotation/mst'
+import { DeleteFeatureChange } from '@apollo-annotation/shared'
 import { AbstractSessionModel } from '@jbrowse/core/util'
 import {
   Button,

--- a/packages/jbrowse-plugin-apollo/src/components/DownloadGFF3.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/DownloadGFF3.tsx
@@ -3,8 +3,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-misused-promises */
-import { ApolloAssembly } from '@apollo-annotation/apollo-mst'
-import { makeGFF3Feature } from '@apollo-annotation/apollo-shared'
+import { ApolloAssembly } from '@apollo-annotation/mst'
+import { makeGFF3Feature } from '@apollo-annotation/shared'
 import gff, { GFF3Item } from '@gmod/gff'
 import { Assembly } from '@jbrowse/core/assemblyManager/assembly'
 import { getConf } from '@jbrowse/core/configuration'

--- a/packages/jbrowse-plugin-apollo/src/components/DownloadGFF3.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/DownloadGFF3.tsx
@@ -3,6 +3,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-misused-promises */
+import { ApolloAssembly } from '@apollo-annotation/apollo-mst'
+import { makeGFF3Feature } from '@apollo-annotation/apollo-shared'
 import gff, { GFF3Item } from '@gmod/gff'
 import { Assembly } from '@jbrowse/core/assemblyManager/assembly'
 import { getConf } from '@jbrowse/core/configuration'
@@ -15,8 +17,6 @@ import {
   Select,
   SelectChangeEvent,
 } from '@mui/material'
-import { ApolloAssembly } from 'apollo-mst'
-import { makeGFF3Feature } from 'apollo-shared'
 import { saveAs } from 'file-saver'
 import { IMSTMap, getSnapshot } from 'mobx-state-tree'
 import React, { useState } from 'react'

--- a/packages/jbrowse-plugin-apollo/src/components/ImportFeatures.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/ImportFeatures.tsx
@@ -4,7 +4,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-misused-promises */
-import { AddFeaturesFromFileChange } from '@apollo-annotation/apollo-shared'
+import { AddFeaturesFromFileChange } from '@apollo-annotation/shared'
 import { Assembly } from '@jbrowse/core/assemblyManager/assembly'
 import { getConf } from '@jbrowse/core/configuration'
 import {

--- a/packages/jbrowse-plugin-apollo/src/components/ImportFeatures.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/ImportFeatures.tsx
@@ -4,6 +4,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-misused-promises */
+import { AddFeaturesFromFileChange } from '@apollo-annotation/apollo-shared'
 import { Assembly } from '@jbrowse/core/assemblyManager/assembly'
 import { getConf } from '@jbrowse/core/configuration'
 import {
@@ -18,7 +19,6 @@ import {
 import Checkbox from '@mui/material/Checkbox'
 import FormControlLabel from '@mui/material/FormControlLabel'
 import LinearProgress from '@mui/material/LinearProgress'
-import { AddFeaturesFromFileChange } from 'apollo-shared'
 import React, { useEffect, useState } from 'react'
 
 import {

--- a/packages/jbrowse-plugin-apollo/src/components/ManageUsers.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/ManageUsers.tsx
@@ -3,6 +3,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
+import { DeleteUserChange, UserChange } from '@apollo-annotation/apollo-shared'
 import { AbstractRootModel } from '@jbrowse/core/util'
 import DeleteIcon from '@mui/icons-material/Delete'
 import {
@@ -24,7 +25,6 @@ import {
   GridRowParams,
   GridToolbar,
 } from '@mui/x-data-grid'
-import { DeleteUserChange, UserChange } from 'apollo-shared'
 import { getRoot } from 'mobx-state-tree'
 import React, { useCallback, useEffect, useState } from 'react'
 

--- a/packages/jbrowse-plugin-apollo/src/components/ManageUsers.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/ManageUsers.tsx
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
-import { DeleteUserChange, UserChange } from '@apollo-annotation/apollo-shared'
+import { DeleteUserChange, UserChange } from '@apollo-annotation/shared'
 import { AbstractRootModel } from '@jbrowse/core/util'
 import DeleteIcon from '@mui/icons-material/Delete'
 import {

--- a/packages/jbrowse-plugin-apollo/src/components/ModifyFeatureAttribute.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/ModifyFeatureAttribute.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-misused-promises */
-import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
-import { FeatureAttributeChange } from '@apollo-annotation/apollo-shared'
+import { AnnotationFeatureI } from '@apollo-annotation/mst'
+import { FeatureAttributeChange } from '@apollo-annotation/shared'
 import { AbstractSessionModel } from '@jbrowse/core/util'
 import DeleteIcon from '@mui/icons-material/Delete'
 import {

--- a/packages/jbrowse-plugin-apollo/src/components/ModifyFeatureAttribute.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/ModifyFeatureAttribute.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-misused-promises */
+import { AnnotationFeatureI } from '@apollo-annotation/apollo-mst'
+import { FeatureAttributeChange } from '@apollo-annotation/apollo-shared'
 import { AbstractSessionModel } from '@jbrowse/core/util'
 import DeleteIcon from '@mui/icons-material/Delete'
 import {
@@ -19,8 +21,6 @@ import {
   TextField,
   Typography,
 } from '@mui/material'
-import { AnnotationFeatureI } from 'apollo-mst'
-import { FeatureAttributeChange } from 'apollo-shared'
 import { getRoot, getSnapshot } from 'mobx-state-tree'
 import React, { useMemo, useState } from 'react'
 import { makeStyles } from 'tss-react/mui'

--- a/packages/jbrowse-plugin-apollo/src/components/ViewChangeLog.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/ViewChangeLog.tsx
@@ -3,6 +3,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
+import { changeRegistry } from '@apollo-annotation/apollo-common'
 import {
   Button,
   DialogActions,
@@ -18,7 +19,6 @@ import {
   GridRowsProp,
   GridToolbar,
 } from '@mui/x-data-grid'
-import { changeRegistry } from 'apollo-common'
 import { getRoot } from 'mobx-state-tree'
 import React, { useEffect, useState } from 'react'
 import { makeStyles } from 'tss-react/mui'

--- a/packages/jbrowse-plugin-apollo/src/components/ViewChangeLog.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/ViewChangeLog.tsx
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
-import { changeRegistry } from '@apollo-annotation/apollo-common'
+import { changeRegistry } from '@apollo-annotation/common'
 import {
   Button,
   DialogActions,

--- a/packages/jbrowse-plugin-apollo/src/extensions/annotationFromPileup.ts
+++ b/packages/jbrowse-plugin-apollo/src/extensions/annotationFromPileup.ts
@@ -3,8 +3,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
-import { AnnotationFeatureSnapshot } from '@apollo-annotation/apollo-mst'
-import { AddFeatureChange } from '@apollo-annotation/apollo-shared'
+import { AnnotationFeatureSnapshot } from '@apollo-annotation/mst'
+import { AddFeatureChange } from '@apollo-annotation/shared'
 import { Assembly } from '@jbrowse/core/assemblyManager/assembly'
 import { DisplayType } from '@jbrowse/core/pluggableElementTypes'
 import PluggableElementBase from '@jbrowse/core/pluggableElementTypes/PluggableElementBase'

--- a/packages/jbrowse-plugin-apollo/src/extensions/annotationFromPileup.ts
+++ b/packages/jbrowse-plugin-apollo/src/extensions/annotationFromPileup.ts
@@ -3,14 +3,14 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
+import { AnnotationFeatureSnapshot } from '@apollo-annotation/apollo-mst'
+import { AddFeatureChange } from '@apollo-annotation/apollo-shared'
 import { Assembly } from '@jbrowse/core/assemblyManager/assembly'
 import { DisplayType } from '@jbrowse/core/pluggableElementTypes'
 import PluggableElementBase from '@jbrowse/core/pluggableElementTypes/PluggableElementBase'
 import { getContainingView, getSession } from '@jbrowse/core/util'
 import { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
 import AddIcon from '@mui/icons-material/Add'
-import { AnnotationFeatureSnapshot } from 'apollo-mst'
-import { AddFeatureChange } from 'apollo-shared'
 import ObjectID from 'bson-objectid'
 
 import { ApolloSessionModel } from '../session'

--- a/packages/jbrowse-plugin-apollo/src/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/index.ts
@@ -2,14 +2,14 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-misused-promises */
-import { changeRegistry, checkRegistry } from '@apollo-annotation/apollo-common'
+import { changeRegistry, checkRegistry } from '@apollo-annotation/common'
 import {
   CDSCheck,
   CoreValidation,
   ParentChildValidation,
   changes,
   validationRegistry,
-} from '@apollo-annotation/apollo-shared'
+} from '@apollo-annotation/shared'
 import { ConfigurationSchema } from '@jbrowse/core/configuration'
 import {
   DisplayType,

--- a/packages/jbrowse-plugin-apollo/src/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/index.ts
@@ -2,6 +2,14 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-misused-promises */
+import { changeRegistry, checkRegistry } from '@apollo-annotation/apollo-common'
+import {
+  CDSCheck,
+  CoreValidation,
+  ParentChildValidation,
+  changes,
+  validationRegistry,
+} from '@apollo-annotation/apollo-shared'
 import { ConfigurationSchema } from '@jbrowse/core/configuration'
 import {
   DisplayType,
@@ -23,14 +31,6 @@ import {
 } from '@jbrowse/core/util'
 import { LinearGenomeViewStateModel } from '@jbrowse/plugin-linear-genome-view'
 import AddIcon from '@mui/icons-material/Add'
-import { changeRegistry, checkRegistry } from 'apollo-common'
-import {
-  CDSCheck,
-  CoreValidation,
-  ParentChildValidation,
-  changes,
-  validationRegistry,
-} from 'apollo-shared'
 
 import { version } from '../package.json'
 import {

--- a/packages/jbrowse-plugin-apollo/src/session/ClientDataStore.ts
+++ b/packages/jbrowse-plugin-apollo/src/session/ClientDataStore.ts
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
-import { ClientDataStore as ClientDataStoreType } from '@apollo-annotation/apollo-common'
+import { ClientDataStore as ClientDataStoreType } from '@apollo-annotation/common'
 import {
   AnnotationFeature,
   AnnotationFeatureSnapshot,
@@ -11,7 +11,7 @@ import {
   ApolloRefSeq,
   CheckResult,
   CheckResultSnapshot,
-} from '@apollo-annotation/apollo-mst'
+} from '@apollo-annotation/mst'
 import { getConf, readConfObject } from '@jbrowse/core/configuration'
 import { ConfigurationModel } from '@jbrowse/core/configuration/types'
 import { Region, getSession, isElectron } from '@jbrowse/core/util'

--- a/packages/jbrowse-plugin-apollo/src/session/ClientDataStore.ts
+++ b/packages/jbrowse-plugin-apollo/src/session/ClientDataStore.ts
@@ -3,11 +3,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
-import { getConf, readConfObject } from '@jbrowse/core/configuration'
-import { ConfigurationModel } from '@jbrowse/core/configuration/types'
-import { Region, getSession, isElectron } from '@jbrowse/core/util'
-import { LocalPathLocation, UriLocation } from '@jbrowse/core/util/types/mst'
-import { ClientDataStore as ClientDataStoreType } from 'apollo-common'
+import { ClientDataStore as ClientDataStoreType } from '@apollo-annotation/apollo-common'
 import {
   AnnotationFeature,
   AnnotationFeatureSnapshot,
@@ -15,7 +11,11 @@ import {
   ApolloRefSeq,
   CheckResult,
   CheckResultSnapshot,
-} from 'apollo-mst'
+} from '@apollo-annotation/apollo-mst'
+import { getConf, readConfObject } from '@jbrowse/core/configuration'
+import { ConfigurationModel } from '@jbrowse/core/configuration/types'
+import { Region, getSession, isElectron } from '@jbrowse/core/util'
+import { LocalPathLocation, UriLocation } from '@jbrowse/core/util/types/mst'
 import {
   Instance,
   SnapshotOut,

--- a/packages/jbrowse-plugin-apollo/src/session/session.ts
+++ b/packages/jbrowse-plugin-apollo/src/session/session.ts
@@ -2,12 +2,9 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
-import { ClientDataStore as ClientDataStoreType } from '@apollo-annotation/apollo-common'
-import {
-  AnnotationFeature,
-  AnnotationFeatureI,
-} from '@apollo-annotation/apollo-mst'
-import { UserLocation } from '@apollo-annotation/apollo-shared'
+import { ClientDataStore as ClientDataStoreType } from '@apollo-annotation/common'
+import { AnnotationFeature, AnnotationFeatureI } from '@apollo-annotation/mst'
+import { UserLocation } from '@apollo-annotation/shared'
 import { AssemblyModel } from '@jbrowse/core/assemblyManager/assembly'
 import { getConf } from '@jbrowse/core/configuration'
 import { BaseInternetAccountModel } from '@jbrowse/core/pluggableElementTypes'

--- a/packages/jbrowse-plugin-apollo/src/session/session.ts
+++ b/packages/jbrowse-plugin-apollo/src/session/session.ts
@@ -2,6 +2,12 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
+import { ClientDataStore as ClientDataStoreType } from '@apollo-annotation/apollo-common'
+import {
+  AnnotationFeature,
+  AnnotationFeatureI,
+} from '@apollo-annotation/apollo-mst'
+import { UserLocation } from '@apollo-annotation/apollo-shared'
 import { AssemblyModel } from '@jbrowse/core/assemblyManager/assembly'
 import { getConf } from '@jbrowse/core/configuration'
 import { BaseInternetAccountModel } from '@jbrowse/core/pluggableElementTypes'
@@ -11,9 +17,6 @@ import {
   SessionWithConfigEditing,
 } from '@jbrowse/core/util'
 import { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
-import { ClientDataStore as ClientDataStoreType } from 'apollo-common'
-import { AnnotationFeature, AnnotationFeatureI } from 'apollo-mst'
-import { UserLocation } from 'apollo-shared'
 import { autorun, observable } from 'mobx'
 import { Instance, flow, getRoot, types } from 'mobx-state-tree'
 

--- a/packages/jbrowse-plugin-apollo/src/util/loadAssemblyIntoClient.ts
+++ b/packages/jbrowse-plugin-apollo/src/util/loadAssemblyIntoClient.ts
@@ -1,10 +1,13 @@
-import gff, { GFF3Comment, GFF3Feature, GFF3Sequence } from '@gmod/gff'
-import { ClientDataStore, checkRegistry } from 'apollo-common'
+import {
+  ClientDataStore,
+  checkRegistry,
+} from '@apollo-annotation/apollo-common'
 import {
   AnnotationFeatureSnapshot,
   ApolloAssemblyI,
   CheckResultSnapshot,
-} from 'apollo-mst'
+} from '@apollo-annotation/apollo-mst'
+import gff, { GFF3Comment, GFF3Feature, GFF3Sequence } from '@gmod/gff'
 import { getSnapshot } from 'mobx-state-tree'
 import { nanoid } from 'nanoid'
 

--- a/packages/jbrowse-plugin-apollo/src/util/loadAssemblyIntoClient.ts
+++ b/packages/jbrowse-plugin-apollo/src/util/loadAssemblyIntoClient.ts
@@ -1,12 +1,9 @@
-import {
-  ClientDataStore,
-  checkRegistry,
-} from '@apollo-annotation/apollo-common'
+import { ClientDataStore, checkRegistry } from '@apollo-annotation/common'
 import {
   AnnotationFeatureSnapshot,
   ApolloAssemblyI,
   CheckResultSnapshot,
-} from '@apollo-annotation/apollo-mst'
+} from '@apollo-annotation/mst'
 import gff, { GFF3Comment, GFF3Feature, GFF3Sequence } from '@gmod/gff'
 import { getSnapshot } from 'mobx-state-tree'
 import { nanoid } from 'nanoid'

--- a/yarn.lock
+++ b/yarn.lock
@@ -115,6 +115,214 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@apollo-annotation/apollo-cli@workspace:packages/apollo-cli":
+  version: 0.0.0-use.local
+  resolution: "@apollo-annotation/apollo-cli@workspace:packages/apollo-cli"
+  dependencies:
+    "@inquirer/input": "npm:^1.2.14"
+    "@inquirer/password": "npm:^1.1.14"
+    "@inquirer/select": "npm:^1.3.1"
+    "@istanbuljs/esm-loader-hook": "npm:^0.2.0"
+    "@istanbuljs/nyc-config-typescript": "npm:^1.0.2"
+    "@oclif/core": "npm:^3.18.2"
+    "@oclif/plugin-help": "npm:^6.0.8"
+    "@oclif/test": "npm:^3.1.3"
+    "@types/chai": "npm:^4"
+    "@types/inquirer": "npm:^9.0.7"
+    "@types/mocha": "npm:^10"
+    "@types/node": "npm:^18.14.2"
+    babel-plugin-istanbul: "npm:^6.1.1"
+    bson: "npm:^6.3.0"
+    joi: "npm:^17.7.0"
+    mocha: "npm:^10.2.0"
+    nyc: "npm:^15.1.0"
+    oclif: "npm:^4.4.2"
+    open: "npm:^9.1.0"
+    shx: "npm:^0.3.3"
+    ts-node: "npm:^10.3.0"
+    tslib: "npm:^2.3.1"
+    tsx: "npm:^4.6.2"
+    typescript: "npm:^5.1.6"
+    undici: "npm:^6.7.0"
+    yaml: "npm:^2.3.4"
+  bin:
+    apollo: ./bin/run.js
+  languageName: unknown
+  linkType: soft
+
+"@apollo-annotation/apollo-common@workspace:^, @apollo-annotation/apollo-common@workspace:packages/apollo-common":
+  version: 0.0.0-use.local
+  resolution: "@apollo-annotation/apollo-common@workspace:packages/apollo-common"
+  dependencies:
+    "@apollo-annotation/apollo-mst": "workspace:^"
+    "@apollo-annotation/apollo-schemas": "workspace:^"
+    "@gmod/gff": "npm:1.2.0"
+    "@jbrowse/core": "npm:^2.7.0"
+    "@nestjs/common": "npm:^10.1.0"
+    "@nestjs/core": "npm:^10.1.0"
+    "@types/node": "npm:^18.14.2"
+    bson-objectid: "npm:^2.0.4"
+    mongoose: "npm:^6.12.0"
+    tslib: "npm:^2.3.1"
+    typescript: "npm:^5.1.6"
+  peerDependencies:
+    "@mui/material": ^5.11.14
+    "@mui/x-data-grid": ^7.0.0
+    mobx: ^6.6.1
+    mobx-react: ^7.2.1
+    mobx-state-tree: ^5.1.7
+    prop-types: ^15.8.1
+    react: ^18.2.0
+    react-dom: ^18.2.0
+    rxjs: ^7.4.0
+    tss-react: ^4.6.1
+  languageName: unknown
+  linkType: soft
+
+"@apollo-annotation/apollo-mst@workspace:^, @apollo-annotation/apollo-mst@workspace:packages/apollo-mst":
+  version: 0.0.0-use.local
+  resolution: "@apollo-annotation/apollo-mst@workspace:packages/apollo-mst"
+  dependencies:
+    "@jbrowse/core": "npm:^2.7.0"
+    mobx: "npm:^6.6.1"
+    mobx-state-tree: "npm:^5.1.7"
+    rxjs: "npm:^7.4.0"
+    tslib: "npm:^2.3.1"
+    typescript: "npm:^5.1.6"
+  languageName: unknown
+  linkType: soft
+
+"@apollo-annotation/apollo-schemas@workspace:^, @apollo-annotation/apollo-schemas@workspace:packages/apollo-schemas":
+  version: 0.0.0-use.local
+  resolution: "@apollo-annotation/apollo-schemas@workspace:packages/apollo-schemas"
+  dependencies:
+    "@apollo-annotation/apollo-mst": "workspace:^"
+    "@nestjs/common": "npm:^10.1.0"
+    "@nestjs/core": "npm:^10.1.0"
+    "@nestjs/mongoose": "npm:^10.0.0"
+    "@types/node": "npm:^18.14.2"
+    mongoose: "npm:^6.12.0"
+    reflect-metadata: "npm:^0.1.13"
+    regenerator-runtime: "npm:^0.13.9"
+    rxjs: "npm:^7.4.0"
+    tslib: "npm:^2.3.1"
+    typescript: "npm:^5.1.6"
+  languageName: unknown
+  linkType: soft
+
+"@apollo-annotation/apollo-shared@workspace:^, @apollo-annotation/apollo-shared@workspace:packages/apollo-shared":
+  version: 0.0.0-use.local
+  resolution: "@apollo-annotation/apollo-shared@workspace:packages/apollo-shared"
+  dependencies:
+    "@apollo-annotation/apollo-common": "workspace:^"
+    "@apollo-annotation/apollo-mst": "workspace:^"
+    "@apollo-annotation/apollo-schemas": "workspace:^"
+    "@gmod/gff": "npm:1.2.0"
+    "@gmod/indexedfasta": "npm:^2.0.4"
+    "@jbrowse/core": "npm:^2.7.0"
+    "@nestjs/common": "npm:^10.1.0"
+    "@nestjs/core": "npm:^10.1.0"
+    "@types/node": "npm:^18.14.2"
+    "@types/rimraf": "npm:^3"
+    bson-objectid: "npm:^2.0.4"
+    generic-filehandle: "npm:^3.0.0"
+    jwt-decode: "npm:^3.1.2"
+    mobx: "npm:^6.6.1"
+    mobx-state-tree: "npm:^5.1.7"
+    mongoose: "npm:^6.12.0"
+    regenerator-runtime: "npm:^0.13.9"
+    rimraf: "npm:^3.0.2"
+    socket.io-client: "npm:^4.5.4"
+    tslib: "npm:^2.3.1"
+    typescript: "npm:^5.1.6"
+  peerDependencies:
+    "@mui/material": ^5.11.14
+    "@mui/x-data-grid": ^7.0.0
+    mobx: ^6.6.1
+    mobx-react: ^7.2.1
+    mobx-state-tree: ^5.1.7
+    prop-types: ^15.8.1
+    react: ^18.2.0
+    react-dom: ^18.2.0
+    rxjs: ^7.4.0
+  languageName: unknown
+  linkType: soft
+
+"@apollo-annotation/jbrowse-plugin-apollo@workspace:packages/jbrowse-plugin-apollo":
+  version: 0.0.0-use.local
+  resolution: "@apollo-annotation/jbrowse-plugin-apollo@workspace:packages/jbrowse-plugin-apollo"
+  dependencies:
+    "@apollo-annotation/apollo-common": "workspace:^"
+    "@apollo-annotation/apollo-mst": "workspace:^"
+    "@apollo-annotation/apollo-shared": "workspace:^"
+    "@emotion/react": "npm:^11.10.6"
+    "@emotion/styled": "npm:^11.10.6"
+    "@gmod/gff": "npm:1.2.0"
+    "@jbrowse/cli": "npm:^2.6.2"
+    "@jbrowse/core": "npm:^2.7.0"
+    "@jbrowse/development-tools": "npm:^2.1.1"
+    "@jbrowse/plugin-authentication": "npm:^2.0.1"
+    "@jbrowse/plugin-linear-genome-view": "npm:^2.0.1"
+    "@jest/globals": "npm:^29.0.3"
+    "@mui/icons-material": "npm:^5.8.4"
+    "@mui/material": "npm:^5.11.14"
+    "@mui/x-data-grid": "npm:^7.0.0"
+    "@types/autosuggest-highlight": "npm:^3"
+    "@types/file-saver": "npm:^2"
+    "@types/jsonpath": "npm:^0.2.0"
+    "@types/node": "npm:^18.14.2"
+    "@types/prop-types": "npm:^15"
+    "@types/react": "npm:^17.0.34"
+    "@types/react-dom": "npm:^18"
+    autosuggest-highlight: "npm:^3.3.4"
+    bson-objectid: "npm:^2.0.4"
+    clsx: "npm:^1.1.1"
+    cypress: "npm:12.17.3"
+    cypress-mongodb: "npm:^6.2.0"
+    fake-indexeddb: "npm:^4.0.2"
+    fast-deep-equal: "npm:^3.1.3"
+    file-saver: "npm:^2.0.5"
+    http-proxy-middleware: "npm:^2.0.6"
+    idb: "npm:^7.1.1"
+    jest: "npm:^29.6.2"
+    jest-fetch-mock: "npm:^3.0.3"
+    jsonpath: "npm:^1.1.1"
+    librpc-web-mod: "npm:^1.1.9"
+    mobx: "npm:^6.6.1"
+    mobx-react: "npm:^7.2.1"
+    mobx-state-tree: "npm:^5.1.7"
+    nanoid: "npm:^4.0.2"
+    npm-run-all: "npm:^4.1.5"
+    prop-types: "npm:^15.8.1"
+    react: "npm:^18.2.0"
+    react-dom: "npm:^18.2.0"
+    regenerator-runtime: "npm:^0.13.9"
+    rimraf: "npm:^3.0.2"
+    rollup: "npm:^2.59.0"
+    rxjs: "npm:^7.4.0"
+    serve: "npm:^14.0.1"
+    shx: "npm:^0.3.3"
+    socket.io-client: "npm:^4.5.4"
+    start-server-and-test: "npm:^1.11.7"
+    ts-jest: "npm:^29.1.1"
+    ts-node: "npm:^10.3.0"
+    tslib: "npm:^2.3.1"
+    tss-react: "npm:^4.6.1"
+    typescript: "npm:^5.1.6"
+  peerDependencies:
+    "@jbrowse/core": ^2.7.0
+    "@mui/material": ^5.11.14
+    mobx: ^6.6.1
+    mobx-react: ^7.2.1
+    mobx-state-tree: ^5.1.7
+    prop-types: ^15.8.1
+    react: ^18.2.0
+    react-dom: ^18.2.0
+    rxjs: ^7.4.0
+    tss-react: ^4.6.1
+  languageName: unknown
+  linkType: soft
+
 "@aws-crypto/crc32@npm:3.0.0":
   version: 3.0.0
   resolution: "@aws-crypto/crc32@npm:3.0.0"
@@ -8143,45 +8351,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"apollo-cli@workspace:packages/apollo-cli":
-  version: 0.0.0-use.local
-  resolution: "apollo-cli@workspace:packages/apollo-cli"
-  dependencies:
-    "@inquirer/input": "npm:^1.2.14"
-    "@inquirer/password": "npm:^1.1.14"
-    "@inquirer/select": "npm:^1.3.1"
-    "@istanbuljs/esm-loader-hook": "npm:^0.2.0"
-    "@istanbuljs/nyc-config-typescript": "npm:^1.0.2"
-    "@oclif/core": "npm:^3.18.2"
-    "@oclif/plugin-help": "npm:^6.0.8"
-    "@oclif/test": "npm:^3.1.3"
-    "@types/chai": "npm:^4"
-    "@types/inquirer": "npm:^9.0.7"
-    "@types/mocha": "npm:^10"
-    "@types/node": "npm:^18.14.2"
-    babel-plugin-istanbul: "npm:^6.1.1"
-    bson: "npm:^6.3.0"
-    joi: "npm:^17.7.0"
-    mocha: "npm:^10.2.0"
-    nyc: "npm:^15.1.0"
-    oclif: "npm:^4.4.2"
-    open: "npm:^9.1.0"
-    shx: "npm:^0.3.3"
-    ts-node: "npm:^10.3.0"
-    tslib: "npm:^2.3.1"
-    tsx: "npm:^4.6.2"
-    typescript: "npm:^5.1.6"
-    undici: "npm:^6.7.0"
-    yaml: "npm:^2.3.4"
-  bin:
-    apollo: ./bin/run.js
-  languageName: unknown
-  linkType: soft
-
 "apollo-collaboration-server@workspace:packages/apollo-collaboration-server":
   version: 0.0.0-use.local
   resolution: "apollo-collaboration-server@workspace:packages/apollo-collaboration-server"
   dependencies:
+    "@apollo-annotation/apollo-common": "workspace:^"
+    "@apollo-annotation/apollo-mst": "workspace:^"
+    "@apollo-annotation/apollo-schemas": "workspace:^"
+    "@apollo-annotation/apollo-shared": "workspace:^"
     "@emotion/react": "npm:^11.10.6"
     "@emotion/styled": "npm:^11.10.6"
     "@gmod/gff": "npm:1.2.0"
@@ -8216,10 +8393,6 @@ __metadata:
     "@types/passport-microsoft": "npm:^0.0.0"
     "@types/react": "npm:^17.0.34"
     "@types/supertest": "npm:^2.0.11"
-    apollo-common: "workspace:^"
-    apollo-mst: "workspace:^"
-    apollo-schemas: "workspace:^"
-    apollo-shared: "workspace:^"
     connect-mongodb-session: "npm:^3.1.1"
     express: "npm:^4.18.0"
     express-session: "npm:^1.17.3"
@@ -8260,104 +8433,6 @@ __metadata:
     tslib: "npm:^2.3.1"
     tss-react: "npm:^4.6.1"
     typescript: "npm:^5.1.6"
-  languageName: unknown
-  linkType: soft
-
-"apollo-common@workspace:^, apollo-common@workspace:packages/apollo-common":
-  version: 0.0.0-use.local
-  resolution: "apollo-common@workspace:packages/apollo-common"
-  dependencies:
-    "@gmod/gff": "npm:1.2.0"
-    "@jbrowse/core": "npm:^2.7.0"
-    "@nestjs/common": "npm:^10.1.0"
-    "@nestjs/core": "npm:^10.1.0"
-    "@types/node": "npm:^18.14.2"
-    apollo-mst: "workspace:^"
-    apollo-schemas: "workspace:^"
-    bson-objectid: "npm:^2.0.4"
-    mongoose: "npm:^6.12.0"
-    tslib: "npm:^2.3.1"
-    typescript: "npm:^5.1.6"
-  peerDependencies:
-    "@mui/material": ^5.11.14
-    "@mui/x-data-grid": ^7.0.0
-    mobx: ^6.6.1
-    mobx-react: ^7.2.1
-    mobx-state-tree: ^5.1.7
-    prop-types: ^15.8.1
-    react: ^18.2.0
-    react-dom: ^18.2.0
-    rxjs: ^7.4.0
-    tss-react: ^4.6.1
-  languageName: unknown
-  linkType: soft
-
-"apollo-mst@workspace:^, apollo-mst@workspace:packages/apollo-mst":
-  version: 0.0.0-use.local
-  resolution: "apollo-mst@workspace:packages/apollo-mst"
-  dependencies:
-    "@jbrowse/core": "npm:^2.7.0"
-    mobx: "npm:^6.6.1"
-    mobx-state-tree: "npm:^5.1.7"
-    rxjs: "npm:^7.4.0"
-    tslib: "npm:^2.3.1"
-    typescript: "npm:^5.1.6"
-  languageName: unknown
-  linkType: soft
-
-"apollo-schemas@workspace:^, apollo-schemas@workspace:packages/apollo-schemas":
-  version: 0.0.0-use.local
-  resolution: "apollo-schemas@workspace:packages/apollo-schemas"
-  dependencies:
-    "@nestjs/common": "npm:^10.1.0"
-    "@nestjs/core": "npm:^10.1.0"
-    "@nestjs/mongoose": "npm:^10.0.0"
-    "@types/node": "npm:^18.14.2"
-    apollo-mst: "workspace:^"
-    mongoose: "npm:^6.12.0"
-    reflect-metadata: "npm:^0.1.13"
-    regenerator-runtime: "npm:^0.13.9"
-    rxjs: "npm:^7.4.0"
-    tslib: "npm:^2.3.1"
-    typescript: "npm:^5.1.6"
-  languageName: unknown
-  linkType: soft
-
-"apollo-shared@workspace:^, apollo-shared@workspace:packages/apollo-shared":
-  version: 0.0.0-use.local
-  resolution: "apollo-shared@workspace:packages/apollo-shared"
-  dependencies:
-    "@gmod/gff": "npm:1.2.0"
-    "@gmod/indexedfasta": "npm:^2.0.4"
-    "@jbrowse/core": "npm:^2.7.0"
-    "@nestjs/common": "npm:^10.1.0"
-    "@nestjs/core": "npm:^10.1.0"
-    "@types/node": "npm:^18.14.2"
-    "@types/rimraf": "npm:^3"
-    apollo-common: "workspace:^"
-    apollo-mst: "workspace:^"
-    apollo-schemas: "workspace:^"
-    bson-objectid: "npm:^2.0.4"
-    generic-filehandle: "npm:^3.0.0"
-    jwt-decode: "npm:^3.1.2"
-    mobx: "npm:^6.6.1"
-    mobx-state-tree: "npm:^5.1.7"
-    mongoose: "npm:^6.12.0"
-    regenerator-runtime: "npm:^0.13.9"
-    rimraf: "npm:^3.0.2"
-    socket.io-client: "npm:^4.5.4"
-    tslib: "npm:^2.3.1"
-    typescript: "npm:^5.1.6"
-  peerDependencies:
-    "@mui/material": ^5.11.14
-    "@mui/x-data-grid": ^7.0.0
-    mobx: ^6.6.1
-    mobx-react: ^7.2.1
-    mobx-state-tree: ^5.1.7
-    prop-types: ^15.8.1
-    react: ^18.2.0
-    react-dom: ^18.2.0
-    rxjs: ^7.4.0
   languageName: unknown
   linkType: soft
 
@@ -14969,81 +15044,6 @@ __metadata:
   checksum: 10c0/89326d01a8bc110d02d973729a66394c79a34b34461116f5c530a2a2dbc30265683fe6737928f75df9178e9d369ff1442f5753fb983d525e740eefdadc56a103
   languageName: node
   linkType: hard
-
-"jbrowse-plugin-apollo@workspace:packages/jbrowse-plugin-apollo":
-  version: 0.0.0-use.local
-  resolution: "jbrowse-plugin-apollo@workspace:packages/jbrowse-plugin-apollo"
-  dependencies:
-    "@emotion/react": "npm:^11.10.6"
-    "@emotion/styled": "npm:^11.10.6"
-    "@gmod/gff": "npm:1.2.0"
-    "@jbrowse/cli": "npm:^2.6.2"
-    "@jbrowse/core": "npm:^2.7.0"
-    "@jbrowse/development-tools": "npm:^2.1.1"
-    "@jbrowse/plugin-authentication": "npm:^2.0.1"
-    "@jbrowse/plugin-linear-genome-view": "npm:^2.0.1"
-    "@jest/globals": "npm:^29.0.3"
-    "@mui/icons-material": "npm:^5.8.4"
-    "@mui/material": "npm:^5.11.14"
-    "@mui/x-data-grid": "npm:^7.0.0"
-    "@types/autosuggest-highlight": "npm:^3"
-    "@types/file-saver": "npm:^2"
-    "@types/jsonpath": "npm:^0.2.0"
-    "@types/node": "npm:^18.14.2"
-    "@types/prop-types": "npm:^15"
-    "@types/react": "npm:^17.0.34"
-    "@types/react-dom": "npm:^18"
-    apollo-common: "workspace:^"
-    apollo-mst: "workspace:^"
-    apollo-shared: "workspace:^"
-    autosuggest-highlight: "npm:^3.3.4"
-    bson-objectid: "npm:^2.0.4"
-    clsx: "npm:^1.1.1"
-    cypress: "npm:12.17.3"
-    cypress-mongodb: "npm:^6.2.0"
-    fake-indexeddb: "npm:^4.0.2"
-    fast-deep-equal: "npm:^3.1.3"
-    file-saver: "npm:^2.0.5"
-    http-proxy-middleware: "npm:^2.0.6"
-    idb: "npm:^7.1.1"
-    jest: "npm:^29.6.2"
-    jest-fetch-mock: "npm:^3.0.3"
-    jsonpath: "npm:^1.1.1"
-    librpc-web-mod: "npm:^1.1.9"
-    mobx: "npm:^6.6.1"
-    mobx-react: "npm:^7.2.1"
-    mobx-state-tree: "npm:^5.1.7"
-    nanoid: "npm:^4.0.2"
-    npm-run-all: "npm:^4.1.5"
-    prop-types: "npm:^15.8.1"
-    react: "npm:^18.2.0"
-    react-dom: "npm:^18.2.0"
-    regenerator-runtime: "npm:^0.13.9"
-    rimraf: "npm:^3.0.2"
-    rollup: "npm:^2.59.0"
-    rxjs: "npm:^7.4.0"
-    serve: "npm:^14.0.1"
-    shx: "npm:^0.3.3"
-    socket.io-client: "npm:^4.5.4"
-    start-server-and-test: "npm:^1.11.7"
-    ts-jest: "npm:^29.1.1"
-    ts-node: "npm:^10.3.0"
-    tslib: "npm:^2.3.1"
-    tss-react: "npm:^4.6.1"
-    typescript: "npm:^5.1.6"
-  peerDependencies:
-    "@jbrowse/core": ^2.7.0
-    "@mui/material": ^5.11.14
-    mobx: ^6.6.1
-    mobx-react: ^7.2.1
-    mobx-state-tree: ^5.1.7
-    prop-types: ^15.8.1
-    react: ^18.2.0
-    react-dom: ^18.2.0
-    rxjs: ^7.4.0
-    tss-react: ^4.6.1
-  languageName: unknown
-  linkType: soft
 
 "jest-changed-files@npm:^29.7.0":
   version: 29.7.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -115,9 +115,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apollo-annotation/apollo-cli@workspace:packages/apollo-cli":
+"@apollo-annotation/cli@workspace:packages/apollo-cli":
   version: 0.0.0-use.local
-  resolution: "@apollo-annotation/apollo-cli@workspace:packages/apollo-cli"
+  resolution: "@apollo-annotation/cli@workspace:packages/apollo-cli"
   dependencies:
     "@inquirer/input": "npm:^1.2.14"
     "@inquirer/password": "npm:^1.1.14"
@@ -150,12 +150,97 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@apollo-annotation/apollo-common@workspace:^, @apollo-annotation/apollo-common@workspace:packages/apollo-common":
+"@apollo-annotation/collaboration-server@workspace:packages/apollo-collaboration-server":
   version: 0.0.0-use.local
-  resolution: "@apollo-annotation/apollo-common@workspace:packages/apollo-common"
+  resolution: "@apollo-annotation/collaboration-server@workspace:packages/apollo-collaboration-server"
   dependencies:
-    "@apollo-annotation/apollo-mst": "workspace:^"
-    "@apollo-annotation/apollo-schemas": "workspace:^"
+    "@apollo-annotation/common": "workspace:^"
+    "@apollo-annotation/mst": "workspace:^"
+    "@apollo-annotation/schemas": "workspace:^"
+    "@apollo-annotation/shared": "workspace:^"
+    "@emotion/react": "npm:^11.10.6"
+    "@emotion/styled": "npm:^11.10.6"
+    "@gmod/gff": "npm:1.2.0"
+    "@gmod/indexedfasta": "npm:^2.0.4"
+    "@jbrowse/core": "npm:^2.7.0"
+    "@mui/base": "npm:^5.0.0-alpha.118"
+    "@mui/material": "npm:^5.11.14"
+    "@nestjs/cli": "npm:^10.1.10"
+    "@nestjs/common": "npm:^10.1.0"
+    "@nestjs/config": "npm:^3.0.0"
+    "@nestjs/core": "npm:^10.1.0"
+    "@nestjs/jwt": "npm:^10.1.0"
+    "@nestjs/mapped-types": "npm:^2.0.2"
+    "@nestjs/mongoose": "npm:^10.0.0"
+    "@nestjs/passport": "npm:^10.0.0"
+    "@nestjs/platform-express": "npm:^10.1.0"
+    "@nestjs/platform-socket.io": "npm:^10.1.0"
+    "@nestjs/schematics": "npm:^10.0.1"
+    "@nestjs/serve-static": "npm:^4.0.0"
+    "@nestjs/terminus": "npm:^10.0.1"
+    "@nestjs/testing": "npm:^10.1.0"
+    "@nestjs/websockets": "npm:^10.1.0"
+    "@types/express": "npm:^4.17.13"
+    "@types/express-session": "npm:^1"
+    "@types/jest": "npm:^27.0.1"
+    "@types/multer": "npm:^1.4.7"
+    "@types/node": "npm:^18.14.2"
+    "@types/node-fetch": "npm:^2.6.2"
+    "@types/passport-google-oauth20": "npm:^2.0.11"
+    "@types/passport-jwt": "npm:^3.0.6"
+    "@types/passport-local": "npm:^1.0.34"
+    "@types/passport-microsoft": "npm:^0.0.0"
+    "@types/react": "npm:^17.0.34"
+    "@types/supertest": "npm:^2.0.11"
+    connect-mongodb-session: "npm:^3.1.1"
+    express: "npm:^4.18.0"
+    express-session: "npm:^1.17.3"
+    generic-filehandle: "npm:^3.0.0"
+    jest: "npm:^29.6.2"
+    joi: "npm:^17.7.0"
+    material-ui-popup-state: "npm:^5.0.4"
+    mobx: "npm:^6.6.1"
+    mobx-react: "npm:^7.2.1"
+    mobx-state-tree: "npm:^5.1.7"
+    mongodb: "npm:^4.7.0"
+    mongoose: "npm:^6.12.0"
+    mongoose-id-validator: "npm:^0.6.0"
+    multer: "npm:^1.4.5-lts.1"
+    node-fetch: "npm:^2.6.7"
+    passport: "npm:^0.5.0"
+    passport-google-oauth20: "npm:^2.0.0"
+    passport-jwt: "npm:^4.0.0"
+    passport-local: "npm:^1.0.0"
+    passport-microsoft: "npm:^1.0.0"
+    prettier: "npm:^3.2.5"
+    prop-types: "npm:^15.8.1"
+    react: "npm:^18.2.0"
+    react-dom: "npm:^18.2.0"
+    reflect-metadata: "npm:^0.1.13"
+    rimraf: "npm:^3.0.2"
+    rxjs: "npm:^7.4.0"
+    sanitize-filename: "npm:^1.6.3"
+    socket.io: "npm:^4.5.3"
+    source-map-support: "npm:^0.5.20"
+    stream-concat: "npm:^1.0.0"
+    supertest: "npm:^6.1.3"
+    ts-jest: "npm:^29.1.1"
+    ts-loader: "npm:^9.2.3"
+    ts-node: "npm:^10.3.0"
+    ts-node-dev: "npm:^1.1.8"
+    tsconfig-paths: "npm:^3.11.0"
+    tslib: "npm:^2.3.1"
+    tss-react: "npm:^4.6.1"
+    typescript: "npm:^5.1.6"
+  languageName: unknown
+  linkType: soft
+
+"@apollo-annotation/common@workspace:^, @apollo-annotation/common@workspace:packages/apollo-common":
+  version: 0.0.0-use.local
+  resolution: "@apollo-annotation/common@workspace:packages/apollo-common"
+  dependencies:
+    "@apollo-annotation/mst": "workspace:^"
+    "@apollo-annotation/schemas": "workspace:^"
     "@gmod/gff": "npm:1.2.0"
     "@jbrowse/core": "npm:^2.7.0"
     "@nestjs/common": "npm:^10.1.0"
@@ -179,82 +264,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@apollo-annotation/apollo-mst@workspace:^, @apollo-annotation/apollo-mst@workspace:packages/apollo-mst":
-  version: 0.0.0-use.local
-  resolution: "@apollo-annotation/apollo-mst@workspace:packages/apollo-mst"
-  dependencies:
-    "@jbrowse/core": "npm:^2.7.0"
-    mobx: "npm:^6.6.1"
-    mobx-state-tree: "npm:^5.1.7"
-    rxjs: "npm:^7.4.0"
-    tslib: "npm:^2.3.1"
-    typescript: "npm:^5.1.6"
-  languageName: unknown
-  linkType: soft
-
-"@apollo-annotation/apollo-schemas@workspace:^, @apollo-annotation/apollo-schemas@workspace:packages/apollo-schemas":
-  version: 0.0.0-use.local
-  resolution: "@apollo-annotation/apollo-schemas@workspace:packages/apollo-schemas"
-  dependencies:
-    "@apollo-annotation/apollo-mst": "workspace:^"
-    "@nestjs/common": "npm:^10.1.0"
-    "@nestjs/core": "npm:^10.1.0"
-    "@nestjs/mongoose": "npm:^10.0.0"
-    "@types/node": "npm:^18.14.2"
-    mongoose: "npm:^6.12.0"
-    reflect-metadata: "npm:^0.1.13"
-    regenerator-runtime: "npm:^0.13.9"
-    rxjs: "npm:^7.4.0"
-    tslib: "npm:^2.3.1"
-    typescript: "npm:^5.1.6"
-  languageName: unknown
-  linkType: soft
-
-"@apollo-annotation/apollo-shared@workspace:^, @apollo-annotation/apollo-shared@workspace:packages/apollo-shared":
-  version: 0.0.0-use.local
-  resolution: "@apollo-annotation/apollo-shared@workspace:packages/apollo-shared"
-  dependencies:
-    "@apollo-annotation/apollo-common": "workspace:^"
-    "@apollo-annotation/apollo-mst": "workspace:^"
-    "@apollo-annotation/apollo-schemas": "workspace:^"
-    "@gmod/gff": "npm:1.2.0"
-    "@gmod/indexedfasta": "npm:^2.0.4"
-    "@jbrowse/core": "npm:^2.7.0"
-    "@nestjs/common": "npm:^10.1.0"
-    "@nestjs/core": "npm:^10.1.0"
-    "@types/node": "npm:^18.14.2"
-    "@types/rimraf": "npm:^3"
-    bson-objectid: "npm:^2.0.4"
-    generic-filehandle: "npm:^3.0.0"
-    jwt-decode: "npm:^3.1.2"
-    mobx: "npm:^6.6.1"
-    mobx-state-tree: "npm:^5.1.7"
-    mongoose: "npm:^6.12.0"
-    regenerator-runtime: "npm:^0.13.9"
-    rimraf: "npm:^3.0.2"
-    socket.io-client: "npm:^4.5.4"
-    tslib: "npm:^2.3.1"
-    typescript: "npm:^5.1.6"
-  peerDependencies:
-    "@mui/material": ^5.11.14
-    "@mui/x-data-grid": ^7.0.0
-    mobx: ^6.6.1
-    mobx-react: ^7.2.1
-    mobx-state-tree: ^5.1.7
-    prop-types: ^15.8.1
-    react: ^18.2.0
-    react-dom: ^18.2.0
-    rxjs: ^7.4.0
-  languageName: unknown
-  linkType: soft
-
 "@apollo-annotation/jbrowse-plugin-apollo@workspace:packages/jbrowse-plugin-apollo":
   version: 0.0.0-use.local
   resolution: "@apollo-annotation/jbrowse-plugin-apollo@workspace:packages/jbrowse-plugin-apollo"
   dependencies:
-    "@apollo-annotation/apollo-common": "workspace:^"
-    "@apollo-annotation/apollo-mst": "workspace:^"
-    "@apollo-annotation/apollo-shared": "workspace:^"
+    "@apollo-annotation/common": "workspace:^"
+    "@apollo-annotation/mst": "workspace:^"
+    "@apollo-annotation/shared": "workspace:^"
     "@emotion/react": "npm:^11.10.6"
     "@emotion/styled": "npm:^11.10.6"
     "@gmod/gff": "npm:1.2.0"
@@ -320,6 +336,75 @@ __metadata:
     react-dom: ^18.2.0
     rxjs: ^7.4.0
     tss-react: ^4.6.1
+  languageName: unknown
+  linkType: soft
+
+"@apollo-annotation/mst@workspace:^, @apollo-annotation/mst@workspace:packages/apollo-mst":
+  version: 0.0.0-use.local
+  resolution: "@apollo-annotation/mst@workspace:packages/apollo-mst"
+  dependencies:
+    "@jbrowse/core": "npm:^2.7.0"
+    mobx: "npm:^6.6.1"
+    mobx-state-tree: "npm:^5.1.7"
+    rxjs: "npm:^7.4.0"
+    tslib: "npm:^2.3.1"
+    typescript: "npm:^5.1.6"
+  languageName: unknown
+  linkType: soft
+
+"@apollo-annotation/schemas@workspace:^, @apollo-annotation/schemas@workspace:packages/apollo-schemas":
+  version: 0.0.0-use.local
+  resolution: "@apollo-annotation/schemas@workspace:packages/apollo-schemas"
+  dependencies:
+    "@apollo-annotation/mst": "workspace:^"
+    "@nestjs/common": "npm:^10.1.0"
+    "@nestjs/core": "npm:^10.1.0"
+    "@nestjs/mongoose": "npm:^10.0.0"
+    "@types/node": "npm:^18.14.2"
+    mongoose: "npm:^6.12.0"
+    reflect-metadata: "npm:^0.1.13"
+    regenerator-runtime: "npm:^0.13.9"
+    rxjs: "npm:^7.4.0"
+    tslib: "npm:^2.3.1"
+    typescript: "npm:^5.1.6"
+  languageName: unknown
+  linkType: soft
+
+"@apollo-annotation/shared@workspace:^, @apollo-annotation/shared@workspace:packages/apollo-shared":
+  version: 0.0.0-use.local
+  resolution: "@apollo-annotation/shared@workspace:packages/apollo-shared"
+  dependencies:
+    "@apollo-annotation/common": "workspace:^"
+    "@apollo-annotation/mst": "workspace:^"
+    "@apollo-annotation/schemas": "workspace:^"
+    "@gmod/gff": "npm:1.2.0"
+    "@gmod/indexedfasta": "npm:^2.0.4"
+    "@jbrowse/core": "npm:^2.7.0"
+    "@nestjs/common": "npm:^10.1.0"
+    "@nestjs/core": "npm:^10.1.0"
+    "@types/node": "npm:^18.14.2"
+    "@types/rimraf": "npm:^3"
+    bson-objectid: "npm:^2.0.4"
+    generic-filehandle: "npm:^3.0.0"
+    jwt-decode: "npm:^3.1.2"
+    mobx: "npm:^6.6.1"
+    mobx-state-tree: "npm:^5.1.7"
+    mongoose: "npm:^6.12.0"
+    regenerator-runtime: "npm:^0.13.9"
+    rimraf: "npm:^3.0.2"
+    socket.io-client: "npm:^4.5.4"
+    tslib: "npm:^2.3.1"
+    typescript: "npm:^5.1.6"
+  peerDependencies:
+    "@mui/material": ^5.11.14
+    "@mui/x-data-grid": ^7.0.0
+    mobx: ^6.6.1
+    mobx-react: ^7.2.1
+    mobx-state-tree: ^5.1.7
+    prop-types: ^15.8.1
+    react: ^18.2.0
+    react-dom: ^18.2.0
+    rxjs: ^7.4.0
   languageName: unknown
   linkType: soft
 
@@ -8350,91 +8435,6 @@ __metadata:
   checksum: 10c0/57b06ae984bc32a0d22592c87384cd88fe4511b1dd7581497831c56d41939c8a001b28e7b853e1450f2bf61992dfcaa8ae2d0d161a0a90c4fb631ef07098fbac
   languageName: node
   linkType: hard
-
-"apollo-collaboration-server@workspace:packages/apollo-collaboration-server":
-  version: 0.0.0-use.local
-  resolution: "apollo-collaboration-server@workspace:packages/apollo-collaboration-server"
-  dependencies:
-    "@apollo-annotation/apollo-common": "workspace:^"
-    "@apollo-annotation/apollo-mst": "workspace:^"
-    "@apollo-annotation/apollo-schemas": "workspace:^"
-    "@apollo-annotation/apollo-shared": "workspace:^"
-    "@emotion/react": "npm:^11.10.6"
-    "@emotion/styled": "npm:^11.10.6"
-    "@gmod/gff": "npm:1.2.0"
-    "@gmod/indexedfasta": "npm:^2.0.4"
-    "@jbrowse/core": "npm:^2.7.0"
-    "@mui/base": "npm:^5.0.0-alpha.118"
-    "@mui/material": "npm:^5.11.14"
-    "@nestjs/cli": "npm:^10.1.10"
-    "@nestjs/common": "npm:^10.1.0"
-    "@nestjs/config": "npm:^3.0.0"
-    "@nestjs/core": "npm:^10.1.0"
-    "@nestjs/jwt": "npm:^10.1.0"
-    "@nestjs/mapped-types": "npm:^2.0.2"
-    "@nestjs/mongoose": "npm:^10.0.0"
-    "@nestjs/passport": "npm:^10.0.0"
-    "@nestjs/platform-express": "npm:^10.1.0"
-    "@nestjs/platform-socket.io": "npm:^10.1.0"
-    "@nestjs/schematics": "npm:^10.0.1"
-    "@nestjs/serve-static": "npm:^4.0.0"
-    "@nestjs/terminus": "npm:^10.0.1"
-    "@nestjs/testing": "npm:^10.1.0"
-    "@nestjs/websockets": "npm:^10.1.0"
-    "@types/express": "npm:^4.17.13"
-    "@types/express-session": "npm:^1"
-    "@types/jest": "npm:^27.0.1"
-    "@types/multer": "npm:^1.4.7"
-    "@types/node": "npm:^18.14.2"
-    "@types/node-fetch": "npm:^2.6.2"
-    "@types/passport-google-oauth20": "npm:^2.0.11"
-    "@types/passport-jwt": "npm:^3.0.6"
-    "@types/passport-local": "npm:^1.0.34"
-    "@types/passport-microsoft": "npm:^0.0.0"
-    "@types/react": "npm:^17.0.34"
-    "@types/supertest": "npm:^2.0.11"
-    connect-mongodb-session: "npm:^3.1.1"
-    express: "npm:^4.18.0"
-    express-session: "npm:^1.17.3"
-    generic-filehandle: "npm:^3.0.0"
-    jest: "npm:^29.6.2"
-    joi: "npm:^17.7.0"
-    material-ui-popup-state: "npm:^5.0.4"
-    mobx: "npm:^6.6.1"
-    mobx-react: "npm:^7.2.1"
-    mobx-state-tree: "npm:^5.1.7"
-    mongodb: "npm:^4.7.0"
-    mongoose: "npm:^6.12.0"
-    mongoose-id-validator: "npm:^0.6.0"
-    multer: "npm:^1.4.5-lts.1"
-    node-fetch: "npm:^2.6.7"
-    passport: "npm:^0.5.0"
-    passport-google-oauth20: "npm:^2.0.0"
-    passport-jwt: "npm:^4.0.0"
-    passport-local: "npm:^1.0.0"
-    passport-microsoft: "npm:^1.0.0"
-    prettier: "npm:^3.2.5"
-    prop-types: "npm:^15.8.1"
-    react: "npm:^18.2.0"
-    react-dom: "npm:^18.2.0"
-    reflect-metadata: "npm:^0.1.13"
-    rimraf: "npm:^3.0.2"
-    rxjs: "npm:^7.4.0"
-    sanitize-filename: "npm:^1.6.3"
-    socket.io: "npm:^4.5.3"
-    source-map-support: "npm:^0.5.20"
-    stream-concat: "npm:^1.0.0"
-    supertest: "npm:^6.1.3"
-    ts-jest: "npm:^29.1.1"
-    ts-loader: "npm:^9.2.3"
-    ts-node: "npm:^10.3.0"
-    ts-node-dev: "npm:^1.1.8"
-    tsconfig-paths: "npm:^3.11.0"
-    tslib: "npm:^2.3.1"
-    tss-react: "npm:^4.6.1"
-    typescript: "npm:^5.1.6"
-  languageName: unknown
-  linkType: soft
 
 "apollo3@workspace:.":
   version: 0.0.0-use.local


### PR DESCRIPTION
Renames the packages so they can be published under our namespace on NPM. Split out from #393 to keep the PRs smaller.

Packages are now named e.g. `@apollo-annotation/cli` instead of `apollo-cli`.