### PR TITLE
Transcript widget upates

### DIFF
--- a/packages/apollo-collaboration-server/src/jbrowse/jbrowse.service.ts
+++ b/packages/apollo-collaboration-server/src/jbrowse/jbrowse.service.ts
@@ -58,6 +58,15 @@ export class JBrowseService {
           quaternary: {
             main: '#571AA3',
           },
+          framesCDS: [
+            null,
+            { main: 'rgb(204,121,167)' },
+            { main: 'rgb(230,159,0)' },
+            { main: 'rgb(240,228,66)' },
+            { main: 'rgb(86,180,233)' },
+            { main: 'rgb(0,114,178)' },
+            { main: 'rgb(0,158,115)' },
+          ],
         },
       },
       ApolloPlugin: {

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/Attributes.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/Attributes.tsx
@@ -242,12 +242,7 @@ export const Attributes = observer(function Attributes({
 
   return (
     <>
-      <Typography
-        style={{ display: 'inline', marginLeft: '15px' }}
-        variant="h5"
-      >
-        Attributes
-      </Typography>
+      <Typography variant="h5">Attributes</Typography>
       <Grid container direction="column" spacing={1}>
         {Object.entries(attributes).map(([key, value]) => {
           if (key === '') {

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptBasic.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptBasic.tsx
@@ -4,80 +4,20 @@ import {
   LocationStartChange,
 } from '@apollo-annotation/shared'
 import { AbstractSessionModel, revcom } from '@jbrowse/core/util'
-import { Typography } from '@mui/material'
+import {
+  Paper,
+  Typography,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+} from '@mui/material'
 import { observer } from 'mobx-react'
 import React from 'react'
 
 import { ApolloSessionModel } from '../session'
 import { NumberTextField } from './NumberTextField'
-
-interface CDSInfo {
-  id: string
-  type: string
-  strand: number
-  min: number
-  oldMin: number
-  max: number
-  oldMax: number
-  startSeq: string
-  endSeq: string
-}
-
-interface ExonInfo {
-  min: number
-  max: number
-}
-
-/**
- * Get single feature by featureId
- * @param feature -
- * @param featureId -
- * @returns
- */
-function getFeatureFromId(
-  feature: AnnotationFeature,
-  featureId: string,
-): AnnotationFeature | undefined {
-  if (feature._id === featureId) {
-    return feature
-  }
-  // Check if there is also childFeatures in parent feature and it's not empty
-  // Let's get featureId from recursive method
-  if (!feature.children) {
-    return
-  }
-  for (const [, childFeature] of feature.children) {
-    const subFeature = getFeatureFromId(childFeature, featureId)
-    if (subFeature) {
-      return subFeature
-    }
-  }
-  return
-}
-
-function findExonInRange(
-  exons: ExonInfo[],
-  pairStart: number,
-  pairEnd: number,
-): ExonInfo | null {
-  for (const exon of exons) {
-    if (Number(exon.min) <= pairStart && Number(exon.max) >= pairEnd) {
-      return exon
-    }
-  }
-  return null
-}
-
-function removeMatchingExon(
-  exons: ExonInfo[],
-  matchStart: number,
-  matchEnd: number,
-): ExonInfo[] {
-  // Filter the array to remove elements matching the specified start and end
-  return exons.filter(
-    (exon) => !(exon.min === matchStart && exon.max === matchEnd),
-  )
-}
 
 export const TranscriptBasicInformation = observer(
   function TranscriptBasicInformation({
@@ -96,361 +36,142 @@ export const TranscriptBasicInformation = observer(
     const refData = currentAssembly?.getByRefName(refName)
     const { changeManager } = session.apolloDataStore
 
-    function handleStartChange(
-      newStart: number,
-      featureId: string,
-      oldStart: number,
+    function handleLocationChange(
+      oldLocation: number,
+      newLocation: number,
+      feature: AnnotationFeature,
+      isMin: boolean,
     ) {
-      newStart--
-      oldStart--
-      if (newStart < feature.min) {
-        notify('Feature start cannot be less than parent starts', 'error')
-        return
+      if (!feature.children) {
+        throw new Error('Transcript should have child features')
       }
-      const subFeature = getFeatureFromId(feature, featureId)
-      if (!subFeature?.children) {
-        return
-      }
-      // Let's check CDS start and end values. And possibly update those too
-      for (const child of subFeature.children) {
-        if (
-          (child[1].type === 'CDS' || child[1].type === 'exon') &&
-          child[1].min === oldStart
-        ) {
+      for (const [, child] of feature.children) {
+        if (isMin && oldLocation - 1 === child.min) {
           const change = new LocationStartChange({
             typeName: 'LocationStartChange',
-            changedIds: [child[1]._id],
-            featureId,
-            oldStart,
-            newStart,
+            changedIds: [child._id],
+            featureId: feature._id,
+            oldStart: oldLocation - 1,
+            newStart: newLocation - 1,
             assembly,
           })
           changeManager.submit(change).catch(() => {
             notify('Error updating feature start position', 'error')
           })
+          return
         }
-      }
-      return
-    }
-
-    function handleEndChange(
-      newEnd: number,
-      featureId: string,
-      oldEnd: number,
-    ) {
-      const subFeature = getFeatureFromId(feature, featureId)
-      if (newEnd > feature.max) {
-        notify('Feature start cannot be greater than parent end', 'error')
-        return
-      }
-      if (!subFeature?.children) {
-        return
-      }
-      // Let's check CDS start and end values. And possibly update those too
-      for (const child of subFeature.children) {
-        if (
-          (child[1].type === 'CDS' || child[1].type === 'exon') &&
-          child[1].max === oldEnd
-        ) {
+        if (!isMin && newLocation === child.max) {
           const change = new LocationEndChange({
             typeName: 'LocationEndChange',
-            changedIds: [child[1]._id],
-            featureId,
-            oldEnd,
-            newEnd,
+            changedIds: [child._id],
+            featureId: feature._id,
+            oldEnd: child.max,
+            newEnd: newLocation,
             assembly,
           })
           changeManager.submit(change).catch(() => {
-            notify('Error updating feature end position', 'error')
+            notify('Error updating feature start position', 'error')
           })
-        }
-      }
-      return
-    }
-
-    const featureNew = feature
-    let exonsArray: ExonInfo[] = []
-    const traverse = (currentFeature: AnnotationFeature) => {
-      if (currentFeature.type === 'exon') {
-        exonsArray.push({
-          min: currentFeature.min + 1,
-          max: currentFeature.max,
-        })
-      }
-      if (currentFeature.children) {
-        for (const child of currentFeature.children) {
-          traverse(child[1])
+          return
         }
       }
     }
-    traverse(featureNew)
 
-    const CDSresult: CDSInfo[] = []
-    const CDSData = featureNew.cdsLocations
-    if (refData) {
-      for (const CDSDatum of CDSData) {
-        for (const dataPoint of CDSDatum) {
-          let startSeq = refData.getSequence(
-            Number(dataPoint.min) - 2,
-            Number(dataPoint.min),
-          )
-          let endSeq = refData.getSequence(
-            Number(dataPoint.max),
-            Number(dataPoint.max) + 2,
-          )
+    if (!refData) {
+      return null
+    }
 
-          if (featureNew.strand === -1 && startSeq && endSeq) {
-            startSeq = revcom(startSeq)
-            endSeq = revcom(endSeq)
-          }
-          const oneCDS: CDSInfo = {
-            id: featureNew._id,
-            type: 'CDS',
-            strand: Number(featureNew.strand),
-            min: dataPoint.min + 1,
-            max: dataPoint.max,
-            oldMin: dataPoint.min + 1,
-            oldMax: dataPoint.max,
-            startSeq,
-            endSeq,
-          }
-          // CDSresult.push(oneCDS)
-          // Check if there is already an object with the same start and end
-          const exists = CDSresult.some(
-            (obj) =>
-              obj.min === oneCDS.min &&
-              obj.max === oneCDS.max &&
-              obj.type === oneCDS.type,
-          )
+    const { strand, transcriptParts } = feature
+    const [firstLocation] = transcriptParts
 
-          // If no such object exists, add the new object to the array
-          if (!exists) {
-            CDSresult.push(oneCDS)
-          }
-
-          // Add possible UTRs
-          const foundExon = findExonInRange(
-            exonsArray,
-            dataPoint.min + 1,
-            dataPoint.max,
-          )
-          if (foundExon && Number(foundExon.min) < dataPoint.min) {
-            if (feature.strand === 1) {
-              const oneCDS: CDSInfo = {
-                id: feature._id,
-                type: 'five_prime_UTR',
-                strand: Number(feature.strand),
-                min: foundExon.min,
-                max: dataPoint.min,
-                oldMin: foundExon.min,
-                oldMax: dataPoint.min,
-                startSeq: '',
-                endSeq: '',
-              }
-              CDSresult.push(oneCDS)
-            } else {
-              const oneCDS: CDSInfo = {
-                id: feature._id,
-                type: 'three_prime_UTR',
-                strand: Number(feature.strand),
-                min: dataPoint.min + 1,
-                max: foundExon.min + 1,
-                oldMin: dataPoint.min + 1,
-                oldMax: foundExon.min + 1,
-                startSeq: '',
-                endSeq: '',
-              }
-              CDSresult.push(oneCDS)
+    const locationData = firstLocation
+      .map((loc, idx) => {
+        const { max, min, type } = loc
+        let label: string = type
+        if (label === 'threePrimeUTR') {
+          label = '3` UTR'
+        } else if (label === 'fivePrimeUTR') {
+          label = '5` UTR'
+        }
+        let fivePrimeSpliceSite
+        let threePrimeSpliceSite
+        if (type === 'CDS') {
+          const previousLoc = firstLocation.at(idx - 1)
+          const nextLoc = firstLocation.at(idx + 1)
+          if (strand === 1) {
+            if (previousLoc?.type === 'intron') {
+              fivePrimeSpliceSite = refData.getSequence(min - 2, min)
             }
-            exonsArray = removeMatchingExon(
-              exonsArray,
-              foundExon.min,
-              foundExon.max,
-            )
-          }
-          if (foundExon && Number(foundExon.max) > dataPoint.max) {
-            if (feature.strand === 1) {
-              const oneCDS: CDSInfo = {
-                id: feature._id,
-                type: 'three_prime_UTR',
-                strand: Number(feature.strand),
-                min: dataPoint.max + 1,
-                max: foundExon.max,
-                oldMin: dataPoint.max + 1,
-                oldMax: foundExon.max,
-                startSeq: '',
-                endSeq: '',
-              }
-              CDSresult.push(oneCDS)
-            } else {
-              const oneCDS: CDSInfo = {
-                id: feature._id,
-                type: 'five_prime_UTR',
-                strand: Number(feature.strand),
-                min: dataPoint.min + 1,
-                max: foundExon.max,
-                oldMin: dataPoint.min + 1,
-                oldMax: foundExon.max,
-                startSeq: '',
-                endSeq: '',
-              }
-              CDSresult.push(oneCDS)
+            if (nextLoc?.type === 'intron') {
+              threePrimeSpliceSite = refData.getSequence(max, max + 2)
             }
-            exonsArray = removeMatchingExon(
-              exonsArray,
-              foundExon.min,
-              foundExon.max,
-            )
-          }
-          if (
-            dataPoint.min + 1 === foundExon?.min &&
-            dataPoint.max === foundExon.max
-          ) {
-            exonsArray = removeMatchingExon(
-              exonsArray,
-              foundExon.min,
-              foundExon.max,
-            )
+          } else {
+            if (previousLoc?.type === 'intron') {
+              fivePrimeSpliceSite = revcom(refData.getSequence(max, max + 2))
+            }
+            if (nextLoc?.type === 'intron') {
+              threePrimeSpliceSite = revcom(refData.getSequence(min - 2, min))
+            }
           }
         }
-      }
-    }
-
-    // Add remaining UTRs if any
-    if (exonsArray.length > 0) {
-      // eslint-disable-next-line unicorn/no-array-for-each
-      exonsArray.forEach((element: ExonInfo) => {
-        if (featureNew.strand === 1) {
-          const oneCDS: CDSInfo = {
-            id: featureNew._id,
-            type: 'five_prime_UTR',
-            strand: Number(featureNew.strand),
-            min: element.min + 1,
-            max: element.max,
-            oldMin: element.min + 1,
-            oldMax: element.max,
-            startSeq: '',
-            endSeq: '',
-          }
-          CDSresult.push(oneCDS)
-        } else {
-          const oneCDS: CDSInfo = {
-            id: featureNew._id,
-            type: 'three_prime_UTR',
-            strand: Number(featureNew.strand),
-            min: element.min + 1,
-            max: element.max + 1,
-            oldMin: element.min + 1,
-            oldMax: element.max + 1,
-            startSeq: '',
-            endSeq: '',
-          }
-          CDSresult.push(oneCDS)
-        }
-        exonsArray = removeMatchingExon(exonsArray, element.min, element.max)
+        return { min, max, label, fivePrimeSpliceSite, threePrimeSpliceSite }
       })
-    }
-
-    CDSresult.sort((a, b) => {
-      // Primary sorting by 'start' property
-      const startDifference = Number(a.min) - Number(b.min)
-      if (startDifference !== 0) {
-        return startDifference
-      }
-      return Number(a.max) - Number(b.max)
-    })
-    if (CDSresult.length > 0) {
-      CDSresult[0].startSeq = ''
-
-      // eslint-disable-next-line unicorn/prefer-at
-      CDSresult[CDSresult.length - 1].endSeq = ''
-
-      // Loop through the array and clear "startSeq" or "endSeq" based on the conditions
-      for (let i = 0; i < CDSresult.length; i++) {
-        if (i > 0 && CDSresult[i].min === CDSresult[i - 1].max) {
-          // Clear "startSeq" if the current item's "start" is equal to the previous item's "end"
-          CDSresult[i].startSeq = ''
-        }
-        if (
-          i < CDSresult.length - 1 &&
-          CDSresult[i].max === CDSresult[i + 1].min
-        ) {
-          // Clear "endSeq" if the next item's "start" is equal to the current item's "end"
-          CDSresult[i].endSeq = ''
-        }
-      }
-    }
-
-    const transcriptItems = CDSresult
+      .filter((loc) => loc.label !== 'intron')
 
     return (
       <>
-        <Typography
-          variant="h5"
-          style={{ marginLeft: '15px', marginBottom: '0' }}
-        >
-          CDS and UTRs
+        <Typography variant="h5">Structure</Typography>
+        <Typography variant="h6">
+          {strand === 1 ? 'Forward' : 'Reverse'} strand
         </Typography>
-        <div>
-          {transcriptItems.map((item, index) => (
-            <div key={index} style={{ display: 'flex', alignItems: 'center' }}>
-              <span style={{ marginLeft: '20px', width: '50px' }}>
-                {item.type === 'three_prime_UTR'
-                  ? '3 UTR'
-                  : // eslint-disable-next-line unicorn/no-nested-ternary
-                    item.type === 'five_prime_UTR'
-                    ? '5 UTR'
-                    : 'CDS'}
-              </span>
-              <span style={{ fontWeight: 'bold', width: '30px' }}>
-                {item.startSeq}
-              </span>
-              <NumberTextField
-                margin="dense"
-                id={item.id}
-                disabled={item.type !== 'CDS'}
-                style={{
-                  width: '150px',
-                  marginLeft: '8px',
-                  backgroundColor:
-                    item.startSeq.trim() === '' && index !== 0
-                      ? 'lightblue'
-                      : 'inherit',
-                }}
-                variant="outlined"
-                value={item.min}
-                onChangeCommitted={(newStart: number) => {
-                  handleStartChange(newStart, item.id, Number(item.oldMin))
-                }}
-              />
-              <span style={{ margin: '0 10px' }}>
-                {/* eslint-disable-next-line unicorn/no-nested-ternary */}
-                {item.strand === -1 ? '-' : item.strand === 1 ? '+' : ''}
-              </span>
-              <NumberTextField
-                margin="dense"
-                id={item.id}
-                disabled={item.type !== 'CDS'}
-                style={{
-                  width: '150px',
-                  backgroundColor:
-                    item.endSeq.trim() === '' &&
-                    index + 1 !== transcriptItems.length
-                      ? 'lightblue'
-                      : 'inherit',
-                }}
-                variant="outlined"
-                value={item.max}
-                onChangeCommitted={(newEnd: number) => {
-                  handleEndChange(newEnd, item.id, Number(item.oldMax))
-                }}
-              />
-              <span style={{ marginLeft: '8px', fontWeight: 'bold' }}>
-                {item.endSeq}
-              </span>
-            </div>
-          ))}
-        </div>
+        <TableContainer component={Paper}>
+          <Table size="small">
+            <TableBody>
+              {locationData.map((loc) => (
+                <TableRow key={`${loc.label}:${loc.min}-${loc.max}`}>
+                  <TableCell component="th" scope="row">
+                    {loc.label}
+                  </TableCell>
+                  <TableCell>{loc.fivePrimeSpliceSite ?? ''}</TableCell>
+                  <TableCell padding="none">
+                    <NumberTextField
+                      margin="dense"
+                      variant="outlined"
+                      value={strand === 1 ? loc.min + 1 : loc.max}
+                      onChangeCommitted={(newLocation: number) => {
+                        handleLocationChange(
+                          strand === 1 ? loc.min + 1 : loc.max,
+                          newLocation,
+                          feature,
+                          strand === 1,
+                        )
+                      }}
+                    />
+                    {/* {strand === 1 ? loc.min : loc.max} */}
+                  </TableCell>
+                  <TableCell padding="none">
+                    <NumberTextField
+                      margin="dense"
+                      // disabled={item.type !== 'CDS'}
+                      variant="outlined"
+                      value={strand === 1 ? loc.max : loc.min + 1}
+                      onChangeCommitted={(newLocation: number) => {
+                        handleLocationChange(
+                          strand === 1 ? loc.max : loc.min + 1,
+                          newLocation,
+                          feature,
+                          strand !== 1,
+                        )
+                      }}
+                    />
+                    {/* {strand === 1 ? loc.max : loc.min} */}
+                  </TableCell>
+                  <TableCell>{loc.threePrimeSpliceSite ?? ''}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
       </>
     )
   },

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptBasic.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptBasic.tsx
@@ -3,7 +3,7 @@ import {
   LocationEndChange,
   LocationStartChange,
 } from '@apollo-annotation/shared'
-import { AbstractSessionModel, revcom } from '@jbrowse/core/util'
+import { AbstractSessionModel, getFrame, revcom } from '@jbrowse/core/util'
 import {
   Paper,
   Typography,
@@ -12,6 +12,7 @@ import {
   TableCell,
   TableContainer,
   TableRow,
+  useTheme,
 } from '@mui/material'
 import { observer } from 'mobx-react'
 import React from 'react'
@@ -35,6 +36,7 @@ export const TranscriptBasicInformation = observer(
     const currentAssembly = session.apolloDataStore.assemblies.get(assembly)
     const refData = currentAssembly?.getByRefName(refName)
     const { changeManager } = session.apolloDataStore
+    const theme = useTheme()
 
     function handleLocationChange(
       oldLocation: number,
@@ -95,7 +97,11 @@ export const TranscriptBasicInformation = observer(
         }
         let fivePrimeSpliceSite
         let threePrimeSpliceSite
+        let frameColor
         if (type === 'CDS') {
+          const { phase } = loc
+          const frame = getFrame(min, max, strand ?? 1, phase)
+          frameColor = theme.palette.framesCDS.at(frame)?.main
           const previousLoc = firstLocation.at(idx - 1)
           const nextLoc = firstLocation.at(idx + 1)
           if (strand === 1) {
@@ -114,7 +120,14 @@ export const TranscriptBasicInformation = observer(
             }
           }
         }
-        return { min, max, label, fivePrimeSpliceSite, threePrimeSpliceSite }
+        return {
+          min,
+          max,
+          label,
+          fivePrimeSpliceSite,
+          threePrimeSpliceSite,
+          frameColor,
+        }
       })
       .filter((loc) => loc.label !== 'intron')
 
@@ -129,7 +142,11 @@ export const TranscriptBasicInformation = observer(
             <TableBody>
               {locationData.map((loc) => (
                 <TableRow key={`${loc.label}:${loc.min}-${loc.max}`}>
-                  <TableCell component="th" scope="row">
+                  <TableCell
+                    component="th"
+                    scope="row"
+                    style={{ background: loc.frameColor }}
+                  >
                     {loc.label}
                   </TableCell>
                   <TableCell>{loc.fivePrimeSpliceSite ?? ''}</TableCell>

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptBasic.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptBasic.tsx
@@ -9,8 +9,19 @@ import { observer } from 'mobx-react'
 import React from 'react'
 
 import { ApolloSessionModel } from '../session'
-import { CDSInfo } from './TranscriptSequence'
 import { NumberTextField } from './NumberTextField'
+
+interface CDSInfo {
+  id: string
+  type: string
+  strand: number
+  min: number
+  oldMin: number
+  max: number
+  oldMax: number
+  startSeq: string
+  endSeq: string
+}
 
 interface ExonInfo {
   min: number

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptSequence.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptSequence.tsx
@@ -1,130 +1,139 @@
-import { AnnotationFeature, ApolloRefSeqI } from '@apollo-annotation/mst'
+import { AnnotationFeature } from '@apollo-annotation/mst'
 import { splitStringIntoChunks } from '@apollo-annotation/shared'
 import { revcom } from '@jbrowse/core/util'
 import {
   Button,
   MenuItem,
+  Paper,
   Select,
   SelectChangeEvent,
   Typography,
+  useTheme,
 } from '@mui/material'
 import { observer } from 'mobx-react'
-import React, { useState } from 'react'
+import React, { useRef, useState } from 'react'
 
 import { ApolloSessionModel } from '../session'
 
-export interface CDSInfo {
-  id: string
-  type: string
-  strand: number
-  min: number
-  oldMin: number
-  max: number
-  oldMax: number
-  startSeq: string
-  endSeq: string
+const SEQUENCE_WRAP_LENGTH = 60
+
+type SegmentType = 'upOrDownstream' | 'UTR' | 'CDS' | 'intron' | 'protein'
+type SegmentListType = 'CDS' | 'cDNA' | 'genomic'
+
+interface SequenceSegment {
+  type: SegmentType
+  sequenceLines: string[]
 }
 
-const getCDSInfo = (
+function getSequenceSegments(
+  segmentType: SegmentListType,
   feature: AnnotationFeature,
-  refData: ApolloRefSeqI,
-): CDSInfo[] => {
-  const CDSresult: CDSInfo[] = []
-  const traverse = (
-    currentFeature: AnnotationFeature,
-    isParentMRNA: boolean,
-  ) => {
-    if (
-      isParentMRNA &&
-      (currentFeature.type === 'CDS' ||
-        currentFeature.type === 'three_prime_UTR' ||
-        currentFeature.type === 'five_prime_UTR')
-    ) {
-      let startSeq = refData.getSequence(
-        Number(currentFeature.min) - 2,
-        Number(currentFeature.min),
-      )
-      let endSeq = refData.getSequence(
-        Number(currentFeature.max),
-        Number(currentFeature.max) + 2,
-      )
-
-      if (currentFeature.strand === -1 && startSeq && endSeq) {
-        startSeq = revcom(startSeq)
-        endSeq = revcom(endSeq)
-      }
-      const oneCDS: CDSInfo = {
-        id: currentFeature._id,
-        type: currentFeature.type,
-        strand: Number(currentFeature.strand),
-        min: currentFeature.min + 1,
-        max: currentFeature.max + 1,
-        oldMin: currentFeature.min + 1,
-        oldMax: currentFeature.max + 1,
-        startSeq: startSeq || '',
-        endSeq: endSeq || '',
-      }
-      CDSresult.push(oneCDS)
-    }
-    if (currentFeature.children) {
-      for (const child of currentFeature.children) {
-        traverse(child[1], feature.type === 'mRNA')
-      }
-    }
-  }
-  traverse(feature, feature.type === 'mRNA')
-  CDSresult.sort((a, b) => {
-    return Number(a.min) - Number(b.min)
-  })
-  if (CDSresult.length > 0) {
-    CDSresult[0].startSeq = ''
-
-    // eslint-disable-next-line unicorn/prefer-at
-    CDSresult[CDSresult.length - 1].endSeq = ''
-
-    // Loop through the array and clear "startSeq" or "endSeq" based on the conditions
-    for (let i = 0; i < CDSresult.length; i++) {
-      if (i > 0 && CDSresult[i].min === CDSresult[i - 1].max) {
-        // Clear "startSeq" if the current item's "start" is equal to the previous item's "end"
-        CDSresult[i].startSeq = ''
-      }
-      if (
-        i < CDSresult.length - 1 &&
-        CDSresult[i].max === CDSresult[i + 1].min
-      ) {
-        // Clear "endSeq" if the next item's "start" is equal to the current item's "end"
-        CDSresult[i].endSeq = ''
-      }
-    }
-  }
-  return CDSresult
-}
-
-interface Props {
-  textSegments: { text: string; color: string }[]
-}
-
-function formatSequence(
-  seq: string,
-  refName: string,
-  start: number,
-  end: number,
-  wrap?: number,
+  getSequence: (min: number, max: number) => string,
 ) {
-  const header = `>${refName}:${start + 1}–${end}\n`
-  const body =
-    wrap === undefined ? seq : splitStringIntoChunks(seq, wrap).join('\n')
-  return `${header}${body}`
+  const segments: SequenceSegment[] = []
+  const { cdsLocations, strand, transcriptParts } = feature
+  switch (segmentType) {
+    case 'genomic':
+    case 'cDNA': {
+      const [firstLocation] = transcriptParts
+      for (const loc of firstLocation) {
+        if (segmentType === 'cDNA' && loc.type === 'intron') {
+          continue
+        }
+        let sequence = getSequence(loc.min, loc.max)
+        if (strand === -1) {
+          sequence = revcom(sequence)
+        }
+        const type: SegmentType =
+          loc.type === 'fivePrimeUTR' || loc.type === 'threePrimeUTR'
+            ? 'UTR'
+            : loc.type
+        const previousSegment = segments.at(-1)
+        if (!previousSegment) {
+          const sequenceLines = splitStringIntoChunks(
+            sequence,
+            SEQUENCE_WRAP_LENGTH,
+          )
+          segments.push({ type, sequenceLines })
+          continue
+        }
+        if (previousSegment.type === type) {
+          const [previousSegmentFirstLine, ...previousSegmentFollowingLines] =
+            previousSegment.sequenceLines
+          const newSequence = previousSegmentFollowingLines.join('') + sequence
+          previousSegment.sequenceLines = [
+            previousSegmentFirstLine,
+            ...splitStringIntoChunks(newSequence, SEQUENCE_WRAP_LENGTH),
+          ]
+        } else {
+          const count = segments.reduce(
+            (accumulator, currentSegment) =>
+              accumulator +
+              currentSegment.sequenceLines.reduce(
+                (subAccumulator, currentLine) =>
+                  subAccumulator + currentLine.length,
+                0,
+              ),
+            0,
+          )
+          const previousLineLength = count % SEQUENCE_WRAP_LENGTH
+          const newSegmentFirstLineLength =
+            SEQUENCE_WRAP_LENGTH - previousLineLength
+          const newSegmentFirstLine = sequence.slice(
+            0,
+            newSegmentFirstLineLength,
+          )
+          const newSegmentRemainderLines = splitStringIntoChunks(
+            sequence.slice(newSegmentFirstLineLength),
+            SEQUENCE_WRAP_LENGTH,
+          )
+          segments.push({
+            type,
+            sequenceLines: [newSegmentFirstLine, ...newSegmentRemainderLines],
+          })
+        }
+      }
+      return segments
+    }
+    case 'CDS': {
+      let wholeSequence = ''
+      const [firstLocation] = cdsLocations
+      for (const loc of firstLocation) {
+        let sequence = getSequence(loc.min, loc.max)
+        if (strand === -1) {
+          sequence = revcom(sequence)
+        }
+        wholeSequence += sequence
+      }
+      const sequenceLines = splitStringIntoChunks(
+        wholeSequence,
+        SEQUENCE_WRAP_LENGTH,
+      )
+      segments.push({ type: 'CDS', sequenceLines })
+      return segments
+    }
+  }
 }
 
-export const intronColor = 'rgb(120,120,120)' // Slightly brighter gray
-export const utrColor = 'rgb(20,200,200)' // Slightly brighter cyan
-export const proteinColor = 'rgb(220,70,220)' // Slightly brighter magenta
-export const cdsColor = 'rgb(240,200,20)' // Slightly brighter yellow
-export const updownstreamColor = 'rgb(255,130,130)' // Slightly brighter red
-export const genomeColor = 'rgb(20,230,20)' // Slightly brighter green
-
-let textSegments = [{ text: '', color: '' }]
+function getSegmentColor(type: SegmentType) {
+  switch (type) {
+    case 'upOrDownstream': {
+      return 'rgb(255,255,255)'
+    }
+    case 'UTR': {
+      return 'rgb(194,106,119)'
+    }
+    case 'CDS': {
+      return 'rgb(93,168,153)'
+    }
+    case 'intron': {
+      return 'rgb(187,187,187)'
+    }
+    case 'protein': {
+      return 'rgb(148,203,236)'
+    }
+  }
+}
 
 export const TranscriptSequence = observer(function TranscriptSequence({
   assembly,
@@ -140,7 +149,9 @@ export const TranscriptSequence = observer(function TranscriptSequence({
   const currentAssembly = session.apolloDataStore.assemblies.get(assembly)
   const refData = currentAssembly?.getByRefName(refName)
   const [showSequence, setShowSequence] = useState(false)
-  const [selectedOption, setSelectedOption] = useState('Select')
+  const [selectedOption, setSelectedOption] = useState<SegmentListType>('CDS')
+  const theme = useTheme()
+  const seqRef = useRef<HTMLDivElement>(null)
 
   if (!(currentAssembly && refData)) {
     return null
@@ -149,215 +160,93 @@ export const TranscriptSequence = observer(function TranscriptSequence({
   if (!refSeq) {
     return null
   }
-  const transcriptItems = getCDSInfo(feature, refData)
-  const { max, min } = feature
-  let sequence = ''
-  if (showSequence) {
-    getSequenceAsString(min, max)
-  }
-
-  function getSequenceAsString(start: number, end: number): string {
-    sequence = refSeq?.getSequence(start, end) ?? ''
-    if (sequence === '') {
-      void session.apolloDataStore.loadRefSeq([
-        { assemblyName: assembly, refName, start, end },
-      ])
-    } else {
-      sequence = formatSequence(sequence, refName, start, end)
-    }
-    getSequenceAsTextSegment(selectedOption) // For color coded sequence
-    return sequence
+  if (feature.type !== 'mRNA') {
+    return null
   }
 
   const handleSeqButtonClick = () => {
     setShowSequence(!showSequence)
   }
 
-  function getSequenceAsTextSegment(option: string) {
-    let seqData = ''
-    textSegments = []
-    if (!refData) {
-      return
-    }
-    switch (option) {
-      case 'CDS': {
-        textSegments.push({ text: `>${refName} : CDS\n`, color: 'black' })
-        for (const item of transcriptItems) {
-          if (item.type === 'CDS') {
-            const refSeq: string = refData.getSequence(
-              Number(item.min + 1),
-              Number(item.max),
-            )
-            seqData += item.strand === -1 && refSeq ? revcom(refSeq) : refSeq
-            textSegments.push({ text: seqData, color: cdsColor })
-          }
-        }
-        break
-      }
-      case 'cDNA': {
-        textSegments.push({ text: `>${refName} : cDNA\n`, color: 'black' })
-        for (const item of transcriptItems) {
-          if (
-            item.type === 'CDS' ||
-            item.type === 'three_prime_UTR' ||
-            item.type === 'five_prime_UTR'
-          ) {
-            const refSeq: string = refData.getSequence(
-              Number(item.min + 1),
-              Number(item.max),
-            )
-            seqData += item.strand === -1 && refSeq ? revcom(refSeq) : refSeq
-            if (item.type === 'CDS') {
-              textSegments.push({ text: seqData, color: cdsColor })
-            } else {
-              textSegments.push({ text: seqData, color: utrColor })
-            }
-          }
-        }
-        break
-      }
-      case 'Full': {
-        textSegments.push({
-          text: `>${refName} : Full genomic\n`,
-          color: 'black',
-        })
-        let lastEnd = 0
-        let count = 0
-        for (const item of transcriptItems) {
-          count++
-          if (
-            lastEnd != 0 &&
-            lastEnd != Number(item.min) &&
-            count != transcriptItems.length
-          ) {
-            // Intron etc. between CDS/UTRs. No need to check this on very last item
-            const refSeq: string = refData.getSequence(
-              lastEnd + 1,
-              Number(item.min) - 1,
-            )
-            seqData += item.strand === -1 && refSeq ? revcom(refSeq) : refSeq
-            textSegments.push({ text: seqData, color: 'black' })
-          }
-          if (
-            item.type === 'CDS' ||
-            item.type === 'three_prime_UTR' ||
-            item.type === 'five_prime_UTR'
-          ) {
-            const refSeq: string = refData.getSequence(
-              Number(item.min + 1),
-              Number(item.max),
-            )
-            seqData += item.strand === -1 && refSeq ? revcom(refSeq) : refSeq
-            switch (item.type) {
-              case 'CDS': {
-                textSegments.push({ text: seqData, color: cdsColor })
-                break
-              }
-              case 'three_prime_UTR': {
-                textSegments.push({ text: seqData, color: utrColor })
-                break
-              }
-              case 'five_prime_UTR': {
-                textSegments.push({ text: seqData, color: utrColor })
-                break
-              }
-              default: {
-                textSegments.push({ text: seqData, color: 'black' })
-                break
-              }
-            }
-          }
-          lastEnd = Number(item.max)
-        }
-        break
-      }
-    }
-  }
-
   function handleChangeSeqOption(e: SelectChangeEvent) {
     const option = e.target.value
-    setSelectedOption(option)
-    getSequenceAsTextSegment(option)
+    setSelectedOption(option as SegmentListType)
   }
 
   // Function to copy text to clipboard
   const copyToClipboard = () => {
-    const textToCopy = textSegments.map((segment) => segment.text).join('')
-
-    if (textToCopy) {
-      navigator.clipboard
-        .writeText(textToCopy)
-        .then(() => {
-          // console.log('Text copied to clipboard!')
-        })
-        .catch((error: unknown) => {
-          console.error('Failed to copy text to clipboard', error)
-        })
+    const seqDiv = seqRef.current
+    if (!seqDiv) {
+      return
     }
+    const textBlob = new Blob([seqDiv.outerText], { type: 'text/plain' })
+    const htmlBlob = new Blob([seqDiv.outerHTML], { type: 'text/html' })
+    const clipboardItem = new ClipboardItem({
+      [textBlob.type]: textBlob,
+      [htmlBlob.type]: htmlBlob,
+    })
+    void navigator.clipboard.write([clipboardItem])
   }
 
-  const ColoredText: React.FC<Props> = ({ textSegments }) => {
-    return (
-      <div>
-        {textSegments.map((segment, index) => (
-          <span key={index} style={{ color: segment.color }}>
-            {splitStringIntoChunks(segment.text, 150).join('\n')}
-          </span>
-        ))}
-      </div>
-    )
-  }
+  const sequenceSegments = showSequence
+    ? getSequenceSegments(selectedOption, feature, (min: number, max: number) =>
+        refData.getSequence(min, max),
+      )
+    : []
 
   return (
     <>
-      <Typography
-        style={{ display: 'inline', marginLeft: '15px' }}
-        variant="h5"
-      >
-        Sequence
-      </Typography>
+      <Typography variant="h5">Sequence</Typography>
       <div>
-        <Button
-          variant="contained"
-          style={{ marginLeft: '15px' }}
-          onClick={handleSeqButtonClick}
-        >
+        <Button variant="contained" onClick={handleSeqButtonClick}>
           {showSequence ? 'Hide sequence' : 'Show sequence'}
         </Button>
       </div>
-      <div>
-        {showSequence && (
+      {showSequence && (
+        <>
           <Select
+            defaultValue="CDS"
             value={selectedOption}
             onChange={handleChangeSeqOption}
-            style={{ width: '150px', marginLeft: '15px', height: '25px' }}
           >
-            <MenuItem value={'Select'}>Select</MenuItem>
-            <MenuItem value={'CDS'}>CDS</MenuItem>
+            <MenuItem value="CDS">CDS</MenuItem>
             <MenuItem value={'cDNA'}>cDNA</MenuItem>
-            <MenuItem value={'Full'}>Full genomics</MenuItem>
+            <MenuItem value={'genomic'}>Genomic</MenuItem>
           </Select>
-        )}
-      </div>
-      <div
-        style={{
-          width: '500px',
-          marginLeft: '15px',
-          height: '300px',
-          overflowY: 'auto',
-          border: '1px solid #ccc',
-        }}
-      >
-        {showSequence && <ColoredText textSegments={textSegments} />}
-      </div>
-      {showSequence && (
-        <Button
-          variant="contained"
-          style={{ marginLeft: '15px' }}
-          onClick={copyToClipboard}
-        >
-          Copy sequence
-        </Button>
+          <Paper
+            style={{
+              fontFamily: 'monospace',
+              padding: theme.spacing(),
+              overflowX: 'auto',
+            }}
+            ref={seqRef}
+          >
+            {sequenceSegments.map((segment, index) => (
+              <span
+                key={`${segment.type}-${index}`}
+                style={{
+                  background: getSegmentColor(segment.type),
+                  color: theme.palette.getContrastText(
+                    getSegmentColor(segment.type),
+                  ),
+                }}
+              >
+                {segment.sequenceLines.map((sequenceLine, idx) => (
+                  <React.Fragment key={`${sequenceLine.slice(0, 5)}-${idx}`}>
+                    {sequenceLine}
+                    {idx === segment.sequenceLines.length - 1 &&
+                    sequenceLine.length !== SEQUENCE_WRAP_LENGTH ? null : (
+                      <br />
+                    )}
+                  </React.Fragment>
+                ))}
+              </span>
+            ))}
+          </Paper>
+          <Button variant="contained" onClick={copyToClipboard}>
+            Copy sequence
+          </Button>
+        </>
       )}
     </>
   )

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
@@ -2,7 +2,11 @@ import { AnnotationFeature } from '@apollo-annotation/mst'
 import { Theme, alpha } from '@mui/material'
 import { MenuItem } from '@jbrowse/core/ui'
 
-import { AbstractSessionModel, SessionWithWidgets } from '@jbrowse/core/util'
+import {
+  AbstractSessionModel,
+  isSessionModelWithWidgets,
+  SessionWithWidgets,
+} from '@jbrowse/core/util'
 
 import {
   AddChildFeature,
@@ -385,6 +389,24 @@ function getContextMenuItems(
       },
     },
   )
+  if (sourceFeature.type === 'mRNA' && isSessionModelWithWidgets(session)) {
+    menuItems.push({
+      label: 'Edit transcript details',
+      onClick: () => {
+        const apolloTranscriptWidget = session.addWidget(
+          'ApolloTranscriptDetails',
+          'apolloTranscriptDetails',
+          {
+            feature: sourceFeature,
+            assembly: currentAssemblyId,
+            changeManager,
+            refName: region.refName,
+          },
+        )
+        session.showWidget(apolloTranscriptWidget)
+      },
+    })
+  }
   return menuItems
 }
 


### PR DESCRIPTION
I've added a new view on the AnnotationFeature model called `transcriptParts`. It returns the list of all parts of a transcript including UTRs, CDS locations, and introns. the `cdsLocations` view on the AnnotationFeature model is now a reference to `transcriptParts` with everything but CDS locations filtered out.

This has been used to replace a lot of cumbersome custom transcript-parsing logic in the TranscriptDetailsWidget to make it easier to maintain and in some cases more accurate. Here are some of the changes:

- "CDS and UTRs" section renamed to "Structure" (as in "Structural annotation")
- Transcript structure is now given in 5\` to 3\` order for both strands
- Extraneous entries in splice sites column removed
- CDSs now color-coded by frame to match track coloring
- New CDS frame color scheme based on the [Okabe and Ito colorblind-friendly palette](https://jfly.uni-koeln.de/color/#pallet)
  - Also gives reverse strand a unique color palette for easier identification
- Color coding of sequence is more efficient and has improved visibility
- "Copy sequence" action now copies HTML and plain text simultaneously, allowing "Paste" to keep colors and "Paste without formatting" to keep only text in applications like Google Docs.

### Before

![image](https://github.com/user-attachments/assets/13202524-f4e7-4d60-b6e4-8c5aa9dd7d64)

![image](https://github.com/user-attachments/assets/729c3bf9-9240-414e-9353-445cf5d546c4)

### After

![image](https://github.com/user-attachments/assets/8c1eb8a7-a005-4974-a298-cc810c06f298)

![image](https://github.com/user-attachments/assets/d6c308d1-59f5-4c2a-bab9-02273142f3d5)
