### PR TITLE
Fix copy to clipboard not working in some contexts

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptSequence.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptSequence.tsx
@@ -13,6 +13,7 @@ import { observer } from 'mobx-react'
 import React, { useEffect, useRef, useState } from 'react'
 
 import { type ApolloSessionModel } from '../session'
+import { copyToClipboard } from '../util/copyToClipboard'
 
 const SEQUENCE_WRAP_LENGTH = 60
 
@@ -275,19 +276,12 @@ export const TranscriptSequence = observer(function TranscriptSequence({
     setLocationIntervals(locIntervals)
   }
 
-  // Function to copy text to clipboard
-  const copyToClipboard = () => {
+  const onCopyClick = () => {
     const seqDiv = seqRef.current
     if (!seqDiv) {
       return
     }
-    const textBlob = new Blob([seqDiv.outerText], { type: 'text/plain' })
-    const htmlBlob = new Blob([seqDiv.outerHTML], { type: 'text/html' })
-    const clipboardItem = new ClipboardItem({
-      [textBlob.type]: textBlob,
-      [htmlBlob.type]: htmlBlob,
-    })
-    void navigator.clipboard.write([clipboardItem])
+    void copyToClipboard(seqDiv)
   }
 
   return (
@@ -306,7 +300,7 @@ export const TranscriptSequence = observer(function TranscriptSequence({
       </Select>
       <Button
         variant="contained"
-        onClick={copyToClipboard}
+        onClick={onCopyClick}
         style={{ marginLeft: 10 }}
         size="medium"
       >

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptWidgetEditLocation.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptWidgetEditLocation.tsx
@@ -34,6 +34,7 @@ import React, { useRef } from 'react'
 
 import { type OntologyRecord } from '../OntologyManager'
 import { type ApolloSessionModel } from '../session'
+import { copyToClipboard } from '../util/copyToClipboard'
 
 import { StyledAccordionSummary } from './ApolloTranscriptDetailsWidget'
 import { NumberTextField } from './NumberTextField'
@@ -1092,18 +1093,12 @@ export const TranscriptWidgetEditLocation = observer(
       }
     }
 
-    const copyToClipboard = () => {
+    const onCopyClick = () => {
       const seqDiv = seqRef.current
       if (!seqDiv) {
         return
       }
-      const textBlob = new Blob([seqDiv.outerText], { type: 'text/plain' })
-      const htmlBlob = new Blob([seqDiv.outerHTML], { type: 'text/html' })
-      const clipboardItem = new ClipboardItem({
-        [textBlob.type]: textBlob,
-        [htmlBlob.type]: htmlBlob,
-      })
-      void navigator.clipboard.write([clipboardItem])
+      void copyToClipboard(seqDiv)
     }
 
     return (
@@ -1142,7 +1137,7 @@ export const TranscriptWidgetEditLocation = observer(
                   <Tooltip title="Copy">
                     <ContentCopyIcon
                       style={{ fontSize: 15, cursor: 'pointer' }}
-                      onClick={copyToClipboard}
+                      onClick={onCopyClick}
                     />
                   </Tooltip>
                   <Tooltip title="Trim">

--- a/packages/jbrowse-plugin-apollo/src/util/copyToClipboard.ts
+++ b/packages/jbrowse-plugin-apollo/src/util/copyToClipboard.ts
@@ -1,0 +1,21 @@
+export async function copyToClipboard(element: HTMLElement) {
+  if (isSecureContext) {
+    const textBlob = new Blob([element.outerText], { type: 'text/plain' })
+    const htmlBlob = new Blob([element.outerHTML], { type: 'text/html' })
+    const clipboardItem = new ClipboardItem({
+      [textBlob.type]: textBlob,
+      [htmlBlob.type]: htmlBlob,
+    })
+    return navigator.clipboard.write([clipboardItem])
+  }
+  const copyCallback = (event: ClipboardEvent) => {
+    event.clipboardData?.setData('text/plain', element.outerText)
+    event.clipboardData?.setData('text/html', element.outerHTML)
+    event.preventDefault()
+  }
+  document.addEventListener('copy', copyCallback)
+  // fall back to deprecated only in non-secure contexts
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  document.execCommand('copy')
+  document.removeEventListener('copy', copyCallback)
+}


### PR DESCRIPTION
If the browsing context is not secure (not HTTPS or localhost), `ClipboardItem` isn't available. This falls back to `document.execCommand('copy')` in that case, which is technically deprecated but still available in all browsers and widely used.