### PR TITLE
Use "transcript" instead of "mRNA" for base term

### DIFF
--- a/packages/apollo-mst/src/AnnotationFeatureModel.ts
+++ b/packages/apollo-mst/src/AnnotationFeatureModel.ts
@@ -133,9 +133,6 @@ export const AnnotationFeatureModel = types
       const { apolloDataStore } = session
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       const { featureTypeOntology } = apolloDataStore.ontologyManager
-      console.log(self.type)
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-      console.log(featureTypeOntology.isTypeOf(self.type, 'transcript'))
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
       if (!featureTypeOntology.isTypeOf(self.type, 'transcript')) {
         throw new Error(

--- a/packages/apollo-mst/src/AnnotationFeatureModel.ts
+++ b/packages/apollo-mst/src/AnnotationFeatureModel.ts
@@ -133,22 +133,25 @@ export const AnnotationFeatureModel = types
       const { apolloDataStore } = session
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       const { featureTypeOntology } = apolloDataStore.ontologyManager
+      console.log(self.type)
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-      if (!featureTypeOntology.isTypeOf(self.type, 'mRNA')) {
+      console.log(featureTypeOntology.isTypeOf(self.type, 'transcript'))
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      if (!featureTypeOntology.isTypeOf(self.type, 'transcript')) {
         throw new Error(
-          'Only features of type "mRNA" or equivalent can calculate CDS locations',
+          'Only features of type "transcript" or equivalent can calculate CDS locations',
         )
       }
       const children = self.children as Children
       if (!children) {
-        throw new Error('no CDS or exons in mRNA')
+        throw new Error('no CDS or exons in transcript')
       }
       const cdsChildren = [...children.values()].filter(
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
         (child) => featureTypeOntology.isTypeOf(child.type, 'CDS'),
       )
       if (cdsChildren.length === 0) {
-        throw new Error('no CDS in mRNA')
+        throw new Error('no CDS in transcript')
       }
       const transcriptParts: TranscriptParts[] = []
       for (const cds of cdsChildren) {

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptBasic.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptBasic.tsx
@@ -83,7 +83,12 @@ export const TranscriptBasicInformation = observer(
       return null
     }
 
-    const { strand, transcriptParts } = feature
+    let strand, transcriptParts
+    try {
+      ;({ strand, transcriptParts } = feature)
+    } catch {
+      return null
+    }
     const [firstLocation] = transcriptParts
 
     const locationData = firstLocation

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
@@ -389,7 +389,14 @@ function getContextMenuItems(
       },
     },
   )
-  if (sourceFeature.type === 'mRNA' && isSessionModelWithWidgets(session)) {
+  const { featureTypeOntology } = session.apolloDataStore.ontologyManager
+  if (!featureTypeOntology) {
+    throw new Error('featureTypeOntology is undefined')
+  }
+  if (
+    featureTypeOntology.isTypeOf(sourceFeature.type, 'transcript') &&
+    isSessionModelWithWidgets(session)
+  ) {
     menuItems.push({
       label: 'Edit transcript details',
       onClick: () => {

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/layouts.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/layouts.ts
@@ -86,7 +86,7 @@ export function layoutsModelFactory(
           return false
         }
         for (const [, child] of children) {
-          if (featureTypeOntology.isTypeOf(child.type, 'mRNA')) {
+          if (featureTypeOntology.isTypeOf(child.type, 'transcript')) {
             const { children: grandChildren } = child
             if (!grandChildren?.size) {
               return false

--- a/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/stateModel.ts
+++ b/packages/jbrowse-plugin-apollo/src/SixFrameFeatureDisplay/stateModel.ts
@@ -300,7 +300,9 @@ export function stateModelFactory(
             },
           )) {
             for (const [, childFeature] of feature.children ?? new Map()) {
-              if (featureTypeOntology.isTypeOf(childFeature.type, 'mRNA')) {
+              if (
+                featureTypeOntology.isTypeOf(childFeature.type, 'transcript')
+              ) {
                 for (const [, grandChildFeature] of childFeature.children ||
                   new Map()) {
                   let startingRow

--- a/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/featureContextMenuItems.ts
+++ b/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/featureContextMenuItems.ts
@@ -142,7 +142,7 @@ export function featureContextMenuItems(
       throw new Error('featureTypeOntology is undefined')
     }
     if (
-      featureTypeOntology.isTypeOf(feature.type, 'mRNA') &&
+      featureTypeOntology.isTypeOf(feature.type, 'transcript') &&
       isSessionModelWithWidgets(session)
     ) {
       menuItems.push({


### PR DESCRIPTION
This uses "transcript" instead of "mRNA" as the base term when doing ontology comparisons since it matches more things we usually want to catch (such as "ncRNA").