### PR TITLE
Add open transcript details option on right click of child feature

### DIFF
--- a/packages/apollo-mst/src/AnnotationFeatureModel.ts
+++ b/packages/apollo-mst/src/AnnotationFeatureModel.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
 import { getSession, intersection2 } from '@jbrowse/core/util'
 import {
   type IAnyModelType,
@@ -127,14 +130,14 @@ export const AnnotationFeatureModel = types
       return false
     },
     get transcriptExonParts(): TranscriptParts {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const session = getSession(self) as any
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const { apolloDataStore } = session
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       const { featureTypeOntology } = apolloDataStore.ontologyManager
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-      if (!featureTypeOntology.isTypeOf(self.type, 'transcript')) {
+      if (
+        !featureTypeOntology.isTypeOf(self.type, 'transcript') &&
+        !featureTypeOntology.isTypeOf(self.type, 'pseudogenic_transcript')
+      ) {
         throw new Error(
           'Feature is not a transcript or equivalent, cannot calculate exon locations',
         )
@@ -144,7 +147,6 @@ export const AnnotationFeatureModel = types
         throw new Error('No exons in transcript')
       }
       const sortedChildren = [...children.values()]
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
         .filter((child) => featureTypeOntology.isTypeOf(child.type, 'exon'))
         .sort((a, b) => a.min - b.min)
       let lastMax = self.min
@@ -177,14 +179,14 @@ export const AnnotationFeatureModel = types
       return parts
     },
     get transcriptParts(): TranscriptParts[] {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const session = getSession(self) as any
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const { apolloDataStore } = session
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       const { featureTypeOntology } = apolloDataStore.ontologyManager
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-      if (!featureTypeOntology.isTypeOf(self.type, 'transcript')) {
+      if (
+        !featureTypeOntology.isTypeOf(self.type, 'transcript') &&
+        !featureTypeOntology.isTypeOf(self.type, 'pseudogenic_transcript')
+      ) {
         throw new Error(
           'Only features of type "transcript" or equivalent can calculate CDS locations',
         )
@@ -193,9 +195,8 @@ export const AnnotationFeatureModel = types
       if (!children) {
         throw new Error('no CDS or exons in transcript')
       }
-      const cdsChildren = [...children.values()].filter(
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-        (child) => featureTypeOntology.isTypeOf(child.type, 'CDS'),
+      const cdsChildren = [...children.values()].filter((child) =>
+        featureTypeOntology.isTypeOf(child.type, 'CDS'),
       )
       const transcriptParts: TranscriptParts[] = []
       if (cdsChildren.length === 0) {
@@ -208,7 +209,6 @@ export const AnnotationFeatureModel = types
         let hasIntersected = false
         const exonLocations: TranscriptPartLocation[] = []
         for (const [, child] of children) {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
           if (featureTypeOntology.isTypeOf(child.type, 'exon')) {
             exonLocations.push({ min: child.min, max: child.max })
           }
@@ -292,11 +292,9 @@ export const AnnotationFeatureModel = types
       )
     },
     get looksLikeGene(): boolean {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const session = getSession(self) as any
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const { apolloDataStore } = session
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       const { featureTypeOntology } = apolloDataStore.ontologyManager
       if (!featureTypeOntology) {
         return false
@@ -305,20 +303,15 @@ export const AnnotationFeatureModel = types
       if (!children?.size) {
         return false
       }
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const isGene =
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
         featureTypeOntology.isTypeOf(self.type, 'gene') ||
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
         featureTypeOntology.isTypeOf(self.type, 'pseudogene')
       if (!isGene) {
         return false
       }
       for (const [, child] of children) {
         if (
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
           featureTypeOntology.isTypeOf(child.type, 'transcript') ||
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
           featureTypeOntology.isTypeOf(child.type, 'pseudogenic_transcript')
         ) {
           const { children: grandChildren } = child
@@ -326,7 +319,6 @@ export const AnnotationFeatureModel = types
             return false
           }
           return [...grandChildren.values()].some((grandchild) =>
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
             featureTypeOntology.isTypeOf(grandchild.type, 'exon'),
           )
         }

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptWidgetEditLocation.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptWidgetEditLocation.tsx
@@ -123,7 +123,10 @@ export const TranscriptWidgetEditLocation = observer(
         featureTypeOntology: OntologyRecord
       }
 
-    if (!featureTypeOntology.isTypeOf(feature.type, 'transcript')) {
+    if (
+      !featureTypeOntology.isTypeOf(feature.type, 'transcript') &&
+      !featureTypeOntology.isTypeOf(feature.type, 'pseudogenic_transcript')
+    ) {
       throw new Error('Feature is not a transcript or equivalent')
     }
 

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
@@ -1,13 +1,9 @@
 import { type AnnotationFeature } from '@apollo-annotation/mst'
 import { type MenuItem } from '@jbrowse/core/ui'
-import {
-  type AbstractSessionModel,
-  isSessionModelWithWidgets,
-} from '@jbrowse/core/util'
+import { type AbstractSessionModel } from '@jbrowse/core/util'
 import { type Theme, alpha } from '@mui/material'
 
 import { AddChildFeature, CopyFeature, DeleteFeature } from '../../components'
-import { type ApolloSessionModel } from '../../session'
 import { type LinearApolloDisplay } from '../stateModel'
 import {
   type LinearApolloDisplayMouseEvents,
@@ -243,34 +239,6 @@ function getTextColor(theme: Theme | undefined, selected: boolean) {
     : theme?.palette.text.primary ?? 'black'
 }
 
-function isTranscriptFeature(
-  feature: AnnotationFeature,
-  session: ApolloSessionModel,
-): boolean {
-  const { featureTypeOntology } = session.apolloDataStore.ontologyManager
-  if (!featureTypeOntology) {
-    throw new Error('featureTypeOntology is undefined')
-  }
-  return (
-    featureTypeOntology.isTypeOf(feature.type, 'transcript') ||
-    featureTypeOntology.isTypeOf(feature.type, 'pseudogenic_transcript')
-  )
-}
-
-function isCdsOrExonFeature(
-  feature: AnnotationFeature,
-  session: ApolloSessionModel,
-): boolean {
-  const { featureTypeOntology } = session.apolloDataStore.ontologyManager
-  if (!featureTypeOntology) {
-    throw new Error('featureTypeOntology is undefined')
-  }
-  return (
-    featureTypeOntology.isTypeOf(feature.type, 'CDS') ||
-    featureTypeOntology.isTypeOf(feature.type, 'exon')
-  )
-}
-
 export function drawBox(
   ctx: CanvasRenderingContext2D,
   x: number,
@@ -407,34 +375,6 @@ function getContextMenuItemsForFeature(
       },
     },
   )
-
-  if (
-    isSessionModelWithWidgets(session) &&
-    (isTranscriptFeature(sourceFeature, session) ||
-      isCdsOrExonFeature(sourceFeature, session))
-  ) {
-    let transcript = sourceFeature
-    if (sourceFeature.parent && isCdsOrExonFeature(sourceFeature, session)) {
-      transcript = sourceFeature.parent
-    }
-
-    menuItems.push({
-      label: 'Open transcript details',
-      onClick: () => {
-        const apolloTranscriptWidget = session.addWidget(
-          'ApolloTranscriptDetails',
-          'apolloTranscriptDetails',
-          {
-            feature: transcript,
-            assembly: currentAssemblyId,
-            changeManager,
-            refName: region.refName,
-          },
-        )
-        session.showWidget(apolloTranscriptWidget)
-      },
-    })
-  }
   return menuItems
 }
 

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
@@ -4,12 +4,14 @@ import {
   type AbstractSessionModel,
   getFrame,
   intersection2,
+  isSessionModelWithWidgets,
 } from '@jbrowse/core/util'
 import { type LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
 import { alpha } from '@mui/material'
 
 import { type OntologyRecord } from '../../OntologyManager'
 import { MergeExons, SplitExon } from '../../components'
+import { type ApolloSessionModel } from '../../session'
 import { getFeaturesUnderClick } from '../../util/annotationFeatureUtils'
 import { type LinearApolloDisplay } from '../stateModel'
 import {
@@ -808,6 +810,31 @@ function getDraggableFeatureInfo(
   return
 }
 
+function isTranscriptFeature(
+  feature: AnnotationFeature,
+  session: ApolloSessionModel,
+): boolean {
+  const { featureTypeOntology } = session.apolloDataStore.ontologyManager
+  if (!featureTypeOntology) {
+    throw new Error('featureTypeOntology is undefined')
+  }
+  return (
+    featureTypeOntology.isTypeOf(feature.type, 'transcript') ||
+    featureTypeOntology.isTypeOf(feature.type, 'pseudogenic_transcript')
+  )
+}
+
+function isExonFeature(
+  feature: AnnotationFeature,
+  session: ApolloSessionModel,
+): boolean {
+  const { featureTypeOntology } = session.apolloDataStore.ontologyManager
+  if (!featureTypeOntology) {
+    throw new Error('featureTypeOntology is undefined')
+  }
+  return featureTypeOntology.isTypeOf(feature.type, 'exon')
+}
+
 function getContextMenuItems(
   display: LinearApolloDisplayMouseEvents,
   mousePosition: MousePositionWithFeatureAndGlyph,
@@ -828,17 +855,13 @@ function getContextMenuItems(
   if (!apolloHover) {
     return menuItems
   }
-  const { featureTypeOntology } = session.apolloDataStore.ontologyManager
-  if (!featureTypeOntology) {
-    throw new Error('featureTypeOntology is undefined')
-  }
 
   for (const feature of getFeaturesUnderClick(mousePosition)) {
     const contextMenuItemsForFeature = boxGlyph.getContextMenuItemsForFeature(
       display,
       feature,
     )
-    if (featureTypeOntology.isTypeOf(feature.type, 'exon')) {
+    if (isExonFeature(feature, session)) {
       contextMenuItemsForFeature.push(
         {
           label: 'Merge exons',
@@ -889,6 +912,27 @@ function getContextMenuItems(
           },
         },
       )
+    }
+    if (
+      isTranscriptFeature(feature, session) &&
+      isSessionModelWithWidgets(session)
+    ) {
+      contextMenuItemsForFeature.push({
+        label: 'Open transcript details',
+        onClick: () => {
+          const apolloTranscriptWidget = session.addWidget(
+            'ApolloTranscriptDetails',
+            'apolloTranscriptDetails',
+            {
+              feature,
+              assembly: currentAssemblyId,
+              changeManager,
+              refName: region.refName,
+            },
+          )
+          session.showWidget(apolloTranscriptWidget)
+        },
+      })
     }
     menuItems.push({
       label: feature.type,

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
@@ -835,6 +835,17 @@ function isExonFeature(
   return featureTypeOntology.isTypeOf(feature.type, 'exon')
 }
 
+function isCDSFeature(
+  feature: AnnotationFeature,
+  session: ApolloSessionModel,
+): boolean {
+  const { featureTypeOntology } = session.apolloDataStore.ontologyManager
+  if (!featureTypeOntology) {
+    throw new Error('featureTypeOntology is undefined')
+  }
+  return featureTypeOntology.isTypeOf(feature.type, 'CDS')
+}
+
 function getContextMenuItems(
   display: LinearApolloDisplayMouseEvents,
   mousePosition: MousePositionWithFeatureAndGlyph,
@@ -856,7 +867,12 @@ function getContextMenuItems(
     return menuItems
   }
 
-  for (const feature of getFeaturesUnderClick(mousePosition)) {
+  let featuresUnderClick = getFeaturesUnderClick(mousePosition)
+  if (isCDSFeature(mousePosition.featureAndGlyphUnderMouse.feature, session)) {
+    featuresUnderClick = getFeaturesUnderClick(mousePosition, true)
+  }
+
+  for (const feature of featuresUnderClick) {
     const contextMenuItemsForFeature = boxGlyph.getContextMenuItemsForFeature(
       display,
       feature,

--- a/packages/jbrowse-plugin-apollo/src/util/annotationFeatureUtils.ts
+++ b/packages/jbrowse-plugin-apollo/src/util/annotationFeatureUtils.ts
@@ -77,6 +77,7 @@ function getParents(feature: AnnotationFeature): AnnotationFeature[] {
 
 export function getFeaturesUnderClick(
   mousePosition: MousePosition,
+  includeSiblings = false,
 ): AnnotationFeature[] {
   const clickedFeatures: AnnotationFeature[] = []
   if (!mousePosition.featureAndGlyphUnderMouse) {
@@ -92,6 +93,9 @@ export function getFeaturesUnderClick(
     if (child.min < bp && child.max >= bp) {
       clickedFeatures.push(child)
     }
+  }
+  if (!includeSiblings) {
+    return clickedFeatures
   }
 
   // Also add siblings , i.e. features having the same parent as the clicked


### PR DESCRIPTION
When the transcript contain single exon thats the whole length of the transcript then we cannot open transcript details widget. This PR adds "Open transcript details" menu option when we right click on transcript or any of its child features.