### PR TITLE
Improve gene glyph display and performance

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/model.ts
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/model.ts
@@ -9,7 +9,6 @@ import { ElementId } from '@jbrowse/core/util/types/mst'
 import { autorun } from 'mobx'
 import { Instance, SnapshotIn, addDisposer, types } from 'mobx-state-tree'
 
-import { ChangeManager } from '../ChangeManager'
 import { ApolloSessionModel } from '../session'
 
 export const ApolloFeatureDetailsWidgetModel = types
@@ -86,7 +85,6 @@ export const ApolloTranscriptDetailsModel = types
     ),
     assembly: types.string,
     refName: types.string,
-    changeManager: types.frozen<ChangeManager>(),
   })
   .volatile(() => ({
     tryReload: undefined as string | undefined,

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/LinearApolloDisplay.tsx
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/LinearApolloDisplay.tsx
@@ -9,7 +9,13 @@ import {
 } from '@jbrowse/core/util'
 import type { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
 import ErrorIcon from '@mui/icons-material/Error'
-import { Alert, Avatar, Tooltip, useTheme } from '@mui/material'
+import {
+  Alert,
+  Avatar,
+  CircularProgress,
+  Tooltip,
+  useTheme,
+} from '@mui/material'
 import { observer } from 'mobx-react'
 import React, { useEffect, useState } from 'react'
 import { makeStyles } from 'tss-react/mui'
@@ -39,6 +45,13 @@ const useStyles = makeStyles()((theme) => ({
     color: theme.palette.warning.light,
     backgroundColor: theme.palette.warning.contrastText,
   },
+  loading: {
+    position: 'absolute',
+    right: theme.spacing(3),
+    zIndex: 10,
+    pointerEvents: 'none',
+    textAlign: 'right',
+  },
 }))
 
 export const LinearApolloDisplay = observer(function LinearApolloDisplay(
@@ -47,6 +60,7 @@ export const LinearApolloDisplay = observer(function LinearApolloDisplay(
   const theme = useTheme()
   const { model } = props
   const {
+    loading,
     apolloRowHeight,
     contextMenuItems: getContextMenuItems,
     cursor,
@@ -128,6 +142,11 @@ export const LinearApolloDisplay = observer(function LinearApolloDisplay(
           }
         }}
       >
+        {loading ? (
+          <div className={classes.loading}>
+            <CircularProgress size="18px" />
+          </div>
+        ) : null}
         {message ? (
           <Alert severity="warning" classes={{ message: classes.ellipses }}>
             <Tooltip title={message}>

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/base.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/base.ts
@@ -44,6 +44,7 @@ export function baseModelFactory(
         ),
       ),
       filteredFeatureTypes: types.array(types.string),
+      loadingState: false,
     })
     .views((self) => {
       const { configuration, renderProps: superRenderProps } = self
@@ -75,6 +76,9 @@ export function baseModelFactory(
           return 200
         }
         return 300
+      },
+      get loading() {
+        return self.loadingState
       },
     }))
     .views((self) => ({
@@ -167,6 +171,9 @@ export function baseModelFactory(
       updateFilteredFeatureTypes(types: string[]) {
         self.filteredFeatureTypes = cast(types)
       },
+      setLoading(loading: boolean) {
+        self.loadingState = loading
+      },
     }))
     .views((self) => {
       const { filteredFeatureTypes, trackMenuItems: superTrackMenuItems } = self
@@ -244,9 +251,16 @@ export function baseModelFactory(
               if (!self.lgv.initialized || self.regionCannotBeRendered()) {
                 return
               }
+              self.setLoading(true)
               void (
                 self.session as unknown as ApolloSessionModel
-              ).apolloDataStore.loadFeatures(self.regions)
+              ).apolloDataStore
+                .loadFeatures(self.regions)
+                .then(() => {
+                  setTimeout(() => {
+                    self.setLoading(false)
+                  }, 1000)
+                })
               if (self.lgv.bpPerPx <= 3) {
                 void (
                   self.session as unknown as ApolloSessionModel

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/mouseEvents.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/mouseEvents.ts
@@ -139,13 +139,18 @@ export function mouseEventsModelIntermediateFactory(
         if (!layoutRow) {
           return mousePosition
         }
-        const foundFeature = layoutRow.find(
-          (f) => bp >= f[1].min && bp <= f[1].max,
-        )
+        const foundFeature = layoutRow.find((f) => {
+          const feature = self.getAnnotationFeatureById(f[1])
+          return feature && bp >= feature.min && bp <= feature.max
+        })
         if (!foundFeature) {
           return mousePosition
         }
-        const [featureRow, topLevelFeature] = foundFeature
+        const [featureRow, topLevelFeatureId] = foundFeature
+        const topLevelFeature = self.getAnnotationFeatureById(topLevelFeatureId)
+        if (!topLevelFeature) {
+          return mousePosition
+        }
         const glyph = self.getGlyph(topLevelFeature)
         const { featureTypeOntology } =
           self.session.apolloDataStore.ontologyManager

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/rendering.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/rendering.ts
@@ -413,8 +413,9 @@ export function renderingModelFactory(
             for (const [idx, featureLayout] of featureLayouts.entries()) {
               const displayedRegion = displayedRegions[idx]
               for (const [row, featureLayoutRow] of featureLayout.entries()) {
-                for (const [featureRow, feature] of featureLayoutRow) {
-                  if (featureRow > 0) {
+                for (const [featureRow, featureId] of featureLayoutRow) {
+                  const feature = self.getAnnotationFeatureById(featureId)
+                  if (featureRow > 0 || !feature) {
                     continue
                   }
                   if (

--- a/packages/jbrowse-plugin-apollo/src/OntologyManager/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/OntologyManager/index.ts
@@ -35,6 +35,7 @@ export const OntologyRecordType = types
   })
   .volatile((_self) => ({
     dataStore: undefined as undefined | OntologyStore,
+    startedEquivalentTypeRequests: new Set<string>(),
   }))
   .actions((self) => ({
     /** does nothing, just used to access the model to force its lifecycle hooks to run */
@@ -66,6 +67,10 @@ export const OntologyRecordType = types
       if (!self.dataStore) {
         return
       }
+      if (self.startedEquivalentTypeRequests.has(type)) {
+        return
+      }
+      self.startedEquivalentTypeRequests.add(type)
       const terms = (yield self.dataStore.getTermsWithLabelOrSynonym(
         type,
       )) as unknown as OntologyTerm[]
@@ -74,6 +79,23 @@ export const OntologyRecordType = types
         .filter((term) => term != undefined)
       self.setEquivalentTypes(type, equivalents)
     }),
+  }))
+  .actions((self) => ({
+    afterCreate() {
+      autorun((reaction) => {
+        if (!self.dataStore) {
+          return
+        }
+        void self.loadEquivalentTypes('gene')
+        void self.loadEquivalentTypes('transcript')
+        void self.loadEquivalentTypes('CDS')
+        void self.loadEquivalentTypes('mRNA')
+        reaction.dispose()
+      })
+    },
+    setEquivalentTypes(type: string, equivalentTypes: string[]) {
+      self.equivalentTypes.set(type, equivalentTypes)
+    },
   }))
   .views((self) => ({
     isTypeOf(queryType: string, typeOf: string): boolean {


### PR DESCRIPTION
A couple fixes here. First fixes the error `DataCloneError: Failed to execute 'put' on 'IDBObjectStore': [object Object] could not be cloned.` when opening the transcript details widget.

The second pre-loads the equivalent types from the ontology for the types we check against in the code. This speeds up gene glyph rendering a lot.

Still potentially some slowness that needs to get tracked down, so starting off as a draft.

Fixes #522