### PR TITLE
Add CLI command to get and put JBrowse config files in collaboration server

### DIFF
--- a/packages/apollo-cli/README.md
+++ b/packages/apollo-cli/README.md
@@ -17,7 +17,7 @@ $ npm install -g @apollo-annotation/cli
 $ apollo COMMAND
 running command...
 $ apollo (--version)
-@apollo-annotation/cli/0.1.19 linux-x64 node-v18.20.3
+@apollo-annotation/cli/0.1.19 darwin-x64 node-v20.10.0
 $ apollo --help [COMMAND]
 USAGE
   $ apollo COMMAND
@@ -41,6 +41,8 @@ USAGE
 - [`apollo feature`](../website/docs/cli//feature.md) - Commands to handle
   features
 - [`apollo help`](../website/docs/cli//help.md) - Display help for apollo.
+- [`apollo jbrowse`](../website/docs/cli//jbrowse.md) - Get Jbrowse
+  configuration from Apollo
 - [`apollo login`](../website/docs/cli//login.md) - Login to Apollo
 - [`apollo logout`](../website/docs/cli//logout.md) - Logout of Apollo
 - [`apollo refseq`](../website/docs/cli//refseq.md) - Commands to handle

--- a/packages/apollo-cli/README.md
+++ b/packages/apollo-cli/README.md
@@ -17,7 +17,7 @@ $ npm install -g @apollo-annotation/cli
 $ apollo COMMAND
 running command...
 $ apollo (--version)
-@apollo-annotation/cli/0.1.19 darwin-x64 node-v20.10.0
+@apollo-annotation/cli/0.1.19 linux-x64 node-v20.17.0
 $ apollo --help [COMMAND]
 USAGE
   $ apollo COMMAND
@@ -41,8 +41,8 @@ USAGE
 - [`apollo feature`](../website/docs/cli//feature.md) - Commands to handle
   features
 - [`apollo help`](../website/docs/cli//help.md) - Display help for apollo.
-- [`apollo jbrowse`](../website/docs/cli//jbrowse.md) - Get Jbrowse
-  configuration from Apollo
+- [`apollo jbrowse`](../website/docs/cli//jbrowse.md) - Commands to manage the
+  JBrowse configuration
 - [`apollo login`](../website/docs/cli//login.md) - Login to Apollo
 - [`apollo logout`](../website/docs/cli//logout.md) - Logout of Apollo
 - [`apollo refseq`](../website/docs/cli//refseq.md) - Commands to handle

--- a/packages/apollo-cli/package.json
+++ b/packages/apollo-cli/package.json
@@ -53,6 +53,9 @@
       "feature": {
         "description": "Commands to handle features"
       },
+      "jbrowse": {
+        "description": "Commands to manage the JBrowse configuration"
+      },
       "refseq": {
         "description": "Commands to handle reference sequences"
       },

--- a/packages/apollo-cli/src/commands/jbrowse/get-config.ts
+++ b/packages/apollo-cli/src/commands/jbrowse/get-config.ts
@@ -2,10 +2,17 @@ import { BaseCommand } from '../../baseCommand.js'
 import { wrapLines, queryApollo } from '../../utils.js'
 
 export default class GetConfig extends BaseCommand<typeof GetConfig> {
-  static summary = 'Get Jbrowse configuration from Apollo'
+  static summary = 'Get JBrowse configuration from Apollo'
   static description = wrapLines(
-    'Print to stdout the Jbrowse configuration from Apollo in json format',
+    'Print to stdout the JBrowse configuration from Apollo in JSON format',
   )
+
+  static examples = [
+    {
+      description: 'Get JBrowse configuration:',
+      command: '<%= config.bin %> <%= command.id %> > config.json',
+    },
+  ]
 
   public async run(): Promise<void> {
     const { flags } = await this.parse(GetConfig)
@@ -20,7 +27,7 @@ export default class GetConfig extends BaseCommand<typeof GetConfig> {
     )
 
     if (!response.ok) {
-      throw new Error('Failed to fetch jbrowse configuration')
+      throw new Error('Failed to fetch JBrowse configuration')
     }
 
     const json = (await response.json()) as object

--- a/packages/apollo-cli/src/commands/jbrowse/get-config.ts
+++ b/packages/apollo-cli/src/commands/jbrowse/get-config.ts
@@ -1,0 +1,29 @@
+import { BaseCommand } from '../../baseCommand.js'
+import { wrapLines, queryApollo } from '../../utils.js'
+
+export default class GetConfig extends BaseCommand<typeof GetConfig> {
+  static summary = 'Get Jbrowse configuration from Apollo'
+  static description = wrapLines(
+    'Print to stdout the Jbrowse configuration from Apollo in json format',
+  )
+
+  public async run(): Promise<void> {
+    const { flags } = await this.parse(GetConfig)
+
+    const access: { address: string; accessToken: string } =
+      await this.getAccess(flags['config-file'], flags.profile)
+
+    const response = await queryApollo(
+      access.address,
+      access.accessToken,
+      'jbrowse/config.json',
+    )
+
+    if (!response.ok) {
+      throw new Error('Failed to fetch jbrowse configuration')
+    }
+
+    const json = (await response.json()) as object
+    this.log(JSON.stringify(json, null, 2))
+  }
+}

--- a/packages/apollo-cli/src/commands/jbrowse/set-config.ts
+++ b/packages/apollo-cli/src/commands/jbrowse/set-config.ts
@@ -14,21 +14,21 @@ import {
 } from '../../utils.js'
 
 export default class SetConfig extends BaseCommand<typeof SetConfig> {
-  static summary = 'Add jbrowse configuration'
+  static summary = 'Set JBrowse configuration'
   static description = wrapLines(
-    'Add jbrowse configuration into apollo database',
+    'Set JBrowse configuration in Apollo collaboration server',
   )
 
   static examples = [
     {
-      description: 'Add jbrowse configuration:',
+      description: 'Add JBrowse configuration:',
       command: '<%= config.bin %> <%= command.id %> config.json',
     },
   ]
 
   static args = {
     inputFile: Args.string({
-      description: 'Input jbrowse configuration file',
+      description: 'JBrowse configuration file',
       required: true,
     }),
   }
@@ -65,10 +65,9 @@ export default class SetConfig extends BaseCommand<typeof SetConfig> {
     if (!response.ok) {
       const errorMessage = await createFetchErrorMessage(
         response,
-        'Failed to add jbrowse configuration',
+        'Failed to add JBrowse configuration',
       )
       throw new ConfigError(errorMessage)
     }
-    this.log('Jbrowse configuartion added successfully to apollo')
   }
 }

--- a/packages/apollo-cli/src/commands/jbrowse/set-config.ts
+++ b/packages/apollo-cli/src/commands/jbrowse/set-config.ts
@@ -1,0 +1,75 @@
+import * as fs from 'node:fs'
+import {
+  ImportJBrowseConfigChange,
+  JBrowseConfig,
+} from '@apollo-annotation/shared'
+import { Flags } from '@oclif/core'
+import { Agent, RequestInit, fetch } from 'undici'
+import { ConfigError } from '../../ApolloConf.js'
+import { BaseCommand } from '../../baseCommand.js'
+import {
+  wrapLines,
+  localhostToAddress,
+  createFetchErrorMessage,
+} from '../../utils.js'
+
+export default class SetConfig extends BaseCommand<typeof SetConfig> {
+  static summary = 'Add jbrowse configuration'
+  static description = wrapLines(
+    'Add jbrowse configuration into apollo database',
+  )
+
+  static examples = [
+    {
+      description: 'Add jbrowse configuration:',
+      command: '<%= config.bin %> <%= command.id %> -i config.json',
+    },
+  ]
+
+  static flags = {
+    'input-file': Flags.string({
+      char: 'i',
+      description: 'Input jbrowse configuration file',
+      required: true,
+    }),
+  }
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(SetConfig)
+
+    if (!fs.existsSync(flags['input-file'])) {
+      this.error(`File ${flags['input-file']} does not exist`)
+    }
+
+    const access: { address: string; accessToken: string } =
+      await this.getAccess(flags['config-file'], flags.profile)
+    const filehandle = await fs.promises.open(flags['input-file'])
+    const fileContent = await filehandle.readFile({ encoding: 'utf8' })
+    await filehandle.close()
+
+    const change = new ImportJBrowseConfigChange({
+      typeName: 'ImportJBrowseConfigChange',
+      newJBrowseConfig: JSON.parse(fileContent) as JBrowseConfig,
+    })
+
+    const auth: RequestInit = {
+      method: 'POST',
+      body: JSON.stringify(change),
+      headers: {
+        Authorization: `Bearer ${access.accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      dispatcher: new Agent({ headersTimeout: 60 * 60 * 1000 }),
+    }
+    const url = new URL(localhostToAddress(`${access.address}/changes`))
+    const response = await fetch(url, auth)
+    if (!response.ok) {
+      const errorMessage = await createFetchErrorMessage(
+        response,
+        'Failed to add jbrowse configuration',
+      )
+      throw new ConfigError(errorMessage)
+    }
+    this.log('Jbrowse configuartion added successfully to apollo')
+  }
+}

--- a/packages/apollo-cli/src/commands/jbrowse/set-config.ts
+++ b/packages/apollo-cli/src/commands/jbrowse/set-config.ts
@@ -1,9 +1,9 @@
 import * as fs from 'node:fs'
 import {
-  ImportJBrowseConfigChange,
-  JBrowseConfig,
+  type JBrowseConfig,
+  type SerializedImportJBrowseConfigChange,
 } from '@apollo-annotation/shared'
-import { Flags } from '@oclif/core'
+import { Args } from '@oclif/core'
 import { Agent, RequestInit, fetch } from 'undici'
 import { ConfigError } from '../../ApolloConf.js'
 import { BaseCommand } from '../../baseCommand.js'
@@ -22,35 +22,34 @@ export default class SetConfig extends BaseCommand<typeof SetConfig> {
   static examples = [
     {
       description: 'Add jbrowse configuration:',
-      command: '<%= config.bin %> <%= command.id %> -i config.json',
+      command: '<%= config.bin %> <%= command.id %> config.json',
     },
   ]
 
-  static flags = {
-    'input-file': Flags.string({
-      char: 'i',
+  static args = {
+    inputFile: Args.string({
       description: 'Input jbrowse configuration file',
       required: true,
     }),
   }
 
   async run(): Promise<void> {
-    const { flags } = await this.parse(SetConfig)
+    const { args, flags } = await this.parse(SetConfig)
 
-    if (!fs.existsSync(flags['input-file'])) {
-      this.error(`File ${flags['input-file']} does not exist`)
+    if (!fs.existsSync(args.inputFile)) {
+      this.error(`File ${args.inputFile} does not exist`)
     }
 
     const access: { address: string; accessToken: string } =
       await this.getAccess(flags['config-file'], flags.profile)
-    const filehandle = await fs.promises.open(flags['input-file'])
+    const filehandle = await fs.promises.open(args.inputFile)
     const fileContent = await filehandle.readFile({ encoding: 'utf8' })
     await filehandle.close()
 
-    const change = new ImportJBrowseConfigChange({
+    const change: SerializedImportJBrowseConfigChange = {
       typeName: 'ImportJBrowseConfigChange',
       newJBrowseConfig: JSON.parse(fileContent) as JBrowseConfig,
-    })
+    }
 
     const auth: RequestInit = {
       method: 'POST',

--- a/packages/website/docs/cli/jbrowse.md
+++ b/packages/website/docs/cli/jbrowse.md
@@ -1,0 +1,54 @@
+# `apollo jbrowse`
+
+Get Jbrowse configuration from Apollo
+
+- [`apollo jbrowse get-config`](#apollo-jbrowse-get-config)
+- [`apollo jbrowse set-config`](#apollo-jbrowse-set-config)
+
+## `apollo jbrowse get-config`
+
+Get Jbrowse configuration from Apollo
+
+```
+USAGE
+  $ apollo jbrowse get-config [--profile <value>] [--config-file <value>]
+
+FLAGS
+  --config-file=<value>  Use this config file (mostly for testing)
+  --profile=<value>      Use credentials from this profile
+
+DESCRIPTION
+  Get Jbrowse configuration from Apollo
+
+  Print to stdout the Jbrowse configuration from Apollo in json format
+```
+
+_See code:
+[src/commands/jbrowse/get-config.ts](https://github.com/GMOD/Apollo3/blob/v0.1.19/packages/apollo-cli/src/commands/jbrowse/get-config.ts)_
+
+## `apollo jbrowse set-config`
+
+Add jbrowse configuration
+
+```
+USAGE
+  $ apollo jbrowse set-config -i <value> [--profile <value>] [--config-file <value>]
+
+FLAGS
+  -i, --input-file=<value>   (required) Input jbrowse configuration file
+      --config-file=<value>  Use this config file (mostly for testing)
+      --profile=<value>      Use credentials from this profile
+
+DESCRIPTION
+  Add jbrowse configuration
+
+  Add jbrowse configuration into apollo database
+
+EXAMPLES
+  Add jbrowse configuration:
+
+    $ apollo jbrowse set-config -i config.json
+```
+
+_See code:
+[src/commands/jbrowse/set-config.ts](https://github.com/GMOD/Apollo3/blob/v0.1.19/packages/apollo-cli/src/commands/jbrowse/set-config.ts)_

--- a/packages/website/docs/cli/jbrowse.md
+++ b/packages/website/docs/cli/jbrowse.md
@@ -1,13 +1,13 @@
 # `apollo jbrowse`
 
-Get Jbrowse configuration from Apollo
+Commands to manage the JBrowse configuration
 
 - [`apollo jbrowse get-config`](#apollo-jbrowse-get-config)
 - [`apollo jbrowse set-config INPUTFILE`](#apollo-jbrowse-set-config-inputfile)
 
 ## `apollo jbrowse get-config`
 
-Get Jbrowse configuration from Apollo
+Get JBrowse configuration from Apollo
 
 ```
 USAGE
@@ -18,9 +18,14 @@ FLAGS
   --profile=<value>      Use credentials from this profile
 
 DESCRIPTION
-  Get Jbrowse configuration from Apollo
+  Get JBrowse configuration from Apollo
 
-  Print to stdout the Jbrowse configuration from Apollo in json format
+  Print to stdout the JBrowse configuration from Apollo in JSON format
+
+EXAMPLES
+  Get JBrowse configuration:
+
+    $ apollo jbrowse get-config > config.json
 ```
 
 _See code:
@@ -28,26 +33,26 @@ _See code:
 
 ## `apollo jbrowse set-config INPUTFILE`
 
-Add jbrowse configuration
+Set JBrowse configuration
 
 ```
 USAGE
   $ apollo jbrowse set-config INPUTFILE [--profile <value>] [--config-file <value>]
 
 ARGUMENTS
-  INPUTFILE  Input jbrowse configuration file
+  INPUTFILE  JBrowse configuration file
 
 FLAGS
   --config-file=<value>  Use this config file (mostly for testing)
   --profile=<value>      Use credentials from this profile
 
 DESCRIPTION
-  Add jbrowse configuration
+  Set JBrowse configuration
 
-  Add jbrowse configuration into apollo database
+  Set JBrowse configuration in Apollo collaboration server
 
 EXAMPLES
-  Add jbrowse configuration:
+  Add JBrowse configuration:
 
     $ apollo jbrowse set-config config.json
 ```

--- a/packages/website/docs/cli/jbrowse.md
+++ b/packages/website/docs/cli/jbrowse.md
@@ -3,7 +3,7 @@
 Get Jbrowse configuration from Apollo
 
 - [`apollo jbrowse get-config`](#apollo-jbrowse-get-config)
-- [`apollo jbrowse set-config`](#apollo-jbrowse-set-config)
+- [`apollo jbrowse set-config INPUTFILE`](#apollo-jbrowse-set-config-inputfile)
 
 ## `apollo jbrowse get-config`
 
@@ -26,18 +26,20 @@ DESCRIPTION
 _See code:
 [src/commands/jbrowse/get-config.ts](https://github.com/GMOD/Apollo3/blob/v0.1.19/packages/apollo-cli/src/commands/jbrowse/get-config.ts)_
 
-## `apollo jbrowse set-config`
+## `apollo jbrowse set-config INPUTFILE`
 
 Add jbrowse configuration
 
 ```
 USAGE
-  $ apollo jbrowse set-config -i <value> [--profile <value>] [--config-file <value>]
+  $ apollo jbrowse set-config INPUTFILE [--profile <value>] [--config-file <value>]
+
+ARGUMENTS
+  INPUTFILE  Input jbrowse configuration file
 
 FLAGS
-  -i, --input-file=<value>   (required) Input jbrowse configuration file
-      --config-file=<value>  Use this config file (mostly for testing)
-      --profile=<value>      Use credentials from this profile
+  --config-file=<value>  Use this config file (mostly for testing)
+  --profile=<value>      Use credentials from this profile
 
 DESCRIPTION
   Add jbrowse configuration
@@ -47,7 +49,7 @@ DESCRIPTION
 EXAMPLES
   Add jbrowse configuration:
 
-    $ apollo jbrowse set-config -i config.json
+    $ apollo jbrowse set-config config.json
 ```
 
 _See code:


### PR DESCRIPTION
Fixes https://github.com/GMOD/Apollo3/issues/433, fixed #214 

Example:
```
apollo-cli % yarn dev jbrowse get-config --profile apollo > config.json

apollo-cli % jbrowse add-track https://ftp.ebi.ac.uk/pub/databases/havana/ngs_havana/CLS/updated_master_table/human/pacBioSII-Cshl-CapTrap_HpreCap_0+_Brain03Rep1.bam --indexFile https://ftp.ebi.ac.uk/pub/databases/havana/ngs_havana/CLS/updated_master_table/human/pacBioSII-Cshl-CapTrap_HpreCap_0+_Brain03Rep1.bam.bai --assemblyNames=66bb60e83db15a4a2aff224d
Added track with name "pacBioSII-Cshl-CapTrap_HpreCap_0+_Brain03Rep1" and trackId "pacBioSII-Cshl-CapTrap_HpreCap_0+_Brain03Rep1" to ./config.json

apollo-cli % yarn dev jbrowse set-config --profile apollo config.json
Jbrowse configuartion added successfully to apollo
```