### PR TITLE
Fix occasional error in LocalFileGzip read

### DIFF
--- a/packages/apollo-collaboration-server/src/files/filesUtil.ts
+++ b/packages/apollo-collaboration-server/src/files/filesUtil.ts
@@ -121,9 +121,9 @@ export class LocalFileGzip implements GenericFilehandle {
     const unzippedContents = await this.contents
     const bytesRead = unzippedContents.copy(
       buffer,
-      position,
       offset,
-      offset + length,
+      position,
+      position + length,
     )
     return { bytesRead, buffer }
   }


### PR DESCRIPTION
I'm not sure what triggered this bug that is different from before, but when I cleared out my local DB I couldn't load features any more. The error was cryptic, saying something like "length should be >=0, got \<some negative number\>". I finally tracked it down to `read` in `LocalFileGzip` where the "position" and "offset" were swapped. I'm guessing they were both usually 0, which is why it usually worked, but occasionally they were not 0 and it failed.