### PR TITLE
Feature layout updates and loading indicator

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/LinearApolloDisplay.tsx
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/LinearApolloDisplay.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-misused-promises */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-import { Menu, MenuItem, LoadingEllipses } from '@jbrowse/core/ui'
+import { Menu, MenuItem } from '@jbrowse/core/ui'
 import {
   AbstractSessionModel,
   doesIntersect2,
@@ -9,7 +9,13 @@ import {
 } from '@jbrowse/core/util'
 import type { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
 import ErrorIcon from '@mui/icons-material/Error'
-import { Alert, Avatar, Tooltip, useTheme } from '@mui/material'
+import {
+  Alert,
+  Avatar,
+  CircularProgress,
+  Tooltip,
+  useTheme,
+} from '@mui/material'
 import { observer } from 'mobx-react'
 import React, { useEffect, useState } from 'react'
 import { makeStyles } from 'tss-react/mui'
@@ -40,13 +46,11 @@ const useStyles = makeStyles()((theme) => ({
     backgroundColor: theme.palette.warning.contrastText,
   },
   loading: {
-    backgroundColor: theme.palette.background.default,
-    backgroundImage: `repeating-linear-gradient(45deg, transparent, transparent 5px, ${theme.palette.action.disabledBackground} 5px, ${theme.palette.action.disabledBackground} 10px)`,
     position: 'absolute',
     right: 0,
     zIndex: 10,
     pointerEvents: 'none',
-    textAlign: 'center',
+    textAlign: 'right',
   },
 }))
 
@@ -139,11 +143,8 @@ export const LinearApolloDisplay = observer(function LinearApolloDisplay(
         }}
       >
         {loading ? (
-          <div
-            className={classes.loading}
-            style={{ width: '100%', height: 18 }}
-          >
-            <LoadingEllipses message="Loading annotations, Please wait..." />
+          <div className={classes.loading}>
+            <CircularProgress size="18px" />
           </div>
         ) : null}
         {message ? (

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/LinearApolloDisplay.tsx
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/LinearApolloDisplay.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-misused-promises */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-import { Menu, MenuItem } from '@jbrowse/core/ui'
+import { Menu, MenuItem, LoadingEllipses } from '@jbrowse/core/ui'
 import {
   AbstractSessionModel,
   doesIntersect2,
@@ -39,6 +39,15 @@ const useStyles = makeStyles()((theme) => ({
     color: theme.palette.warning.light,
     backgroundColor: theme.palette.warning.contrastText,
   },
+  loading: {
+    backgroundColor: theme.palette.background.default,
+    backgroundImage: `repeating-linear-gradient(45deg, transparent, transparent 5px, ${theme.palette.action.disabledBackground} 5px, ${theme.palette.action.disabledBackground} 10px)`,
+    position: 'absolute',
+    right: 0,
+    zIndex: 10,
+    pointerEvents: 'none',
+    textAlign: 'center',
+  },
 }))
 
 export const LinearApolloDisplay = observer(function LinearApolloDisplay(
@@ -47,6 +56,7 @@ export const LinearApolloDisplay = observer(function LinearApolloDisplay(
   const theme = useTheme()
   const { model } = props
   const {
+    loading,
     apolloRowHeight,
     contextMenuItems: getContextMenuItems,
     cursor,
@@ -128,6 +138,14 @@ export const LinearApolloDisplay = observer(function LinearApolloDisplay(
           }
         }}
       >
+        {loading ? (
+          <div
+            className={classes.loading}
+            style={{ width: '100%', height: 18 }}
+          >
+            <LoadingEllipses message="Fetching annotations, Please wait..." />
+          </div>
+        ) : null}
         {message ? (
           <Alert severity="warning" classes={{ message: classes.ellipses }}>
             <Tooltip title={message}>

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/LinearApolloDisplay.tsx
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/LinearApolloDisplay.tsx
@@ -47,7 +47,7 @@ const useStyles = makeStyles()((theme) => ({
   },
   loading: {
     position: 'absolute',
-    right: 0,
+    right: theme.spacing(3),
     zIndex: 10,
     pointerEvents: 'none',
     textAlign: 'right',

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/LinearApolloDisplay.tsx
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/LinearApolloDisplay.tsx
@@ -143,7 +143,7 @@ export const LinearApolloDisplay = observer(function LinearApolloDisplay(
             className={classes.loading}
             style={{ width: '100%', height: 18 }}
           >
-            <LoadingEllipses message="Fetching annotations, Please wait..." />
+            <LoadingEllipses message="Loading annotations, Please wait..." />
           </div>
         ) : null}
         {message ? (

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/layouts.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/layouts.ts
@@ -62,6 +62,9 @@ export function layoutsModelFactory(
           return
         })
       },
+      getAnnotationFeatureById(id: string) {
+        return self.seenFeatures.get(id)
+      },
       getGlyph(feature: AnnotationFeature) {
         if (this.looksLikeGene(feature)) {
           return geneGlyph
@@ -113,7 +116,7 @@ export function layoutsModelFactory(
           self.session as unknown as AbstractSessionModel
         return self.lgv.displayedRegions.map((region, idx) => {
           const assembly = assemblyManager.get(region.assemblyName)
-          const featureLayout = new Map<number, [number, AnnotationFeature][]>()
+          const featureLayout = new Map<number, [number, string][]>()
           const minMax = self.featuresMinMax[idx]
           if (!minMax) {
             return featureLayout
@@ -192,7 +195,7 @@ export function layoutsModelFactory(
                 }
                 row.fill(true, start, end)
                 const layoutRow = featureLayout.get(rowNum)
-                layoutRow?.push([rowNum - startingRow, feature])
+                layoutRow?.push([rowNum - startingRow, feature._id])
               }
               placed = true
             }
@@ -206,10 +209,15 @@ export function layoutsModelFactory(
           self.session.apolloDataStore.ontologyManager
         for (const [idx, layout] of featureLayouts.entries()) {
           for (const [layoutRowNum, layoutRow] of layout) {
-            for (const [featureRowNum, layoutFeature] of layoutRow) {
+            for (const [featureRowNum, layoutFeatureId] of layoutRow) {
               if (featureRowNum !== 0) {
                 // Same top-level feature in all feature rows, so only need to
                 // check the first one
+                continue
+              }
+              const layoutFeature =
+                self.getAnnotationFeatureById(layoutFeatureId)
+              if (!layoutFeature) {
                 continue
               }
               if (feature._id === layoutFeature._id) {

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/layouts.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/layouts.ts
@@ -1,4 +1,3 @@
-import { addDisposer, isAlive } from 'mobx-state-tree'
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 
 import { AnnotationFeature } from '@apollo-annotation/mst'
@@ -6,6 +5,7 @@ import { AnyConfigurationSchemaType } from '@jbrowse/core/configuration/configur
 import PluginManager from '@jbrowse/core/PluginManager'
 import { AbstractSessionModel, doesIntersect2 } from '@jbrowse/core/util'
 import { autorun, observable } from 'mobx'
+import { addDisposer, isAlive } from 'mobx-state-tree'
 
 import { ApolloSessionModel } from '../../session'
 import { baseModelFactory } from './base'

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/mouseEvents.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/mouseEvents.ts
@@ -139,13 +139,18 @@ export function mouseEventsModelIntermediateFactory(
         if (!layoutRow) {
           return mousePosition
         }
-        const foundFeature = layoutRow.find(
-          (f) => bp >= f[1].min && bp <= f[1].max,
-        )
+        const foundFeature = layoutRow.find((f) => {
+          const feature = self.getAnnotationFeatureById(f[1])
+          return feature && bp >= feature.min && bp <= feature.max
+        })
         if (!foundFeature) {
           return mousePosition
         }
-        const [featureRow, topLevelFeature] = foundFeature
+        const [featureRow, topLevelFeatureId] = foundFeature
+        const topLevelFeature = self.getAnnotationFeatureById(topLevelFeatureId)
+        if (!topLevelFeature) {
+          return mousePosition
+        }
         const glyph = self.getGlyph(topLevelFeature)
         const { featureTypeOntology } =
           self.session.apolloDataStore.ontologyManager

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/rendering.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/rendering.ts
@@ -413,8 +413,9 @@ export function renderingModelFactory(
             for (const [idx, featureLayout] of featureLayouts.entries()) {
               const displayedRegion = displayedRegions[idx]
               for (const [row, featureLayoutRow] of featureLayout.entries()) {
-                for (const [featureRow, feature] of featureLayoutRow) {
-                  if (featureRow > 0) {
+                for (const [featureRow, featureId] of featureLayoutRow) {
+                  const feature = self.getAnnotationFeatureById(featureId)
+                  if (featureRow > 0 || !feature) {
                     continue
                   }
                   if (


### PR DESCRIPTION
- Change featureLayouts data structure to store feature id instead of the object and access feature from seenFeatures using feature id
- If feature min max range is large, rows boolean array in feature layouts was consuming too much memory leading to crash. Its replaced with a data structure which maintains feature coordinate range for each row
- Clean up seen features outside certain boundary to save memory
- Add loading indicator

Fixes https://github.com/GMOD/Apollo3/issues/522