### PR TITLE
Make feature type ontology configurable

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/OntologyManager/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/OntologyManager/index.ts
@@ -1,15 +1,26 @@
-import { ConfigurationSchema } from '@jbrowse/core/configuration'
+import {
+  AnyConfigurationModel,
+  ConfigurationSchema,
+  readConfObject,
+} from '@jbrowse/core/configuration'
 import {
   BlobLocation,
   LocalPathLocation,
   UriLocation,
 } from '@jbrowse/core/util/types/mst'
 import { autorun } from 'mobx'
-import { Instance, addDisposer, getSnapshot, types } from 'mobx-state-tree'
-
+import {
+  Instance,
+  addDisposer,
+  getRoot,
+  getSnapshot,
+  types,
+} from 'mobx-state-tree'
 import OntologyStore, { OntologyStoreOptions } from './OntologyStore'
 import { OntologyDBNode } from './OntologyStore/indexeddb-schema'
 import { applyPrefixes, expandPrefixes } from './OntologyStore/prefixes'
+import ApolloPluginConfigurationSchema from '../config'
+import { ApolloRootModel } from '../types'
 
 export { isDeprecated } from './OntologyStore/indexeddb-schema'
 
@@ -56,14 +67,26 @@ export const OntologyManagerType = types
     }),
   })
   .views((self) => ({
+    get featureTypeOntologyName(): string {
+      const jbConfig = getRoot<ApolloRootModel>(self).jbrowse
+        .configuration as AnyConfigurationModel
+      const pluginConfiguration = jbConfig.ApolloPlugin as Instance<
+        typeof ApolloPluginConfigurationSchema
+      >
+      const featureTypeOntologyName = readConfObject(
+        pluginConfiguration,
+        'featureTypeOntologyName',
+      ) as string
+      return featureTypeOntologyName
+    },
+  }))
+  .views((self) => ({
     /**
      * gets the OntologyRecord for the ontology we should be
      * using for feature types (e.g. SO or maybe biotypes)
      **/
     get featureTypeOntology() {
-      // TODO: change this to read some configuration for which feature type ontology
-      // we should be using. currently hardcoded to use SO.
-      return this.findOntology('Sequence Ontology')
+      return this.findOntology(self.featureTypeOntologyName)
     },
 
     findOntology(name: string, version?: string) {

--- a/packages/jbrowse-plugin-apollo/src/config.ts
+++ b/packages/jbrowse-plugin-apollo/src/config.ts
@@ -5,6 +5,11 @@ import { OntologyRecordConfiguration } from './OntologyManager'
 
 const ApolloPluginConfigurationSchema = ConfigurationSchema('ApolloPlugin', {
   ontologies: types.array(OntologyRecordConfiguration),
+  featureTypeOntologyName: {
+    description: 'Name of the feature type ontology',
+    type: 'string',
+    defaultValue: 'Sequence Ontology',
+  },
 })
 
 export default ApolloPluginConfigurationSchema

--- a/packages/jbrowse-plugin-apollo/src/session/ClientDataStore.ts
+++ b/packages/jbrowse-plugin-apollo/src/session/ClientDataStore.ts
@@ -51,6 +51,7 @@ export function clientDataStoreFactory(
       typeName: types.optional(types.literal('Client'), 'Client'),
       assemblies: types.map(ApolloAssembly),
       checkResults: types.map(CheckResult),
+      ontologyManager: types.optional(OntologyManagerType, {}),
     })
     .views((self) => ({
       get internetAccounts() {
@@ -136,7 +137,6 @@ export function clientDataStoreFactory(
       desktopFileDriver: isElectron
         ? new DesktopFileDriver(self as unknown as ClientDataStoreType)
         : undefined,
-      ontologyManager: OntologyManagerType.create(),
     }))
     .actions((self) => ({
       afterCreate() {

--- a/packages/jbrowse-plugin-apollo/src/session/session.ts
+++ b/packages/jbrowse-plugin-apollo/src/session/session.ts
@@ -419,6 +419,7 @@ export function extendSession(
           ([, assembly]) => assembly.backendDriverType === 'InMemoryFileDriver',
         ),
       )
+      // @ts-expect-error ontologyManager isn't actually required
       snap.apolloDataStore = {
         typeName: 'Client',
         assemblies,


### PR DESCRIPTION
With this change, if you want to use a custom ontology as the feature type ontology (instead of the default Sequence Ontology), you can configure it like this in the JBrowse config:

```json
{
  "configuration": {
    "ApolloPlugin": {
      "featureTypeOntologyName": "My Custom Ontology",
      "ontologies": [
        {
          "name": "My Custom Ontology",
          "version": "1",
          "source": {
            "uri": "data/my_custom_ontology.json",
            "locationType": "UriLocation"
          }
        }
      ]
    }
  }
}
```

Fixes #458 
