### PR TITLE
Save/Remove multiple tracks at once from track widget

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/session/session.ts
+++ b/packages/jbrowse-plugin-apollo/src/session/session.ts
@@ -273,7 +273,7 @@ export function extendSession(
           if (!response.ok) {
             const errorMessage = yield createFetchErrorMessage(
               response,
-              'Failed to fetch assemblies',
+              'Failed to fetch jbrowse config',
             )
             console.error(errorMessage)
             continue
@@ -335,6 +335,7 @@ export function extendSession(
                       ...trackConfigSnapshot,
                       trackId: newTrackId,
                     }
+                    currentConfig.tracks?.push(trackConfigSnapshot)
                     for (const internetAccount of internetAccounts as ApolloInternetAccountModel[]) {
                       if (internetAccount.type !== 'ApolloInternetAccount') {
                         continue
@@ -377,6 +378,17 @@ export function extendSession(
                     const filteredTracks = filteredConfig?.tracks?.filter(
                       (t) => t.trackId !== trackId,
                     )
+                    if (currentConfig?.tracks) {
+                      for (const [
+                        index,
+                        track,
+                      ] of currentConfig.tracks.entries()) {
+                        if (track.trackId === trackId) {
+                          currentConfig.tracks.splice(index, 1)
+                          break
+                        }
+                      }
+                    }
                     for (const internetAccount of internetAccounts as ApolloInternetAccountModel[]) {
                       if (internetAccount.type !== 'ApolloInternetAccount') {
                         continue


### PR DESCRIPTION
There is a minor issue when we try to save multiple tracks into apollo in the same track widget window, newly added track replaces previous saved track so, only last track added will be saved to db. 

Fixes https://github.com/GMOD/Apollo3/issues/435