### PR TITLE
Print gff_id when reporting errors

### DIFF
--- a/packages/apollo-shared/src/Validations/ParentChildValidation.ts
+++ b/packages/apollo-shared/src/Validations/ParentChildValidation.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
+
 import { type Change } from '@apollo-annotation/common'
 import { type Feature, type FeatureDocument } from '@apollo-annotation/schemas'
 import { type ClientSession, type Model } from 'mongoose'
@@ -10,6 +10,7 @@ import {
   isLocationEndChange,
   isLocationStartChange,
 } from '../Changes'
+import { getPrintableId } from '../util'
 
 import { Validation, type ValidationResult } from './Validation'
 
@@ -80,7 +81,7 @@ export class ParentChildValidation extends Validation {
         (childFeature.max > feature.max || childFeature.min < feature.min)
       ) {
         throw new Error(
-          `Feature "${childFeature._id}" exceeds the bounds of its parent, "${feature._id}"`,
+          `Feature ${getPrintableId(childFeature)} exceeds the bounds of its parent, ${getPrintableId(feature)}`,
         )
       }
       this.checkChildFeatureBoundaries(childFeature)

--- a/packages/apollo-shared/src/util.ts
+++ b/packages/apollo-shared/src/util.ts
@@ -1,3 +1,6 @@
+import { type AnnotationFeature } from '@apollo-annotation/mst'
+import { type Feature } from '@apollo-annotation/schemas'
+
 export function splitStringIntoChunks(
   input: string,
   chunkSize: number,
@@ -8,4 +11,17 @@ export function splitStringIntoChunks(
     chunks.push(chunk)
   }
   return chunks
+}
+
+export function getPrintableId(feature: Feature): string {
+  const ff = feature as unknown as AnnotationFeature
+  const gff_id = ff.attributes.get('gff_id')?.join(',')
+  if (gff_id) {
+    return `ID=${gff_id} (_id: ${feature._id.toString()})`
+  }
+  const gff_name = ff.attributes.get('gff_name')?.join(',')
+  if (gff_name) {
+    return `Name=${gff_name} (_id: ${feature._id.toString()})`
+  }
+  return `_id: ${feature._id.toString()}`
 }


### PR DESCRIPTION
This PR edits the post-validation error message to include an identifier accessible to the user. E.g:

```
Error: submitChange failed — 422 Unprocessable Entity ({"message":"Error in backend post-validation: Error: Feature ID=exon10 (_id: 683f1a0331ebb6a40378e739) exceeds the bounds of its parent, ID=mrna05 (_id: 683f1a0331ebb6a40378e73a)","error":"Unprocessable Entity","statusCode":422})
```

![Image](https://github.com/user-attachments/assets/d7efcad1-8c16-40b8-8dac-2a993c923178)

If there is no gff_id, use gff_name, with no gff_name fall back on `_id` (`_id` is always reported).