### PR TITLE
Fix loading non-Apollo plugins from stored config

### DIFF
--- a/packages/apollo-collaboration-server/src/jbrowse/jbrowse.service.ts
+++ b/packages/apollo-collaboration-server/src/jbrowse/jbrowse.service.ts
@@ -69,6 +69,7 @@ export class JBrowseService {
           ],
         },
       },
+      ApolloPlugin: { hasRole: false },
     }
     if (role === Role.None) {
       return configuration
@@ -76,6 +77,7 @@ export class JBrowseService {
     return {
       ...configuration,
       ApolloPlugin: {
+        hasRole: true,
         ontologies: [
           {
             name: 'Sequence Ontology',

--- a/packages/apollo-shared/src/Changes/ImportJBrowseConfigChange.ts
+++ b/packages/apollo-shared/src/Changes/ImportJBrowseConfigChange.ts
@@ -26,6 +26,9 @@ interface JBrowseInternetAccount {
 
 export interface JBrowseConfig {
   assemblies?: JBrowseAssembly[]
+  configuration?: {
+    ApolloPlugin?: Record<string, unknown>
+  }
   tracks?: JBrowseTrack[]
   plugins?: JBrowsePlugin[]
   internetAccounts?: JBrowseInternetAccount[]
@@ -39,28 +42,40 @@ export interface SerializedImportJBrowseConfigChange {
 }
 
 export function filterJBrowseConfig(config: JBrowseConfig): JBrowseConfig {
-  const { __v, _id, assemblies, internetAccounts, plugins, tracks, ...rest } =
-    config
-  const filteredAssemblies = assemblies?.filter(
-    (a) => a.sequence.adapter.type !== 'ApolloSequenceAdapter',
-  )
-  const filteredTracks = tracks?.filter((t) => t.type !== 'ApolloTrack')
-  const filteredPlugins = plugins?.filter((p) => p.name !== 'Apollo')
-  const filteredInternetAccounts = internetAccounts?.filter(
-    (i) => i.type !== 'ApolloInternetAccount',
-  )
+  const {
+    __v,
+    _id,
+    assemblies,
+    configuration,
+    internetAccounts,
+    plugins,
+    tracks,
+    ...rest
+  } = config
+  // Need to make sure that configuration.ApolloPlugin.hasRole isn't set
   const filteredConfig = rest as JBrowseConfig
-  if (filteredAssemblies) {
-    filteredConfig.assemblies = filteredAssemblies
+  if (assemblies) {
+    filteredConfig.assemblies = assemblies.filter(
+      (a) => a.sequence.adapter.type !== 'ApolloSequenceAdapter',
+    )
   }
-  if (filteredTracks) {
-    filteredConfig.tracks = filteredTracks
+  if (configuration?.ApolloPlugin?.hasRole) {
+    const { hasRole, ...apolloPluginRest } = configuration.ApolloPlugin
+    filteredConfig.configuration = {
+      ...configuration,
+      ApolloPlugin: apolloPluginRest,
+    }
   }
-  if (filteredPlugins) {
-    filteredConfig.plugins = filteredPlugins
+  if (internetAccounts) {
+    filteredConfig.internetAccounts = internetAccounts.filter(
+      (i) => i.type !== 'ApolloInternetAccount',
+    )
   }
-  if (filteredInternetAccounts) {
-    filteredConfig.internetAccounts = filteredInternetAccounts
+  if (plugins) {
+    filteredConfig.plugins = plugins.filter((p) => p.name !== 'Apollo')
+  }
+  if (tracks) {
+    filteredConfig.trackss = tracks.filter((t) => t.type !== 'ApolloTrack')
   }
   return filteredConfig
 }

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
@@ -20,7 +20,10 @@ let forwardFillLight: CanvasPattern | null = null
 let backwardFillLight: CanvasPattern | null = null
 let forwardFillDark: CanvasPattern | null = null
 let backwardFillDark: CanvasPattern | null = null
-if ('document' in globalThis) {
+const canvas = globalThis.document.createElement('canvas')
+// @ts-expect-error getContext is undefined in the web worker
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+if (canvas?.getContext) {
   for (const direction of ['forward', 'backward']) {
     for (const themeMode of ['light', 'dark']) {
       const canvas = document.createElement('canvas')

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/glyphs/GeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/glyphs/GeneGlyph.ts
@@ -31,7 +31,10 @@ let forwardFillLight: CanvasPattern | null = null
 let backwardFillLight: CanvasPattern | null = null
 let forwardFillDark: CanvasPattern | null = null
 let backwardFillDark: CanvasPattern | null = null
-if ('document' in globalThis) {
+const canvas = globalThis.document.createElement('canvas')
+// @ts-expect-error getContext is undefined in the web worker
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+if (canvas?.getContext) {
   for (const direction of ['forward', 'backward']) {
     for (const themeMode of ['light', 'dark']) {
       const canvas = document.createElement('canvas')

--- a/packages/jbrowse-plugin-apollo/src/OntologyManager/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/OntologyManager/index.ts
@@ -15,6 +15,7 @@ import {
   flow,
   getRoot,
   getSnapshot,
+  isAlive,
   types,
 } from 'mobx-state-tree'
 
@@ -79,7 +80,9 @@ export const OntologyRecordType = types
       const equivalents: string[] = terms
         .map((term) => term.lbl)
         .filter((term) => term != undefined)
-      self.setEquivalentTypes(type, equivalents)
+      if (isAlive(self)) {
+        self.setEquivalentTypes(type, equivalents)
+      }
     }),
   }))
   .actions((self) => ({

--- a/packages/jbrowse-plugin-apollo/src/config.ts
+++ b/packages/jbrowse-plugin-apollo/src/config.ts
@@ -10,6 +10,11 @@ const ApolloPluginConfigurationSchema = ConfigurationSchema('ApolloPlugin', {
     type: 'string',
     defaultValue: 'Sequence Ontology',
   },
+  hasRole: {
+    description: 'Flag used internally by jbrowse-plugin-apollo',
+    type: 'boolean',
+    defaultValue: false,
+  },
 })
 
 export default ApolloPluginConfigurationSchema

--- a/packages/jbrowse-plugin-apollo/src/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/index.ts
@@ -201,21 +201,6 @@ export default class ApolloPlugin extends Plugin {
       })
     })
 
-    pluginManager.addDisplayType(() => {
-      const configSchema = linearApolloSixFrameDisplayConfigSchema
-      return new DisplayType({
-        name: 'LinearApolloSixFrameDisplay',
-        configSchema,
-        stateModel: LinearApolloSixFrameDisplayStateModelFactory(
-          pluginManager,
-          configSchema,
-        ),
-        trackType: 'ApolloTrack',
-        viewType: 'LinearGenomeView',
-        ReactComponent: LinearApolloSixFrameDisplayComponent,
-      })
-    })
-
     pluginManager.addToExtensionPoint(
       'Core-extendSession',
       // @ts-expect-error not sure how to deal with snapshot model types


### PR DESCRIPTION
Fixes #525 

Previously, any plugins in the stored JBrowse config wouldn't load when using Apollo. This fixes that by using JBrowse's new `reloadPluginManagerCallback` to reload the root model instead of calling `applySnapshot` on the root model.