### PR TITLE
Make sure LocalFile handles get closed

### DIFF
--- a/packages/apollo-collaboration-server/src/files/files.service.ts
+++ b/packages/apollo-collaboration-server/src/files/files.service.ts
@@ -86,8 +86,6 @@ export class FilesService {
     return fileStream.pipe(gunzip)
   }
 
-  private fileHandleCache: Record<string, GenericFilehandle | undefined> = {}
-
   getFileHandle(file: FileDocument): GenericFilehandle {
     const fileUploadFolder = this.configService.get('FILE_UPLOAD_FOLDER', {
       infer: true,
@@ -96,13 +94,7 @@ export class FilesService {
     switch (file.type) {
       case 'text/x-fai':
       case 'application/x-gzi': {
-        const fileHandleCacheHit = this.fileHandleCache[fileName]
-        if (fileHandleCacheHit) {
-          return fileHandleCacheHit
-        }
-        const fh = new LocalFileGzip(fileName)
-        this.fileHandleCache[fileName] = fh
-        return fh
+        return new LocalFileGzip(fileName)
       }
       case 'application/x-bgzip-fasta':
       case 'text/x-gff3':

--- a/packages/apollo-shared/src/Changes/AddAssemblyFromFileChange.ts
+++ b/packages/apollo-shared/src/Changes/AddAssemblyFromFileChange.ts
@@ -87,7 +87,7 @@ export class AddAssemblyFromFileChange extends FromFileBaseChange {
       throw new Error('No FILE_UPLOAD_FOLDER found in .env file')
     }
 
-    const { fa, fai, gzi } = fileIds
+    const { fa: faId, fai: faiId, gzi: gziId } = fileIds
     const {
       assemblyModel,
       checkModel,
@@ -97,30 +97,30 @@ export class AddAssemblyFromFileChange extends FromFileBaseChange {
       user,
     } = backend
 
-    const faDoc = await fileModel.findById(fa)
+    const faDoc = await fileModel.findById(faId)
     const faChecksum = faDoc?.checksum
     if (!faChecksum) {
       throw new Error(`No checksum for file document ${faDoc}`)
     }
 
-    const faiDoc = await fileModel.findById(fai)
+    const faiDoc = await fileModel.findById(faiId)
     const faiChecksum = faiDoc?.checksum
     if (!faiChecksum) {
       throw new Error(`No checksum for file document ${faiDoc}`)
     }
 
-    const gziDoc = await fileModel.findById(gzi)
+    const gziDoc = await fileModel.findById(gziId)
     const gziChecksum = gziDoc?.checksum
     if (!gziChecksum) {
       throw new Error(`No checksum for file document ${gziDoc}`)
     }
 
-    const sequenceAdapter = new BgzipIndexedFasta({
-      fasta: filesService.getFileHandle(faDoc),
-      fai: filesService.getFileHandle(faiDoc),
-      gzi: filesService.getFileHandle(gziDoc),
-    })
+    const fasta = filesService.getFileHandle(faDoc)
+    const fai = filesService.getFileHandle(faiDoc)
+    const gzi = filesService.getFileHandle(gziDoc)
+    const sequenceAdapter = new BgzipIndexedFasta({ fasta, fai, gzi })
     const allSequenceSizes = await sequenceAdapter.getSequenceSizes()
+    await Promise.all([fasta.close(), fai.close(), gzi.close()])
 
     const assemblyDoc = await assemblyModel
       .findOne({ name: assemblyName })


### PR DESCRIPTION
As described in #488, I was getting this error when loading data on the demo server:

```
    Error: importFeatures failed — 422 Unprocessable Entity 
    ({"message":"Error: EMFILE: too many open files, open 
    '/data/uploads/05dc2a73502099956dce87e417ed886c'","error":"Unprocessable 
    Entity","statusCode":422})
```

It turns out #488 did not fix this, so after some more digging I found the solution in this PR. It turns out we have to be a bit careful about making sure we close filehandles when using `LocalFile` so that we don't have a lot of opened files.