### PR TITLE
Fix error when refreshing page with GFF evidence track open

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/extensions/annotationFromJBrowseFeature.ts
+++ b/packages/jbrowse-plugin-apollo/src/extensions/annotationFromJBrowseFeature.ts
@@ -130,11 +130,11 @@ export function annotationFromJBrowseFeature(
     }))
     .views((self) => {
       const superContextMenuItems = self.contextMenuItems
-      const session = getSession(self)
-      const assembly = self.getAssembly()
 
       return {
         contextMenuItems() {
+          const session = getSession(self)
+          const assembly = self.getAssembly()
           const feature = self.contextMenuFeature
           if (!feature) {
             return superContextMenuItems()


### PR DESCRIPTION
Fixes an issue found by @shashankbrgowda where if there was a GFF evidence track open and you refreshed the page, you would get this error:

![image](https://github.com/user-attachments/assets/f065d8d7-8e2f-4afc-bf5e-7c0d4b925a66)
