### PR TITLE
Dockerfile for apollo collaboration server fails to build on Mac

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM node:18-alpine AS setup
+FROM node:20-alpine AS setup
 WORKDIR /app
 COPY package.json yarn.lock .yarnrc.yml ./
 COPY .yarn/ .yarn/
@@ -8,7 +8,7 @@ COPY packages/ packages/
 RUN find packages/ -type f \! \( -name "package.json" -o -name "yarn.lock" \) -delete && \
 find . -type d -empty -delete
 
-FROM node:18-alpine AS build
+FROM node:20-alpine AS build
 WORKDIR /app
 COPY --from=setup /app .
 RUN yarn install --immutable
@@ -16,7 +16,7 @@ COPY . .
 WORKDIR /app/packages/apollo-collaboration-server
 RUN yarn build
 
-FROM node:18-alpine
+FROM node:20-alpine
 LABEL org.opencontainers.image.source=https://github.com/GMOD/Apollo3
 LABEL org.opencontainers.image.description="Apollo collaboration server"
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,35 @@
 # syntax=docker/dockerfile:1
 
-FROM node:18 AS setup
+FROM node:18-alpine AS build
 WORKDIR /app
+
 COPY package.json yarn.lock .yarnrc.yml ./
 COPY .yarn/ .yarn/
 COPY packages/ packages/
-RUN find packages/ -type f \! \( -name "package.json" -o -name "yarn.lock" \) -delete && \
-find . -type d -empty -delete
-
-FROM node:18 AS build
-WORKDIR /app
-COPY --from=setup /app .
+RUN find packages/ -type f \! \( -name "package.json" -o -name "yarn.lock" \) -delete
+RUN find . -type d -empty -delete
 RUN yarn install --immutable
 COPY . .
 WORKDIR /app/packages/apollo-collaboration-server
 RUN yarn build
 
-FROM node:18
-LABEL org.opencontainers.image.source=https://github.com/GMOD/Apollo3
-LABEL org.opencontainers.image.description="Apollo collaboration server"
+FROM node:18-alpine
 WORKDIR /app
-COPY --from=setup /app .
 COPY --from=build /app/packages/apollo-collaboration-server/dist /app/packages/apollo-collaboration-server/dist
 COPY --from=build /app/packages/apollo-common/dist /app/packages/apollo-common/dist
 COPY --from=build /app/packages/apollo-mst/dist /app/packages/apollo-mst/dist
 COPY --from=build /app/packages/apollo-schemas/dist /app/packages/apollo-schemas/dist
 COPY --from=build /app/packages/apollo-shared/dist /app/packages/apollo-shared/dist
+COPY --from=build /app/packages/apollo-shared/package.json /app/packages/apollo-shared/package.json
+COPY --from=build /app/packages/apollo-schemas/package.json /app/packages/apollo-schemas/package.json
+COPY --from=build /app/packages/apollo-mst/package.json /app/packages/apollo-mst/package.json
+COPY --from=build /app/packages/apollo-common/package.json /app/packages/apollo-common/package.json
+COPY --from=build /app/packages/apollo-collaboration-server/package.json /app/packages/apollo-collaboration-server/package.json
+COPY --from=build /app/package.json /app/package.json
+COPY --from=build /app/yarn.lock /app/yarn.lock
+COPY --from=build /app/.yarnrc.yml /app/.yarnrc.yml
+COPY --from=build /app/.yarn/ /app/.yarn/
 RUN yarn workspaces focus --production @apollo-annotation/collaboration-server
+
 EXPOSE 3999
 CMD ["yarn", "start:prod"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ WORKDIR /app
 COPY package.json yarn.lock .yarnrc.yml ./
 COPY .yarn/ .yarn/
 COPY packages/ packages/
-RUN find packages/ -type f \! \( -name "package.json" -o -name "yarn.lock" \) -delete
-RUN find . -type d -empty -delete
+RUN find packages/ -type f \! \( -name "package.json" -o -name "yarn.lock" \) -delete && \
+find . -type d -empty -delete
 
 FROM node:18-alpine AS build
 WORKDIR /app
@@ -20,21 +20,12 @@ FROM node:18-alpine
 LABEL org.opencontainers.image.source=https://github.com/GMOD/Apollo3
 LABEL org.opencontainers.image.description="Apollo collaboration server"
 WORKDIR /app
+COPY --from=setup /app .
 COPY --from=build /app/packages/apollo-collaboration-server/dist /app/packages/apollo-collaboration-server/dist
 COPY --from=build /app/packages/apollo-common/dist /app/packages/apollo-common/dist
 COPY --from=build /app/packages/apollo-mst/dist /app/packages/apollo-mst/dist
 COPY --from=build /app/packages/apollo-schemas/dist /app/packages/apollo-schemas/dist
 COPY --from=build /app/packages/apollo-shared/dist /app/packages/apollo-shared/dist
-COPY --from=build /app/packages/apollo-shared/package.json /app/packages/apollo-shared/package.json
-COPY --from=build /app/packages/apollo-schemas/package.json /app/packages/apollo-schemas/package.json
-COPY --from=build /app/packages/apollo-mst/package.json /app/packages/apollo-mst/package.json
-COPY --from=build /app/packages/apollo-common/package.json /app/packages/apollo-common/package.json
-COPY --from=build /app/packages/apollo-collaboration-server/package.json /app/packages/apollo-collaboration-server/package.json
-COPY --from=build /app/package.json /app/package.json
-COPY --from=build /app/yarn.lock /app/yarn.lock
-COPY --from=build /app/.yarnrc.yml /app/.yarnrc.yml
-COPY --from=build /app/.yarn/ /app/.yarn/
 RUN yarn workspaces focus --production @apollo-annotation/collaboration-server
-
 EXPOSE 3999
 CMD ["yarn", "start:prod"]


### PR DESCRIPTION
The current Dockerfile for the collaboration server `ghcr.io/gmod/apollo-collaboration-server:devel` is not building successfully and does not run on a Mac machine. I updated the Dockerfile to use node:18-alpine as the base image and made some modifications to the build stages. These changes allow the image to build correctly and run on Mac environments without issues.