### PR TITLE
Fix #548 by setting mouse bp to be 0-based coordinate

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
@@ -691,9 +691,10 @@ function getDraggableFeatureInfo(
     }
 
     const overlappingExon = exonChildren.find((child) => {
-      const [start, end] = intersection2(bp, bp + 1, child.min, child.max)
+      const [start, end] = intersection2(bp - 1, bp, child.min, child.max)
       return start !== undefined && end !== undefined
     })
+
     if (!overlappingExon) {
       return
     }


### PR DESCRIPTION
It appears to be an off-by-one error. Mouse bp has 1-based coordinates but in intersect2 you need 0-based.