### PR TITLE
Fix protein translation in sequence panel

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptWidgetEditLocation.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptWidgetEditLocation.tsx
@@ -141,7 +141,7 @@ export const TranscriptWidgetEditLocation = observer(
     const cdsPresent = firstCDSLocation.length > 0
 
     if (cdsPresent) {
-      const sortedCDSLocations = firstCDSLocation.sort(
+      const sortedCDSLocations = firstCDSLocation.toSorted(
         ({ min: a }, { min: b }) => a - b,
       )
       cdsMin = sortedCDSLocations[0].min
@@ -863,7 +863,10 @@ export const TranscriptWidgetEditLocation = observer(
     const getTranslationSequence = () => {
       let wholeSequence = ''
       const [firstLocation] = cdsLocations
-      for (const loc of firstLocation) {
+      const sortedCDSLocations = firstLocation.toSorted(
+        ({ min: a }, { min: b }) => a - b,
+      )
+      for (const loc of sortedCDSLocations) {
         wholeSequence += refData.getSequence(loc.min, loc.max)
       }
       if (strand === -1) {


### PR DESCRIPTION
This changes an instance of `sort` to `toSorted` so that it doesn't mutate the original `cdlLocations` array. The mutation was breaking the protein sequence translation panel, which expects the array to be in the order promised by `AnnotationFeature`.

@shashankbrgowda It looks like another part of `TranscriptWidgetEditLocation` depended on this mutation behavior. I think I fixed it, but I'll need to have you double-check that what I did makes sense.