### PR TITLE
New gene or transcript must have strand set

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/components/AddFeature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/AddFeature.tsx
@@ -120,7 +120,9 @@ export function AddFeature({
     }
 
     if (!refSeqId) {
-      setErrorMessage('Invalid refseq id')
+      setErrorMessage(
+        'Invalid refseq id. Make sure you have the Apollo annotation track open',
+      )
       return
     }
 
@@ -231,7 +233,11 @@ export function AddFeature({
   }
 
   let submitDisabled: boolean = Boolean(error) || !(start && end && type)
-  if (type === NewFeature.CUSTOM && !customType) {
+  if (
+    (type === NewFeature.CUSTOM && !customType) ||
+    (!strand && type === NewFeature.GENE_AND_SUBFEATURES) ||
+    (!strand && type === NewFeature.TRANSCRIPT_AND_SUBFEATURES)
+  ) {
     submitDisabled = true
   }
 


### PR DESCRIPTION
The dialog box for "Add new feature" requires strand to be + or - for options "Add gene ..." and "Add transcript..." so to avoid unreasonable unstranded genes. 

Option "Add feature with a sequence ontology type" still allows unstranded features.

![image](https://github.com/user-attachments/assets/76e67a7f-60ab-4aaf-80dc-38ea41747ce5)


Also address #617