### PR TITLE
Fix converted GFF3 properties

### DIFF
--- a/.lintstagedrc.yml
+++ b/.lintstagedrc.yml
@@ -1,1 +1,1 @@
-'*': prettier --write --ignore-unknown
+'*': prettier --write --ignore-unknown --config .prettierrc.lint-staged.mjs

--- a/.prettierrc.lint-staged.mjs
+++ b/.prettierrc.lint-staged.mjs
@@ -1,3 +1,4 @@
+import packagejson from 'prettier-plugin-packagejson'
 /**
  * @see https://prettier.io/docs/en/configuration.html
  * @type {import("prettier").Config}
@@ -12,6 +13,7 @@ const config = {
       options: { parser: 'jsonc' },
     },
   ],
+  plugins: [packagejson],
 }
 
 export default config

--- a/packages/apollo-cli/test/test.py
+++ b/packages/apollo-cli/test/test.py
@@ -300,7 +300,7 @@ class TestCLI(unittest.TestCase):
         out = json.loads(p.stdout)[0]
         self.assertEqual(out["type"], "BAC")
 
-        p = shell(f"{apollo} assembly get -a vv1")
+        p = shell(f"{apollo} assembly get {P} -a vv1")
         asm_id = json.loads(p.stdout)[0]["_id"]
 
         req = [

--- a/packages/apollo-cli/test_data/tiny.fasta.gff3
+++ b/packages/apollo-cli/test_data/tiny.fasta.gff3
@@ -10,10 +10,12 @@ ctgA	example	mRNA	100	200	.	+	.	ID=EDEN.1;Parent=EDEN;Name=EDEN.1;Note=Eden spli
 ctgB	someExample	contig	1	50	.	.	.	Name=SomeContig
 ctgC	example	gene	100	200	.	+	.	ID=MyGene
 ctgC	example	mRNA	100	200	.	+	.	ID=MyGene.1;Parent=MyGene
-ctgC	example	CDS	100	170	.	+	.	ID=MyExon.1;Parent=MyGene.1
+ctgC	example	CDS	100	170	.	+	.	ID=myCDS.1;Parent=MyGene.1
+ctgC	example	exon	100	170	.	+	.	ID=MyExon.1;Parent=MyGene.1
 ctgC	example	gene	150	250	.	+	.	ID=AnotherGene
 ctgC	example	mRNA	150	250	.	+	.	ID=mRNA.1;Parent=AnotherGene
 ctgC	example	CDS	150	201	.	+	.	ID=CDS.1;Parent=mRNA.1
+ctgC	example	exon	150	201	.	+	.	ID=exon.1;Parent=mRNA.1
 ##FASTA
 >ctgA
 cattgttgcggagttgaacaACGGCATTAGGAACACTTCCGTCTCtcacttttatacgat
@@ -37,4 +39,3 @@ ctgcccataaatcaaagggttagtgcggccaaaacgttggacaacggtattagaagacca
 acctgaccaccaaaccgtcaattaaccggtatcttctcggaaacggcggttctctcctag
 atagcgatctgtggtctcaccatgcaatttaaacaggtgagtaaagattgctacaaatac
 gagactagctgtcaccagatgctgttcatctgttggctccttggtcgctccgttgtaccc
-

--- a/packages/apollo-collaboration-server/src/authentication/authentication.service.ts
+++ b/packages/apollo-collaboration-server/src/authentication/authentication.service.ts
@@ -177,10 +177,15 @@ export class AuthenticationService {
       if (isRootUser) {
         newUserRole = Role.Admin
       } else {
-        const userCount = await this.usersService.getCount()
-        const guestUser = await this.usersService.findGuest()
-        const hasAdmin = userCount > 1 || (userCount === 1 && !guestUser)
-        // If there is not a non-guest user yet, the 1st user role will be admin
+        const users = await this.usersService.findAll()
+        const hasAdmin = users.some(
+          (user) =>
+            user.role === Role.Admin &&
+            user.email !== 'root_user' &&
+            user.email !== 'guest_user',
+        )
+        // If there is not a non-guest and non-root user yet, the 1st user to
+        // log in will be made an admin
         newUserRole = hasAdmin ? this.defaultNewUserRole : Role.Admin
       }
       const newUser: CreateUserDto = {

--- a/packages/apollo-shared/src/GFF3/gff3ToAnnotationFeature.ts
+++ b/packages/apollo-shared/src/GFF3/gff3ToAnnotationFeature.ts
@@ -80,8 +80,9 @@ function getFeatureMinMax(gff3Feature: GFF3Feature): [number, number] {
 
 function convertFeatureAttributes(
   gff3Feature: GFF3Feature,
-): Record<string, string[]> | undefined {
-  const convertedAttributes: Record<string, string[]> = {}
+): Record<string, string[] | undefined> | undefined {
+  const convertedAttributes: Record<string, string[] | undefined> | undefined =
+    {}
   const scores = gff3Feature
     .map((f) => f.score)
     .filter((score) => score !== null)
@@ -106,22 +107,21 @@ function convertFeatureAttributes(
   if (sources.length > 0) {
     let [source] = sources
     if (sources.length > 1) {
-      const sourceSet = new Set(...sources)
+      const sourceSet = new Set(sources)
       source = [...sourceSet].join(',')
     }
     convertedAttributes.gff_source = [source]
   }
   if (attributesCollections.length > 0) {
-    const newAttributes: Record<string, string[] | undefined> = {}
     for (const attributesCollection of attributesCollections) {
       for (const [key, val] of Object.entries(attributesCollection)) {
         if (!val || key === 'Parent') {
           continue
         }
         const newKey = isGFFReservedAttribute(key) ? gffToInternal[key] : key
-        const existingVal = newAttributes[newKey]
+        const existingVal = convertedAttributes[newKey]
         if (existingVal) {
-          const valSet = new Set(...existingVal, ...val)
+          const valSet = new Set([...existingVal, ...val])
           convertedAttributes[newKey] = [...valSet]
         } else {
           convertedAttributes[newKey] = val


### PR DESCRIPTION
When combining multiple CDS into a single internal feature, we want to keep both IDs. This wasn't happening, so this PR fixes that.