### PR TITLE
Add option in UI to download GFF without FASTA

### DIFF
--- a/packages/jbrowse-plugin-apollo/cypress/e2e/downloadGff.cy.ts
+++ b/packages/jbrowse-plugin-apollo/cypress/e2e/downloadGff.cy.ts
@@ -12,7 +12,7 @@ describe('Download GFF', () => {
     cy.deleteAssemblies()
   })
 
-  it('Can download gff', () => {
+  it('Can download gff with fasta', () => {
     cy.addAssemblyFromGff('volvox.fasta.gff3', 'test_data/volvox.fasta.gff3')
     cy.get('button[data-testid="dropDownMenuButton"]')
       .contains('Apollo')
@@ -22,7 +22,39 @@ describe('Download GFF', () => {
       .contains('Select assembly')
       .parent()
       .within(() => {
-        cy.get('input').parent().click()
+        cy.get('input').parent().first().click()
+      })
+    cy.get('li').contains('volvox.fasta.gff3').click()
+    cy.get('label[data-testid="include-fasta-checkbox"]').within(() => {
+      cy.get('input').click()
+    })
+    cy.get('button').contains('Download').click()
+
+    // We don't know when the download is done
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(10_000)
+    cy.task('readdirSync', Cypress.config('downloadsFolder')).then((out) => {
+      const gff = out as string
+      cy.readFile(`${Cypress.config('downloadsFolder')}/${gff[0]}`).then(
+        (x: string) => {
+          const lines: string[] = x.trim().split('\n')
+          expect(lines.length).eq(962)
+        },
+      )
+    })
+  })
+
+  it.skip('Can download gff without fasta', () => {
+    cy.addAssemblyFromGff('volvox.fasta.gff3', 'test_data/volvox.fasta.gff3')
+    cy.get('button[data-testid="dropDownMenuButton"]')
+      .contains('Apollo')
+      .click()
+    cy.contains('Download GFF3').click()
+    cy.focused()
+      .contains('Select assembly')
+      .parent()
+      .within(() => {
+        cy.get('input').parent().first().click()
       })
     cy.get('li').contains('volvox.fasta.gff3').click()
     cy.get('button').contains('Download').click()
@@ -35,7 +67,7 @@ describe('Download GFF', () => {
       cy.readFile(`${Cypress.config('downloadsFolder')}/${gff[0]}`).then(
         (x: string) => {
           const lines: string[] = x.trim().split('\n')
-          expect(lines.length).eq(962)
+          expect(lines.length).eq(257)
         },
       )
     })

--- a/packages/jbrowse-plugin-apollo/cypress/e2e/downloadGff.cy.ts
+++ b/packages/jbrowse-plugin-apollo/cypress/e2e/downloadGff.cy.ts
@@ -44,7 +44,7 @@ describe('Download GFF', () => {
     })
   })
 
-  it.skip('Can download gff without fasta', () => {
+  it('Can download gff without fasta', () => {
     cy.addAssemblyFromGff('volvox.fasta.gff3', 'test_data/volvox.fasta.gff3')
     cy.get('button[data-testid="dropDownMenuButton"]')
       .contains('Apollo')

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
@@ -284,6 +284,7 @@ function getContextMenuItems(
     throw new Error('featureTypeOntology is undefined')
   }
 
+  // Add only relevant options
   menuItems.push(
     {
       label: 'Add child feature',

--- a/packages/jbrowse-plugin-apollo/src/components/DownloadGFF3.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/DownloadGFF3.tsx
@@ -10,9 +10,12 @@ import { type Assembly } from '@jbrowse/core/assemblyManager/assembly'
 import { getConf } from '@jbrowse/core/configuration'
 import {
   Button,
+  Checkbox,
   DialogActions,
   DialogContent,
   DialogContentText,
+  FormControlLabel,
+  FormGroup,
   MenuItem,
   Select,
   type SelectChangeEvent,
@@ -37,6 +40,7 @@ interface DownloadGFF3Props {
 }
 
 export function DownloadGFF3({ handleClose, session }: DownloadGFF3Props) {
+  const [includeFASTA, setincludeFASTA] = useState(false)
   const [selectedAssembly, setSelectedAssembly] = useState<Assembly>()
   const [errorMessage, setErrorMessage] = useState('')
 
@@ -114,7 +118,7 @@ export function DownloadGFF3({ handleClose, session }: DownloadGFF3Props) {
     const exportURL = new URL('export', internetAccount.baseURL)
     const params: Record<string, string> = {
       exportID,
-      includeFASTA: 'true',
+      includeFASTA: includeFASTA ? 'true' : 'false',
     }
     const exportSearchParams = new URLSearchParams(params)
     exportURL.search = exportSearchParams.toString()
@@ -199,6 +203,21 @@ export function DownloadGFF3({ handleClose, session }: DownloadGFF3Props) {
           <DialogContentText>
             Select assembly to export to GFF3
           </DialogContentText>
+
+          <FormGroup>
+            <FormControlLabel
+              data-testid="include-fasta-checkbox"
+              control={
+                <Checkbox
+                  checked={includeFASTA}
+                  onChange={() => {
+                    setincludeFASTA(!includeFASTA)
+                  }}
+                />
+              }
+              label="Include fasta sequence in GFF output"
+            />
+          </FormGroup>
         </DialogContent>
         <DialogActions>
           <Button


### PR DESCRIPTION
In "Export GFF", make the export of fasta sequence optional

![image](https://github.com/user-attachments/assets/5f4a21f4-adad-42a4-85b2-8659058e21a5)
