### PR TITLE
Allow numbers in template expressions when linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -66,6 +66,10 @@ module.exports = {
       'warn',
       { argsIgnorePattern: '^_', ignoreRestSiblings: true },
     ],
+    '@typescript-eslint/restrict-template-expressions': [
+      'warn',
+      { allowNumber: true },
+    ],
     '@typescript-eslint/return-await': 'error',
     // eslint-plugin-import rules (override recommended)
     'import/no-extraneous-dependencies': 'error',

--- a/packages/apollo-cli/src/commands/assembly/delete.ts
+++ b/packages/apollo-cli/src/commands/assembly/delete.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 import { Flags } from '@oclif/core'
 
 import { BaseCommand } from '../../baseCommand.js'

--- a/packages/apollo-cli/src/commands/feature/edit-attribute.ts
+++ b/packages/apollo-cli/src/commands/feature/edit-attribute.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */

--- a/packages/apollo-cli/src/commands/feature/edit-coords.ts
+++ b/packages/apollo-cli/src/commands/feature/edit-coords.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */

--- a/packages/apollo-cli/src/commands/feature/edit-type.ts
+++ b/packages/apollo-cli/src/commands/feature/edit-type.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */

--- a/packages/apollo-cli/src/commands/login.ts
+++ b/packages/apollo-cli/src/commands/login.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/require-await */
 /* eslint-disable @typescript-eslint/no-misused-promises */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */

--- a/packages/apollo-cli/src/test/fixtures.ts
+++ b/packages/apollo-cli/src/test/fixtures.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'

--- a/packages/apollo-cli/src/utils.ts
+++ b/packages/apollo-cli/src/utils.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */

--- a/packages/apollo-collaboration-server/src/changes/changes.service.ts
+++ b/packages/apollo-collaboration-server/src/changes/changes.service.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import {
   Change as BaseChange,

--- a/packages/apollo-collaboration-server/src/checks/checks.controller.ts
+++ b/packages/apollo-collaboration-server/src/checks/checks.controller.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 import { Controller, Get, Logger, Param, Query } from '@nestjs/common'
 
 import { FeatureRangeSearchDto } from '../entity/gff3Object.dto'

--- a/packages/apollo-collaboration-server/src/export/export.service.ts
+++ b/packages/apollo-collaboration-server/src/export/export.service.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-confusing-void-expression */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */

--- a/packages/apollo-collaboration-server/src/features/features.controller.ts
+++ b/packages/apollo-collaboration-server/src/features/features.controller.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 import { Controller, Get, Logger, Param, Query } from '@nestjs/common'
 
 import { FeatureRangeSearchDto } from '../entity/gff3Object.dto'

--- a/packages/apollo-collaboration-server/src/features/features.service.ts
+++ b/packages/apollo-collaboration-server/src/features/features.service.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 import {

--- a/packages/apollo-collaboration-server/src/main.ts
+++ b/packages/apollo-collaboration-server/src/main.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-return */

--- a/packages/apollo-collaboration-server/test/app/app.e2e-spec.ts
+++ b/packages/apollo-collaboration-server/test/app/app.e2e-spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */

--- a/packages/apollo-mst/src/AnnotationFeature.ts
+++ b/packages/apollo-mst/src/AnnotationFeature.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */

--- a/packages/apollo-shared/src/Changes/AddFeaturesFromFileChange.ts
+++ b/packages/apollo-shared/src/Changes/AddFeaturesFromFileChange.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/require-await */
 import {
   AssemblySpecificChange,

--- a/packages/apollo-shared/src/Common/jwtPayload.ts
+++ b/packages/apollo-shared/src/Common/jwtPayload.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 import jwtDecode from 'jwt-decode'
 
 export interface JWTPayload {

--- a/packages/jbrowse-plugin-apollo/cypress/support/commands.ts
+++ b/packages/jbrowse-plugin-apollo/cypress/support/commands.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 Cypress.Commands.add('loginAsGuest', () => {
   cy.visit('/?config=http://localhost:9000/jbrowse_config.json')
   cy.contains('Continue as Guest', { timeout: 10_000 }).click()

--- a/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */

--- a/packages/jbrowse-plugin-apollo/src/ApolloSequenceAdapter/ApolloSequenceAdapter.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloSequenceAdapter/ApolloSequenceAdapter.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/prefer-promise-reject-errors */
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */

--- a/packages/jbrowse-plugin-apollo/src/ApolloSixFrameRenderer/components/ApolloRendering.tsx
+++ b/packages/jbrowse-plugin-apollo/src/ApolloSixFrameRenderer/components/ApolloRendering.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */

--- a/packages/jbrowse-plugin-apollo/src/ApolloTextSearchAdapter/ApolloTextSearchAdapter.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloTextSearchAdapter/ApolloTextSearchAdapter.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */

--- a/packages/jbrowse-plugin-apollo/src/BackendDrivers/CollaborationServerDriver.ts
+++ b/packages/jbrowse-plugin-apollo/src/BackendDrivers/CollaborationServerDriver.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-base-to-string */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-return */

--- a/packages/jbrowse-plugin-apollo/src/BackendDrivers/DesktopFileDriver.ts
+++ b/packages/jbrowse-plugin-apollo/src/BackendDrivers/DesktopFileDriver.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/require-await */
 import {
   AssemblySpecificChange,

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/BasicInformation.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/BasicInformation.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/use-unknown-in-catch-callback-variable */
 /* eslint-disable @typescript-eslint/no-misused-promises */
 import { AnnotationFeatureI } from '@apollo-annotation/mst'

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/RelatedFeature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/RelatedFeature.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/Sequence.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/Sequence.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import { AnnotationFeatureI } from '@apollo-annotation/mst'
 import { splitStringIntoChunks } from '@apollo-annotation/shared'

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/rendering.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/rendering.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import { AnyConfigurationSchemaType } from '@jbrowse/core/configuration/configurationSchema'
 import PluginManager from '@jbrowse/core/PluginManager'

--- a/packages/jbrowse-plugin-apollo/src/OntologyManager/OntologyStore/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/OntologyManager/OntologyStore/index.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/only-throw-error */
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
- 
+
 /* eslint-disable unicorn/no-await-expression-member */
 import {
   BlobLocation,

--- a/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/Feature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/Feature.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/use-unknown-in-catch-callback-variable */
 /* eslint-disable unicorn/no-nested-ternary */
 /* eslint-disable @typescript-eslint/unbound-method */

--- a/packages/jbrowse-plugin-apollo/src/components/AddChildFeature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/AddChildFeature.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-misused-promises */
 import { AnnotationFeatureI } from '@apollo-annotation/mst'
 import { AddFeatureChange } from '@apollo-annotation/shared'

--- a/packages/jbrowse-plugin-apollo/src/components/CopyFeature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/CopyFeature.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/use-unknown-in-catch-callback-variable */
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-misused-promises */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */

--- a/packages/jbrowse-plugin-apollo/src/components/DownloadGFF3.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/DownloadGFF3.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */

--- a/packages/jbrowse-plugin-apollo/src/components/ImportFeatures.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/ImportFeatures.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/use-unknown-in-catch-callback-variable */
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */

--- a/packages/jbrowse-plugin-apollo/src/components/ManageUsers.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/ManageUsers.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/use-unknown-in-catch-callback-variable */
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-misused-promises */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */

--- a/packages/jbrowse-plugin-apollo/src/extensions/annotationFromPileup.ts
+++ b/packages/jbrowse-plugin-apollo/src/extensions/annotationFromPileup.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */

--- a/packages/jbrowse-plugin-apollo/src/session/ClientDataStore.ts
+++ b/packages/jbrowse-plugin-apollo/src/session/ClientDataStore.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-call */

--- a/packages/jbrowse-plugin-apollo/src/session/session.ts
+++ b/packages/jbrowse-plugin-apollo/src/session/session.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */

--- a/packages/jbrowse-plugin-apollo/src/util/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/util/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 import { getParent } from 'mobx-state-tree'
 
 import { ApolloInternetAccountModel } from '../ApolloInternetAccount/model'


### PR DESCRIPTION
During the most recent `@typescript-eslint` upgrade, a strict version of the `@typescript-eslint/restrict-template-expressions` rule was enabled, which only allowed strings in template expression variables. Reasoning for this rule is [here](https://typescript-eslint.io/rules/restrict-template-expressions/), but basically it aims to keep things like an object being stringified into `'[object Object]'` from happening.

We use numbers in our template expressions a lot, though, and since they're more safe to stringify, I think the benefits of allowing numbers outweighs any potential problems, so this PR allows numbers in template expressions.