### PR TITLE
Fix #506: Warnings do not disappear after fixing

### DIFF
--- a/packages/apollo-cli/src/test/test.ts
+++ b/packages/apollo-cli/src/test/test.ts
@@ -323,7 +323,7 @@ void describe('Test CLI', () => {
     fs.unlinkSync('test_data/tmp.fa')
   })
 
-  void globalThis.itName('FIXME Checks are triggered and resolved', () => {
+  void globalThis.itName('Checks are triggered and resolved', () => {
     new Shell(`${apollo} assembly add-from-gff ${P} test_data/checks.gff -f`)
     let p = new Shell(`${apollo} feature get ${P} -a checks.gff`)
     const out = JSON.parse(p.stdout)
@@ -348,18 +348,61 @@ void describe('Test CLI', () => {
     )
     p = new Shell(`${apollo} feature check ${P} -a checks.gff`)
     const checks = JSON.parse(p.stdout)
-    // FIXME: There should be 2 failing checks, not 3
-    assert.strictEqual(checks.length, 3)
-    assert.ok(p.stdout.includes('InternalStopCodonCheck'))
-    assert.ok(p.stdout.includes('MissingStopCodonCheck'))
+    assert.strictEqual(checks.length, 2)
+    assert.ok(p.stdout.includes('InternalStopCodon'))
+    assert.ok(p.stdout.includes('MissingStopCodon'))
 
     // Problems fixed
     new Shell(
       `${apollo} feature edit-coords ${P} -i ${cds_id} --start 16 --end 27`,
     )
     p = new Shell(`${apollo} feature check ${P} -a checks.gff`)
-    // FIXME: After fixing, how many warnings do we expect?
-    assert.deepStrictEqual(JSON.parse(p.stdout).length, 4)
+    assert.deepStrictEqual(JSON.parse(p.stdout).length, 0)
+  })
+
+  void globalThis.itName('FIXME: Checks stay after invalid operation', () => {
+    new Shell(`${apollo} assembly add-from-gff ${P} test_data/checks.gff -f`)
+    let p = new Shell(`${apollo} feature get ${P} -a checks.gff`)
+    const out = JSON.parse(p.stdout)
+
+    p = new Shell(`${apollo} feature check ${P} -a checks.gff`)
+    assert.deepStrictEqual(p.stdout.trim(), '[]') // No failing check
+
+    // Get the ID of the CDS. We need need it to modify the CDS coordinates
+    const gene = out.filter(
+      (x: any) =>
+        JSON.stringify(x.attributes.gff_id) === JSON.stringify(['gene01']),
+    )
+    const mrna = Object.values(gene.at(0).children).at(0) as any
+    const cds = Object.values(mrna.children).find(
+      (x: any) => x.attributes.gff_id.at(0) === 'cds01',
+    ) as any
+    const cds_id = cds._id
+
+    // Introduce problems
+    new Shell(
+      `${apollo} feature edit-coords ${P} -i ${cds_id} --start 4 --end 24`,
+    )
+    p = new Shell(`${apollo} feature check ${P} -a checks.gff`)
+    let checks = JSON.parse(p.stdout)
+    assert.strictEqual(checks.length, 2)
+    assert.ok(p.stdout.includes('InternalStopCodon'))
+    assert.ok(p.stdout.includes('MissingStopCodon'))
+
+    // Do something invalid: extend CDS beyond parent
+    p = new Shell(
+      `${apollo} feature edit-coords ${P} -i ${cds_id} --end 30`,
+      false,
+    )
+    assert.ok(p.returncode != 0)
+    assert.ok(p.stderr.includes('exceeds the bounds of its parent'))
+
+    // FIXME: Checks should be the same as before the invalid edit
+    p = new Shell(`${apollo} feature check ${P} -a checks.gff`)
+    checks = JSON.parse(p.stdout)
+    //assert.strictEqual(checks.length, 2)
+    //assert.ok(p.stdout.includes('InternalStopCodon'))
+    //assert.ok(p.stdout.includes('MissingStopCodon'))
   })
 
   void globalThis.itName('Add assembly from local fasta', () => {
@@ -1034,7 +1077,7 @@ void describe('Test CLI', () => {
     let p = new Shell(`${apollo} feature check ${P} -a v1`)
     const out = JSON.parse(p.stdout)
     assert.ok(out.length > 1)
-    assert.ok(p.stdout.includes('InternalStopCodonCheck'))
+    assert.ok(p.stdout.includes('InternalStopCodon'))
 
     // Ids with checks
     const ids: string[] = out.map((x: any) => x.ids)
@@ -1043,7 +1086,7 @@ void describe('Test CLI', () => {
     // Retrieve by feature id
     const xid = [...ids].join(' ')
     p = new Shell(`${apollo} feature check ${P} -i ${xid}`)
-    assert.ok(p.stdout.includes('InternalStopCodonCheck'))
+    assert.ok(p.stdout.includes('InternalStopCodon'))
   })
 
   void globalThis.itName('Feature checks indexed', () => {
@@ -1057,7 +1100,7 @@ void describe('Test CLI', () => {
     let p = new Shell(`${apollo} feature check ${P} -a v1`)
     const out = JSON.parse(p.stdout)
     assert.ok(out.length > 1)
-    assert.ok(p.stdout.includes('InternalStopCodonCheck'))
+    assert.ok(p.stdout.includes('InternalStopCodon'))
 
     // Ids with checks
     const ids: string[] = out.map((x: any) => x.ids)
@@ -1066,7 +1109,7 @@ void describe('Test CLI', () => {
     // Retrieve by feature id
     const xid = [...ids].join(' ')
     p = new Shell(`${apollo} feature check ${P} -i ${xid}`)
-    assert.ok(p.stdout.includes('InternalStopCodonCheck'))
+    assert.ok(p.stdout.includes('InternalStopCodon'))
   })
 
   void globalThis.itName('User', () => {

--- a/packages/apollo-common/src/Check.ts
+++ b/packages/apollo-common/src/Check.ts
@@ -6,6 +6,7 @@ import {
 export abstract class Check {
   abstract name: string
   abstract version: number
+  abstract causes: string[]
 
   abstract checkFeature(
     feature: AnnotationFeatureSnapshot,

--- a/packages/apollo-mst/src/CheckResult.ts
+++ b/packages/apollo-mst/src/CheckResult.ts
@@ -5,6 +5,7 @@ import { AnnotationFeatureModel } from './AnnotationFeatureModel'
 export const CheckResult = types.model('CheckResult', {
   _id: types.identifier,
   name: types.string,
+  cause: types.string,
   ids: types.array(types.safeReference(AnnotationFeatureModel)),
   refSeq: types.string,
   start: types.number,

--- a/packages/apollo-schemas/src/check.schema.ts
+++ b/packages/apollo-schemas/src/check.schema.ts
@@ -15,6 +15,9 @@ export class Check {
   name: string
 
   @Prop()
+  causes: string[]
+
+  @Prop()
   default: boolean
 
   @Prop()

--- a/packages/apollo-schemas/src/checkResult.schema.ts
+++ b/packages/apollo-schemas/src/checkResult.schema.ts
@@ -14,6 +14,9 @@ export class CheckResult
   @Prop()
   name: string
 
+  @Prop()
+  cause: string
+
   @Prop({ type: [MongooseSchema.Types.ObjectId], required: true, index: true })
   ids: Types.ObjectId[]
 

--- a/packages/apollo-shared/src/Checks/CDSCheck.ts
+++ b/packages/apollo-shared/src/Checks/CDSCheck.ts
@@ -12,6 +12,14 @@ enum STOP_CODONS {
   'TGA',
 }
 
+const CHECK_NAME = 'CDSCheck'
+
+enum CAUSES {
+  'MissingStopCodon',
+  'MultipleOfThree',
+  'InternalStopCodon',
+}
+
 const iupacComplements: Record<string, string | undefined> = {
   G: 'C',
   A: 'T',
@@ -119,7 +127,8 @@ async function checkMRNA(
       if (lastCodon && !(lastCodon.toUpperCase() in STOP_CODONS)) {
         checkResults.push({
           _id: new ObjectID().toHexString(),
-          name: 'MissingStopCodonCheck',
+          name: CHECK_NAME,
+          cause: CAUSES[CAUSES.MissingStopCodon],
           ids,
           refSeq: refSeq.toString(),
           start: max,
@@ -130,7 +139,8 @@ async function checkMRNA(
     } else {
       checkResults.push({
         _id: new ObjectID().toHexString(),
-        name: 'MultipleOfThreeCheck',
+        name: CHECK_NAME,
+        cause: CAUSES[CAUSES.MultipleOfThree],
         ids,
         refSeq: refSeq.toString(),
         start: min,
@@ -144,7 +154,8 @@ async function checkMRNA(
         const [codonStart, codonEnd] = location
         checkResults.push({
           _id: new ObjectID().toHexString(),
-          name: 'InternalStopCodonCheck',
+          name: CHECK_NAME,
+          cause: CAUSES[CAUSES.InternalStopCodon],
           ids,
           refSeq: refSeq.toString(),
           start: codonStart,
@@ -201,8 +212,14 @@ function getCDSLocations(
   return cdsLocations
 }
 
+function getCauses(): string[] {
+  return Object.values(CAUSES).filter((x) =>
+    Number.isNaN(Number(x)),
+  ) as string[]
+}
 export class CDSCheck extends Check {
-  name = 'CDSCheck'
+  name = CHECK_NAME
+  causes = getCauses()
   version = 1
   default = true
 

--- a/packages/jbrowse-plugin-apollo/cypress/e2e/showWarnings.cy.ts
+++ b/packages/jbrowse-plugin-apollo/cypress/e2e/showWarnings.cy.ts
@@ -5,7 +5,7 @@ describe('Warning signs', () => {
   afterEach(() => {
     cy.deleteAssemblies()
   })
-  it('FIXME Show warnings', () => {
+  it('Show warnings', () => {
     cy.addAssemblyFromGff(
       'stopcodon.gff3',
       'test_data/cdsChecks/stopcodon.gff3',
@@ -30,10 +30,9 @@ describe('Warning signs', () => {
       })
     cy.get('button[data-testid="zoom_out"]').click()
 
-    // FIXME: There should be 2 ErrorIcons not 3
     cy.get('[data-testid="ErrorIcon"]', { timeout: 5000 }).should(
       'have.length',
-      3,
+      2,
     )
     cy.get('[data-testid="ErrorIcon"]', { timeout: 5000 })
       .last()
@@ -49,10 +48,9 @@ describe('Warning signs', () => {
     cy.get('button[data-testid="zoom_out"]').click()
     cy.reload()
 
-    // FIXME: There should be 1 error icon not 4
     cy.get('[data-testid="ErrorIcon"]', { timeout: 5000 }).should(
       'have.length',
-      4,
+      1,
     )
   })
 })


### PR DESCRIPTION
The problem is a mismatch between `name` in CheckResult.ts and `name` in Check.ts. In CheckResult.ts name is (was) something like "InternalStopCodonCheck", but in Check.ts it is something like "CDSCheck". So when calling `clearChecksForFeature` in check.service.ts, the query returns nothing because 'CDSCheck' != 'InternalStopCodonCheck'.

This fix sets `name = "CDSCheck"` in class CDSCheck and adds a property `cause` to CheckResult to store the cause of the failing check, e.g cause = InternalStopCodonCheck. Also add property `causes` to class `Check` to enumerate all the possible causes for the fail.

Note test in test.ts to be fixed: FIXME: Checks stay after invalid operation