### PR TITLE
Remove unwanted (?!) keys in output jbrowse config

### DIFF
--- a/packages/apollo-cli/README.md
+++ b/packages/apollo-cli/README.md
@@ -16,7 +16,7 @@ $ npm install -g @apollo-annotation/cli
 $ apollo COMMAND
 running command...
 $ apollo (--version)
-@apollo-annotation/cli/0.1.20 linux-x64 node-v20.17.0
+@apollo-annotation/cli/0.1.20 linux-x64 node-v20.13.0
 $ apollo --help [COMMAND]
 USAGE
   $ apollo COMMAND

--- a/packages/apollo-cli/src/commands/jbrowse/get-config.ts
+++ b/packages/apollo-cli/src/commands/jbrowse/get-config.ts
@@ -27,6 +27,10 @@ export default class GetConfig extends BaseCommand<typeof GetConfig> {
     }
 
     const json = (await response.json()) as object
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete json['_id' as keyof typeof json]
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete json['__v' as keyof typeof json]
     this.log(JSON.stringify(json, null, 2))
   }
 }

--- a/packages/apollo-cli/test/test.py
+++ b/packages/apollo-cli/test/test.py
@@ -1031,6 +1031,7 @@ class TestCLI(unittest.TestCase):
         )  # NB: "Timeout" comes from utils.py, not Apollo
         # This should be ok
         shell(f"{apollo} login {P} --force", timeout=5, strict=True)
+
     def testFileUpload(self):
         p = shell(f"{apollo} file upload {P} -i test_data/tiny.fasta")
         out = json.loads(p.stdout)
@@ -1218,6 +1219,31 @@ class TestCLI(unittest.TestCase):
         p = shell(f"{apollo} file get {P} -i {up1['_id']} {up2['_id']}")
         out = json.loads(p.stdout)
         self.assertEqual(0, len(out))
+
+    def testGetAndSetJbrowseConfig(self):
+        shell(f"{apollo} jbrowse get-config {P} > tmp.jb.json")
+        shell(
+            """
+        jq '.configuration += { 
+            "ApolloPlugin": {
+              "featureTypeOntology": "Some Ontology Name",
+              "ontologies": [
+                {
+                  "name": "Some Ontology Name",
+                  "version": "full",
+                  "source": {
+                    "uri": "http://localhost:9000/test_data/so-v3.1.json",
+                    "locationType": "UriLocation"
+                  }
+                }
+              ]
+            }
+        }' tmp.jb.json > tmp.jb2.json
+        """
+        )
+        shell(f"{apollo} jbrowse set-config {P} tmp.jb2.json")
+        os.remove("tmp.jb.json")
+        os.remove("tmp.jb2.json")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Occasionally `jbrowse get-config` outputs `_id` and `__v` keys:

```
gitpod /workspace/apollo3-annotation/jbrowse_data (create_script) $ apollo jbrowse get-config
{
  "configuration": {
    "theme": {
      "palette": {
....
  },
  "_id": {},
  "__v": 0
}
```

Which result in:

```
 apollo jbrowse set-config config.json
    Error: Failed to add JBrowse configuration — 422 Unprocessable Entity ({"message":"ValidationError: _id: Cast to ObjectId failed for value \"{}\" (type Object) at path \"_id\" because of
    \"BSONTypeError\"","error":"Unprocessable Entity","statusCode":422})
```