### PR TITLE
Fix:Update CDS locations for translation trim without validation

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptSequence.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptSequence.tsx
@@ -112,12 +112,11 @@ function getSequenceSegments(
       const [firstLocation] = cdsLocations
       const locs: { min: number; max: number }[] = []
       for (const loc of firstLocation) {
-        let sequence = getSequence(loc.min, loc.max)
-        if (strand === -1) {
-          sequence = revcom(sequence)
-        }
-        wholeSequence += sequence
+        wholeSequence += getSequence(loc.min, loc.max)
         locs.push({ min: loc.min, max: loc.max })
+      }
+      if (strand === -1) {
+        wholeSequence = revcom(wholeSequence)
       }
       const sequenceLines = splitStringIntoChunks(
         wholeSequence,
@@ -131,12 +130,11 @@ function getSequenceSegments(
       const [firstLocation] = cdsLocations
       const locs: { min: number; max: number }[] = []
       for (const loc of firstLocation) {
-        let sequence = getSequence(loc.min, loc.max)
-        if (strand === -1) {
-          sequence = revcom(sequence)
-        }
-        wholeSequence += sequence
+        wholeSequence += getSequence(loc.min, loc.max)
         locs.push({ min: loc.min, max: loc.max })
+      }
+      if (strand === -1) {
+        wholeSequence = revcom(wholeSequence)
       }
       let protein = ''
       for (let i = 0; i < wholeSequence.length; i += 3) {

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptWidgetEditLocation.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptWidgetEditLocation.tsx
@@ -1157,34 +1157,75 @@ export const TranscriptWidgetEditLocation = observer(
               style={{ textAlign: 'center', marginTop: 10 }}
             >
               <Grid2 size={1} />
-              <Grid2 size={4}>
-                <StyledTextField
-                  margin="dense"
-                  variant="outlined"
-                  value={cdsMin + 1}
-                  onChangeCommitted={(newLocation: number) => {
-                    handleCDSLocationChange(
-                      cdsMin,
-                      newLocation - 1,
-                      feature,
-                      true,
-                    )
-                  }}
-                />
-              </Grid2>
+              {strand === 1 ? (
+                <Grid2 size={4}>
+                  <StyledTextField
+                    margin="dense"
+                    variant="outlined"
+                    value={cdsMin + 1}
+                    onChangeCommitted={(newLocation: number) => {
+                      handleCDSLocationChange(
+                        cdsMin,
+                        newLocation - 1,
+                        feature,
+                        true,
+                      )
+                    }}
+                  />
+                </Grid2>
+              ) : (
+                <Grid2 size={4}>
+                  <StyledTextField
+                    margin="dense"
+                    variant="outlined"
+                    value={cdsMax}
+                    onChangeCommitted={(newLocation: number) => {
+                      handleCDSLocationChange(
+                        cdsMax,
+                        newLocation,
+                        feature,
+                        false,
+                      )
+                    }}
+                  />
+                </Grid2>
+              )}
               <Grid2 size={2}>
                 <Typography component={'span'}>CDS</Typography>
               </Grid2>
-              <Grid2 size={4}>
-                <StyledTextField
-                  margin="dense"
-                  variant="outlined"
-                  value={cdsMax}
-                  onChangeCommitted={(newLocation: number) => {
-                    handleCDSLocationChange(cdsMax, newLocation, feature, false)
-                  }}
-                />
-              </Grid2>
+              {strand === 1 ? (
+                <Grid2 size={4}>
+                  <StyledTextField
+                    margin="dense"
+                    variant="outlined"
+                    value={cdsMax}
+                    onChangeCommitted={(newLocation: number) => {
+                      handleCDSLocationChange(
+                        cdsMax,
+                        newLocation,
+                        feature,
+                        false,
+                      )
+                    }}
+                  />
+                </Grid2>
+              ) : (
+                <Grid2 size={4}>
+                  <StyledTextField
+                    margin="dense"
+                    variant="outlined"
+                    value={cdsMin + 1}
+                    onChangeCommitted={(newLocation: number) => {
+                      handleCDSLocationChange(
+                        cdsMin,
+                        newLocation - 1,
+                        feature,
+                        true,
+                      )
+                    }}
+                  />
+                </Grid2>
+              )}
               <Grid2 size={1} />
             </Grid2>
           </div>

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptWidgetEditLocation.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptWidgetEditLocation.tsx
@@ -1171,6 +1171,7 @@ export const TranscriptWidgetEditLocation = observer(
                         true,
                       )
                     }}
+                    style={{ border: '1px solid black', borderRadius: 5 }}
                   />
                 </Grid2>
               ) : (
@@ -1187,6 +1188,7 @@ export const TranscriptWidgetEditLocation = observer(
                         false,
                       )
                     }}
+                    style={{ border: '1px solid black', borderRadius: 5 }}
                   />
                 </Grid2>
               )}
@@ -1207,6 +1209,7 @@ export const TranscriptWidgetEditLocation = observer(
                         false,
                       )
                     }}
+                    style={{ border: '1px solid black', borderRadius: 5 }}
                   />
                 </Grid2>
               ) : (
@@ -1223,6 +1226,7 @@ export const TranscriptWidgetEditLocation = observer(
                         true,
                       )
                     }}
+                    style={{ border: '1px solid black', borderRadius: 5 }}
                   />
                 </Grid2>
               )}
@@ -1253,39 +1257,75 @@ export const TranscriptWidgetEditLocation = observer(
                           </Typography>
                         ))}
                     </Grid2>
-                    <Grid2 size={4} style={{ padding: 0 }}>
-                      <StyledTextField
-                        margin="dense"
-                        variant="outlined"
-                        value={loc.min + 1}
-                        onChangeCommitted={(newLocation: number) => {
-                          handleExonLocationChange(
-                            loc.min,
-                            newLocation - 1,
-                            feature,
-                            true,
-                          )
-                        }}
-                      />
-                    </Grid2>
+                    {strand === 1 ? (
+                      <Grid2 size={4} style={{ padding: 0 }}>
+                        <StyledTextField
+                          margin="dense"
+                          variant="outlined"
+                          value={loc.min + 1}
+                          onChangeCommitted={(newLocation: number) => {
+                            handleExonLocationChange(
+                              loc.min,
+                              newLocation - 1,
+                              feature,
+                              true,
+                            )
+                          }}
+                        />
+                      </Grid2>
+                    ) : (
+                      <Grid2 size={4} style={{ padding: 0 }}>
+                        <StyledTextField
+                          margin="dense"
+                          variant="outlined"
+                          value={loc.max}
+                          onChangeCommitted={(newLocation: number) => {
+                            handleExonLocationChange(
+                              loc.max,
+                              newLocation,
+                              feature,
+                              false,
+                            )
+                          }}
+                        />
+                      </Grid2>
+                    )}
                     <Grid2 size={2}>
                       <Strand strand={feature.strand} />
                     </Grid2>
-                    <Grid2 size={4} style={{ padding: 0 }}>
-                      <StyledTextField
-                        margin="dense"
-                        variant="outlined"
-                        value={loc.max}
-                        onChangeCommitted={(newLocation: number) => {
-                          handleExonLocationChange(
-                            loc.max,
-                            newLocation,
-                            feature,
-                            false,
-                          )
-                        }}
-                      />
-                    </Grid2>
+                    {strand === 1 ? (
+                      <Grid2 size={4} style={{ padding: 0 }}>
+                        <StyledTextField
+                          margin="dense"
+                          variant="outlined"
+                          value={loc.max}
+                          onChangeCommitted={(newLocation: number) => {
+                            handleExonLocationChange(
+                              loc.max,
+                              newLocation,
+                              feature,
+                              false,
+                            )
+                          }}
+                        />
+                      </Grid2>
+                    ) : (
+                      <Grid2 size={4} style={{ padding: 0 }}>
+                        <StyledTextField
+                          margin="dense"
+                          variant="outlined"
+                          value={loc.min + 1}
+                          onChangeCommitted={(newLocation: number) => {
+                            handleExonLocationChange(
+                              loc.min,
+                              newLocation - 1,
+                              feature,
+                              true,
+                            )
+                          }}
+                        />
+                      </Grid2>
+                    )}
                     <Grid2 size={1}>
                       {index !== transcriptExonParts.length - 1 &&
                         getThreePrimeSpliceSite(loc, index).map((site, idx) => (

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptWidgetSummary.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptWidgetSummary.tsx
@@ -38,6 +38,10 @@ export const TranscriptWidgetSummary = observer(
             </TableRow>
           )}
           <TableRow>
+            <HeaderTableCell>Type</HeaderTableCell>
+            <TableCell>{feature.type}</TableCell>
+          </TableRow>
+          <TableRow>
             <HeaderTableCell>Location</HeaderTableCell>
             <TableCell>
               {props.refName}:{feature.min}..{feature.max}


### PR DESCRIPTION
- Update the CDS location when we perform trim operation without validations
- Close translation sequence accordion by default
- Switch cds positions