### PR TITLE
Fix checks getting deleted sometimes

### DIFF
--- a/packages/jbrowse-plugin-apollo/cypress/e2e/editFeature.cy.ts
+++ b/packages/jbrowse-plugin-apollo/cypress/e2e/editFeature.cy.ts
@@ -71,6 +71,8 @@ describe('Different ways of editing features', () => {
         })
       })
     cy.get('body').click(0, 0)
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(5000)
 
     // Check edit is done
     cy.reload()


### PR DESCRIPTION
Checks were getting cleared any time a feature check was requested instead of only when the check result was stale.