### PR TITLE
split docker build action by platform arch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,14 +20,15 @@ on:
 jobs:
   build-and-push-docker:
     name: Build and push Docker image
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        runner:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
     steps:
       - name: Check out
         uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - name: Log in to the GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -37,7 +38,6 @@ jobs:
       - name: Build and push Apollo CLI image
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/arm64/v8,linux/amd64
           push: true
           tags: ghcr.io/gmod/apollo-cli:${{ inputs.tag }}
           file:
@@ -51,7 +51,6 @@ jobs:
       - name: Build and push Apollo collaboration server image
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/arm64/v8,linux/amd64
           push: true
           tags: ghcr.io/gmod/apollo-collaboration-server:${{ inputs.tag }}
           outputs:


### PR DESCRIPTION
Building the `aarch64` container directly on this architecture instead of cross-platform improves performances dramatically (about 3 minutes for the build, comparable to `x86_64`, instead of 50).

See an example run here (I tweaked the action to be able to run it on my fork for testing purposes): https://github.com/amorison/Apollo3/actions/runs/15873809734

Note: it would be good to have some kind of smoke test for the image before pushing it instead of building it and pushing it in one go. Is there an existing one we can easily set up as part of this PR, or should I open an issue for now?