### PR TITLE
Update Cypress tests to work on latest JBrowse

### DIFF
--- a/.github/workflows/cypress_debug.yml
+++ b/.github/workflows/cypress_debug.yml
@@ -28,6 +28,11 @@ jobs:
           mongodb-version: 7
           mongodb-replica-set: test-rs
 
+      - name: Start local file server
+        run:
+          yarn --cwd packages/apollo-collaboration-server/test/data/ serve
+          --listen 3131 &
+
       - name: Run tests
         run: yarn run test:e2e:debug
         working-directory: packages/jbrowse-plugin-apollo

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run Jest tests
         run: yarn test
       - name: Get latest JBrowse
-        run: yarn run jbrowse create --tag v3.3.0 .jbrowse
+        run: yarn run jbrowse create --nightly .jbrowse
         working-directory: packages/jbrowse-plugin-apollo
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.10.0

--- a/packages/jbrowse-plugin-apollo/cypress/e2e/addAssembly.cy.ts
+++ b/packages/jbrowse-plugin-apollo/cypress/e2e/addAssembly.cy.ts
@@ -30,6 +30,7 @@ describe('Add Assembly', () => {
     })
     cy.contains('added successfully', { timeout: 10_000 })
     cy.reload()
+    cy.contains('Launch view').click()
     cy.get('[data-testid="assembly-selector-textfield"]').within(() => {
       cy.contains('volvox')
     })
@@ -61,6 +62,7 @@ describe('Add Assembly', () => {
     })
     cy.contains('added successfully', { timeout: 10_000 })
     cy.reload()
+    cy.contains('Launch view').click()
     cy.get('[data-testid="assembly-selector-textfield"]').within(() => {
       cy.contains('volvox')
     })
@@ -86,6 +88,7 @@ describe('Add Assembly', () => {
     })
     cy.contains('added successfully', { timeout: 10_000 })
     cy.reload()
+    cy.contains('Launch view').click()
     cy.get('[data-testid="assembly-selector-textfield"]').within(() => {
       cy.contains('volvox')
     })
@@ -121,6 +124,7 @@ describe('Add Assembly', () => {
     })
     cy.contains('added successfully', { timeout: 10_000 })
     cy.reload()
+    cy.contains('Launch view').click()
     cy.get('[data-testid="assembly-selector-textfield"]').within(() => {
       cy.contains('volvox')
     })
@@ -144,6 +148,7 @@ describe('Add Assembly', () => {
     })
     cy.contains('added successfully', { timeout: 10_000 })
     cy.reload()
+    cy.contains('Launch view').click()
     cy.get('[data-testid="assembly-selector-textfield"]').within(() => {
       cy.contains('volvox')
     })
@@ -177,6 +182,7 @@ describe('Add Assembly', () => {
     })
     cy.contains('added successfully', { timeout: 10_000 })
     cy.reload()
+    cy.contains('Launch view').click()
     cy.get('[data-testid="assembly-selector-textfield"]').within(() => {
       cy.contains('volvox')
     })
@@ -254,6 +260,7 @@ describe('Add Assembly', () => {
     })
     cy.contains('added successfully', { timeout: 10_000 })
     cy.reload()
+    cy.contains('Launch view').click()
     cy.get('[data-testid="assembly-selector-textfield"]').within(() => {
       cy.contains('volvox')
     })
@@ -286,6 +293,7 @@ describe('Add Assembly', () => {
     })
     cy.contains('added successfully', { timeout: 10_000 })
     cy.reload()
+    cy.contains('Launch view').click()
     cy.get('[data-testid="assembly-selector-textfield"]').within(() => {
       cy.contains('volvox')
     })

--- a/packages/jbrowse-plugin-apollo/cypress/e2e/searchFeatures.cy.ts
+++ b/packages/jbrowse-plugin-apollo/cypress/e2e/searchFeatures.cy.ts
@@ -19,7 +19,7 @@ describe('Search features', () => {
 
     cy.searchFeatures('transmem', 0)
     cy.searchFeatures('transmembrane', 1)
-    cy.currentLocationEquals('ctgA', 9520, 9900, 10)
+    cy.currentLocationEquals('ctgA', 9444, 9976, 10)
     cy.searchFeatures('7-transmembrane', 1)
     cy.searchFeatures('someKeyWord', 1)
     cy.searchFeatures('mRNA', 1)
@@ -34,14 +34,14 @@ describe('Search features', () => {
     cy.addAssemblyFromGff('volvox.fasta.gff3', 'test_data/volvox.fasta.gff3')
     cy.selectAssemblyToView('volvox.fasta.gff3')
     cy.searchFeatures('Match6', 1)
-    cy.currentLocationEquals('ctgA', 8000, 9000, 10)
+    cy.currentLocationEquals('ctgA', 7800, 9200, 10)
   })
 
   it('Match is not case sensitive', () => {
     cy.addAssemblyFromGff('volvox.fasta.gff3', 'test_data/volvox.fasta.gff3')
     cy.selectAssemblyToView('volvox.fasta.gff3')
     cy.searchFeatures('match6', 1)
-    cy.currentLocationEquals('ctgA', 8000, 9000, 10)
+    cy.currentLocationEquals('ctgA', 7800, 9200, 10)
   })
 
   it('Decode URL escapes', () => {
@@ -49,26 +49,30 @@ describe('Search features', () => {
     cy.selectAssemblyToView('volvox.fasta.gff3')
     cy.searchFeatures('Some%2CNote', 0)
     cy.searchFeatures('Some,Note', 1)
-    cy.currentLocationEquals('ctgA', 1000, 2000, 10)
+    cy.currentLocationEquals('ctgA', 800, 2200, 10)
   })
 
   it('One matching parent and multiple matching children', () => {
     cy.addAssemblyFromGff('volvox.fasta.gff3', 'test_data/volvox.fasta.gff3')
     cy.selectAssemblyToView('volvox.fasta.gff3')
     cy.searchFeatures('EDEN', 1)
-    cy.currentLocationEquals('ctgA', 1050, 9000, 10)
+    cy.currentLocationEquals('ctgA', 1, 10_590, 10)
   })
 
   it('Search only the selected assembly', () => {
     cy.addAssemblyFromGff('volvox.fasta.gff3', 'test_data/volvox.fasta.gff3')
-    cy.addAssemblyFromGff('volvox2.fasta.gff3', 'test_data/volvox2.fasta.gff3')
+    cy.addAssemblyFromGff(
+      'volvox2.fasta.gff3',
+      'test_data/volvox2.fasta.gff3',
+      false,
+    )
 
     cy.selectAssemblyToView('volvox2.fasta.gff3')
     cy.searchFeatures('SpamGene', 1)
-    cy.currentLocationEquals('ctgA', 100, 200, 10)
+    cy.currentLocationEquals('ctgA', 80, 220, 10)
 
     cy.visit('/?config=http://localhost:3999/jbrowse/config.json')
-    cy.contains('Linear Genome View', { timeout: 10_000 }).click()
+    cy.contains('Launch view', { timeout: 10_000 }).click()
     cy.selectAssemblyToView('volvox.fasta.gff3')
     cy.searchFeatures('SpamGene', 0)
   })
@@ -77,7 +81,7 @@ describe('Search features', () => {
     cy.addAssemblyFromGff('volvox.fasta.gff3', 'test_data/volvox.fasta.gff3')
     cy.selectAssemblyToView('volvox.fasta.gff3')
     cy.searchFeatures('hga', 3)
-    cy.contains('td', 'ctgA:1000..2000')
+    cy.contains('td', 'ctgA:1,000..2,000')
       .parent()
       .within(() => {
         cy.contains('button', /^Go$/, { matchCase: false }).click()
@@ -88,19 +92,19 @@ describe('Search features', () => {
     cy.searchFeatures('hgb', 2)
   })
 
-  it('Can handle regex and space in attribute values', () => {
+  it.only('Can handle regex and space in attribute values', () => {
     cy.addAssemblyFromGff('space.gff3', 'test_data/space.gff3')
     cy.selectAssemblyToView('space.gff3')
     cy.searchFeatures('Ma.*1', 0)
 
     cy.searchFeatures('agt 2', 1)
-    cy.currentLocationEquals('ctgA', 1150, 7200, 10)
+    cy.currentLocationEquals('ctgA', 1, 8410, 10)
 
     cy.searchFeatures('spam"foo"eggs', 1)
-    cy.currentLocationEquals('ctgA', 1150, 7200, 10)
+    cy.currentLocationEquals('ctgA', 1, 8410, 10)
 
     cy.searchFeatures('agt B', 1)
-    cy.currentLocationEquals('ctgA', 8000, 9000, 10)
+    cy.currentLocationEquals('ctgA', 7800, 9200, 10)
 
     cy.searchFeatures('agt 1', 2)
   })

--- a/packages/jbrowse-plugin-apollo/cypress/support/commands.ts
+++ b/packages/jbrowse-plugin-apollo/cypress/support/commands.ts
@@ -2,7 +2,6 @@ import { type IDBPDatabase, openDB } from 'idb'
 
 Cypress.Commands.add('loginAsGuest', () => {
   cy.visit('/?config=http://localhost:3999/jbrowse/config.json')
-  cy.contains('Linear Genome View', { timeout: 10_000 }).click()
   cy.contains('Continue as Guest', { timeout: 10_000 }).click()
   // eslint-disable-next-line cypress/no-unnecessary-waiting
   cy.wait(2000)
@@ -99,42 +98,48 @@ Cypress.Commands.add('addOntologies', () => {
   })
 })
 
-Cypress.Commands.add('addAssemblyFromGff', (assemblyName, fin) => {
-  cy.get('button[data-testid="dropDownMenuButton"]', { timeout: 10_000 })
-    .contains('Apollo')
-    .click({ force: true, timeout: 10_000 })
-  cy.contains('Add Assembly', { timeout: 10_000 }).click()
-  cy.get('form[data-testid="submit-form"]').within(() => {
-    cy.get('input[type="TextField"]').type(assemblyName)
-    cy.contains('GFF3 input')
-      .parent()
-      .parent()
-      .within(() => {
-        cy.get('button').click()
-      })
-    cy.get('input[data-testid="gff3-input-file"]').selectFile(fin)
-    cy.contains('Load features from GFF3')
-      .parent()
-      .within(() => {
-        cy.get('input[type="checkbox"]').should('be.checked')
-      })
-    cy.intercept('/changes').as('changes')
-    cy.get('Button[data-testid="submit-button"]').click()
-    cy.wait('@changes').its('response.statusCode').should('match', /2../)
-  })
+Cypress.Commands.add(
+  'addAssemblyFromGff',
+  (assemblyName, fin, launch = true) => {
+    cy.get('button[data-testid="dropDownMenuButton"]', { timeout: 10_000 })
+      .contains('Apollo')
+      .click({ force: true, timeout: 10_000 })
+    cy.contains('Add Assembly', { timeout: 10_000 }).click()
+    cy.get('form[data-testid="submit-form"]').within(() => {
+      cy.get('input[type="TextField"]').type(assemblyName)
+      cy.contains('GFF3 input')
+        .parent()
+        .parent()
+        .within(() => {
+          cy.get('button').click()
+        })
+      cy.get('input[data-testid="gff3-input-file"]').selectFile(fin)
+      cy.contains('Load features from GFF3')
+        .parent()
+        .within(() => {
+          cy.get('input[type="checkbox"]').should('be.checked')
+        })
+      cy.intercept('/changes').as('changes')
+      cy.get('Button[data-testid="submit-button"]').click()
+      cy.wait('@changes').its('response.statusCode').should('match', /2../)
+    })
 
-  cy.contains('UploadAssemblyFile')
-    .parent()
-    .should('contain', 'All operations successful')
-  cy.contains('AddAssemblyAndFeaturesFromFileChange')
-    .parent()
-    .should('contain', 'All operations successful')
-  cy.get('button[aria-label="Close drawer"]', { timeout: 10_000 }).click()
-  // eslint-disable-next-line cypress/no-unnecessary-waiting
-  cy.wait(1000)
-  cy.reload()
-  cy.contains('Select assembly to view', { timeout: 10_000 })
-})
+    cy.contains('UploadAssemblyFile')
+      .parent()
+      .should('contain', 'All operations successful')
+    cy.contains('AddAssemblyAndFeaturesFromFileChange')
+      .parent()
+      .should('contain', 'All operations successful')
+    cy.get('button[aria-label="Close drawer"]', { timeout: 10_000 }).click()
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(1000)
+    cy.reload()
+    if (launch) {
+      cy.contains('Launch view').click()
+    }
+    cy.contains('Select assembly to view', { timeout: 10_000 })
+  },
+)
 
 Cypress.Commands.add('selectAssemblyToView', (assemblyName) => {
   cy.contains('Select assembly to view', { timeout: 10_000 })

--- a/packages/jbrowse-plugin-apollo/cypress/support/index.d.ts
+++ b/packages/jbrowse-plugin-apollo/cypress/support/index.d.ts
@@ -5,7 +5,11 @@ declare namespace Cypress {
     addOntologies(): Chainable<void>
     loginAsGuest(): Chainable<void>
     deleteAssemblies(): Chainable<void>
-    addAssemblyFromGff(assemblyName: string, fin: string): Chainable<void>
+    addAssemblyFromGff(
+      assemblyName: string,
+      fin: string,
+      launch?: boolean,
+    ): Chainable<void>
     selectAssemblyToView(assemblyName: string): Chainable<void>
     searchFeatures(query: string, expectedNumOfHits: number): Chainable<void>
     currentLocationEquals(


### PR DESCRIPTION
The latest releases of JBrowse have a couple changes that made it so our Cypress tests needed to be updated. Mainly:

- Start screen was removed
- When navigating to search results, there is now a padding area around them