### PR TITLE
Add custom display to reference sequence track, don't render sequence on Apollo track

### DIFF
--- a/packages/apollo-collaboration-server/src/jbrowse/jbrowse.service.ts
+++ b/packages/apollo-collaboration-server/src/jbrowse/jbrowse.service.ts
@@ -141,6 +141,7 @@ export class JBrowseService {
           ids[refSeq.name] = (refSeq._id as Types.ObjectId).toHexString()
         })
         this.logger.debug(`generating assembly ${assemblyId}`)
+        const trackId = `sequenceConfigId-${assembly.name}`
         return {
           name: assemblyId,
           aliases:
@@ -149,7 +150,7 @@ export class JBrowseService {
               : [assembly.name],
           displayName: assembly.displayName || assembly.name,
           sequence: {
-            trackId: `sequenceConfigId-${assembly.name}`,
+            trackId,
             type: 'ReferenceSequenceTrack',
             adapter: {
               type: 'ApolloSequenceAdapter',
@@ -159,6 +160,12 @@ export class JBrowseService {
                 locationType: 'UriLocation',
               },
             },
+            displays: [
+              {
+                type: 'LinearApolloReferenceSequenceDisplay',
+                displayId: `${trackId}-LinearApolloReferenceSequenceDisplay`,
+              },
+            ],
             metadata: {
               apollo: true,
               internetAccountConfigId: this.internetAccountId,

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/LinearApolloDisplay.tsx
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/LinearApolloDisplay.tsx
@@ -36,6 +36,10 @@ const useStyles = makeStyles()((theme) => ({
     position: 'absolute',
     left: 0,
   },
+  center: {
+    display: 'flex',
+    justifyContent: 'center',
+  },
   ellipses: {
     textOverflow: 'ellipsis',
     overflow: 'hidden',
@@ -76,8 +80,6 @@ export const LinearApolloDisplay = observer(function LinearApolloDisplay(
     setCanvas,
     setCollaboratorCanvas,
     setOverlayCanvas,
-    setSeqTrackCanvas,
-    setSeqTrackOverlayCanvas,
     setTheme,
   } = model
   const { classes } = useStyles()
@@ -95,36 +97,6 @@ export const LinearApolloDisplay = observer(function LinearApolloDisplay(
   const { assemblyManager } = session as unknown as AbstractSessionModel
   return (
     <>
-      {3 / lgv.bpPerPx >= 1 ? (
-        <div
-          className={classes.canvasContainer}
-          style={{
-            width: lgv.dynamicBlocks.totalWidthPx,
-            height: lgv.bpPerPx <= 1 ? 125 : 95,
-          }}
-        >
-          <canvas
-            ref={async (node: HTMLCanvasElement) => {
-              await Promise.resolve()
-              setSeqTrackCanvas(node)
-            }}
-            width={lgv.dynamicBlocks.totalWidthPx}
-            height={lgv.bpPerPx <= 1 ? 125 : 95}
-            className={classes.canvas}
-            data-testid="seqTrackCanvas"
-          />
-          <canvas
-            ref={async (node: HTMLCanvasElement) => {
-              await Promise.resolve()
-              setSeqTrackOverlayCanvas(node)
-            }}
-            width={lgv.dynamicBlocks.totalWidthPx}
-            height={lgv.bpPerPx <= 1 ? 125 : 95}
-            className={classes.canvas}
-            data-testid="seqTrackOverlayCanvas"
-          />
-        </div>
-      ) : null}
       <div
         className={classes.canvasContainer}
         style={{
@@ -149,7 +121,11 @@ export const LinearApolloDisplay = observer(function LinearApolloDisplay(
           </div>
         ) : null}
         {message ? (
-          <Alert severity="warning" classes={{ message: classes.ellipses }}>
+          <Alert
+            severity="warning"
+            classes={{ message: classes.ellipses }}
+            slotProps={{ root: { className: classes.center } }}
+          >
             <Tooltip title={message}>
               <div>{message}</div>
             </Tooltip>

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
@@ -129,11 +129,11 @@ function drawHover(
   stateModel: LinearApolloDisplay,
   ctx: CanvasRenderingContext2D,
 ) {
-  const { apolloHover, apolloRowHeight, lgv, theme } = stateModel
-  if (!apolloHover) {
+  const { hoveredFeature, apolloRowHeight, lgv, theme } = stateModel
+  if (!hoveredFeature) {
     return
   }
-  const position = stateModel.getFeatureLayoutPosition(apolloHover)
+  const position = stateModel.getFeatureLayoutPosition(hoveredFeature)
   if (!position) {
     return
   }
@@ -141,7 +141,7 @@ function drawHover(
   const { layoutIndex, layoutRow } = position
   const displayedRegion = displayedRegions[layoutIndex]
   const { refName, reversed } = displayedRegion
-  const { length, max, min } = apolloHover
+  const { length, max, min } = hoveredFeature
   const startPx =
     (lgv.bpToPx({
       refName,
@@ -158,11 +158,11 @@ function drawTooltip(
   display: LinearApolloDisplayMouseEvents,
   context: CanvasRenderingContext2D,
 ): void {
-  const { apolloHover, apolloRowHeight, lgv, theme } = display
-  if (!apolloHover) {
+  const { hoveredFeature, apolloRowHeight, lgv, theme } = display
+  if (!hoveredFeature) {
     return
   }
-  const position = display.getFeatureLayoutPosition(apolloHover)
+  const position = display.getFeatureLayoutPosition(hoveredFeature)
   if (!position) {
     return
   }
@@ -173,7 +173,7 @@ function drawTooltip(
 
   let location = 'Loc: '
 
-  const { length, max, min } = apolloHover
+  const { length, max, min } = hoveredFeature
   location += `${min + 1}–${max}`
 
   let startPx =
@@ -185,8 +185,8 @@ function drawTooltip(
   const top = (layoutRow + featureRow) * apolloRowHeight
   const widthPx = length / bpPerPx
 
-  const featureType = `Type: ${apolloHover.type}`
-  const { attributes } = apolloHover
+  const featureType = `Type: ${hoveredFeature.type}`
+  const { attributes } = hoveredFeature
   const featureName = attributes.get('gff_name')?.find((name) => name !== '')
   const textWidth = [
     context.measureText(featureType).width,
@@ -251,11 +251,11 @@ export function drawBox(
 function getContextMenuItems(
   display: LinearApolloDisplayMouseEvents,
 ): MenuItem[] {
-  const { apolloHover } = display
-  if (!apolloHover) {
+  const { hoveredFeature } = display
+  if (!hoveredFeature) {
     return []
   }
-  return getContextMenuItemsForFeature(display, apolloHover)
+  return getContextMenuItemsForFeature(display, hoveredFeature)
 }
 
 function makeFeatureLabel(feature: AnnotationFeature) {
@@ -419,7 +419,7 @@ function onMouseMove(
 ) {
   if (isMousePositionWithFeature(mousePosition)) {
     const { feature } = mousePosition
-    stateModel.setApolloHover(feature)
+    stateModel.setHoveredFeature(feature)
     const edge = isMouseOnFeatureEdge(mousePosition, feature, stateModel)
     if (edge) {
       stateModel.setCursor('col-resize')

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
@@ -63,7 +63,7 @@ function draw(
   stateModel: LinearApolloDisplayRendering,
   displayedRegionIndex: number,
 ) {
-  const { apolloRowHeight: heightPx, lgv, session, theme } = stateModel
+  const { apolloRowHeight: heightPx, lgv, selectedFeature, theme } = stateModel
   const { bpPerPx, displayedRegions, offsetPx } = lgv
   const displayedRegion = displayedRegions[displayedRegionIndex]
   const minX =
@@ -73,11 +73,10 @@ function draw(
       regionNumber: displayedRegionIndex,
     })?.offsetPx ?? 0) - offsetPx
   const { reversed } = displayedRegion
-  const { apolloSelectedFeature } = session
   const widthPx = feature.length / bpPerPx
   const startPx = reversed ? minX - widthPx : minX
   const top = row * heightPx
-  const isSelected = isSelectedFeature(feature, apolloSelectedFeature)
+  const isSelected = isSelectedFeature(feature, selectedFeature)
   const backgroundColor = getBackgroundColor(theme, isSelected)
   const textColor = getTextColor(theme, isSelected)
   const featureBox: [number, number, number, number] = [

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
@@ -8,8 +8,8 @@ import { type LinearApolloDisplay } from '../stateModel'
 import {
   type LinearApolloDisplayMouseEvents,
   type MousePosition,
-  type MousePositionWithFeatureAndGlyph,
-  isMousePositionWithFeatureAndGlyph,
+  type MousePositionWithFeature,
+  isMousePositionWithFeature,
 } from '../stateModel/mouseEvents'
 import { type LinearApolloDisplayRendering } from '../stateModel/rendering'
 import { type CanvasMouseEvent } from '../types'
@@ -133,8 +133,7 @@ function drawHover(
   if (!apolloHover) {
     return
   }
-  const { feature } = apolloHover
-  const position = stateModel.getFeatureLayoutPosition(feature)
+  const position = stateModel.getFeatureLayoutPosition(apolloHover)
   if (!position) {
     return
   }
@@ -142,7 +141,7 @@ function drawHover(
   const { layoutIndex, layoutRow } = position
   const displayedRegion = displayedRegions[layoutIndex]
   const { refName, reversed } = displayedRegion
-  const { length, max, min } = feature
+  const { length, max, min } = apolloHover
   const startPx =
     (lgv.bpToPx({
       refName,
@@ -163,8 +162,7 @@ function drawTooltip(
   if (!apolloHover) {
     return
   }
-  const { feature } = apolloHover
-  const position = display.getFeatureLayoutPosition(feature)
+  const position = display.getFeatureLayoutPosition(apolloHover)
   if (!position) {
     return
   }
@@ -175,7 +173,7 @@ function drawTooltip(
 
   let location = 'Loc: '
 
-  const { length, max, min } = feature
+  const { length, max, min } = apolloHover
   location += `${min + 1}–${max}`
 
   let startPx =
@@ -187,8 +185,8 @@ function drawTooltip(
   const top = (layoutRow + featureRow) * apolloRowHeight
   const widthPx = length / bpPerPx
 
-  const featureType = `Type: ${feature.type}`
-  const { attributes } = feature
+  const featureType = `Type: ${apolloHover.type}`
+  const { attributes } = apolloHover
   const featureName = attributes.get('gff_name')?.find((name) => name !== '')
   const textWidth = [
     context.measureText(featureType).width,
@@ -257,8 +255,7 @@ function getContextMenuItems(
   if (!apolloHover) {
     return []
   }
-  const { feature: sourceFeature } = apolloHover
-  return getContextMenuItemsForFeature(display, sourceFeature)
+  return getContextMenuItemsForFeature(display, apolloHover)
 }
 
 function makeFeatureLabel(feature: AnnotationFeature) {
@@ -399,13 +396,12 @@ function getRowForFeature(
 
 function onMouseDown(
   stateModel: LinearApolloDisplay,
-  currentMousePosition: MousePositionWithFeatureAndGlyph,
+  currentMousePosition: MousePositionWithFeature,
   event: CanvasMouseEvent,
 ) {
-  const { featureAndGlyphUnderMouse } = currentMousePosition
+  const { feature } = currentMousePosition
   // swallow the mouseDown if we are on the edge of the feature so that we
   // don't start dragging the view if we try to drag the feature edge
-  const { feature } = featureAndGlyphUnderMouse
   const edge = isMouseOnFeatureEdge(currentMousePosition, feature, stateModel)
   if (edge) {
     event.stopPropagation()
@@ -421,10 +417,9 @@ function onMouseMove(
   stateModel: LinearApolloDisplay,
   mousePosition: MousePosition,
 ) {
-  if (isMousePositionWithFeatureAndGlyph(mousePosition)) {
-    const { featureAndGlyphUnderMouse } = mousePosition
-    stateModel.setApolloHover(featureAndGlyphUnderMouse)
-    const { feature } = featureAndGlyphUnderMouse
+  if (isMousePositionWithFeature(mousePosition)) {
+    const { feature } = mousePosition
+    stateModel.setApolloHover(feature)
     const edge = isMouseOnFeatureEdge(mousePosition, feature, stateModel)
     if (edge) {
       stateModel.setCursor('col-resize')
@@ -441,11 +436,10 @@ function onMouseUp(
   if (stateModel.apolloDragging) {
     return
   }
-  const { featureAndGlyphUnderMouse } = mousePosition
-  if (!featureAndGlyphUnderMouse) {
+  const { feature } = mousePosition
+  if (!feature) {
     return
   }
-  const { feature } = featureAndGlyphUnderMouse
   stateModel.setSelectedFeature(feature)
   stateModel.showFeatureDetailsWidget(feature)
 }

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
@@ -414,13 +414,13 @@ function drawHover(
   stateModel: LinearApolloDisplay,
   ctx: CanvasRenderingContext2D,
 ) {
-  const { apolloHover, apolloRowHeight, lgv, session, theme } = stateModel
+  const { hoveredFeature, apolloRowHeight, lgv, session, theme } = stateModel
   const { featureTypeOntology } = session.apolloDataStore.ontologyManager
 
-  if (!apolloHover) {
+  if (!hoveredFeature) {
     return
   }
-  const position = stateModel.getFeatureLayoutPosition(apolloHover)
+  const position = stateModel.getFeatureLayoutPosition(hoveredFeature)
   if (!position) {
     return
   }
@@ -428,7 +428,7 @@ function drawHover(
   const { featureRow, layoutIndex, layoutRow } = position
   const displayedRegion = displayedRegions[layoutIndex]
   const { refName, reversed } = displayedRegion
-  const { length, max, min } = apolloHover
+  const { length, max, min } = hoveredFeature
   const startPx =
     (lgv.bpToPx({
       refName,
@@ -447,7 +447,7 @@ function drawHover(
     startPx,
     top,
     widthPx,
-    apolloRowHeight * getRowCount(apolloHover, featureTypeOntology),
+    apolloRowHeight * getRowCount(hoveredFeature, featureTypeOntology),
   )
 }
 
@@ -640,7 +640,7 @@ function onMouseMove(
 ) {
   if (isMousePositionWithFeature(mousePosition)) {
     const { feature } = mousePosition
-    stateModel.setApolloHover(feature)
+    stateModel.setHoveredFeature(feature)
     const draggableFeature = getDraggableFeatureInfo(
       mousePosition,
       feature,
@@ -805,7 +805,7 @@ function getContextMenuItems(
 ): MenuItem[] {
   const {
     apolloInternetAccount: internetAccount,
-    apolloHover,
+    hoveredFeature,
     changeManager,
     regions,
     selectedFeature,
@@ -816,7 +816,7 @@ function getContextMenuItems(
   const menuItems: MenuItem[] = []
   const role = internetAccount ? internetAccount.role : 'admin'
   const admin = role === 'admin'
-  if (!apolloHover) {
+  if (!hoveredFeature) {
     return menuItems
   }
 

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
@@ -84,7 +84,7 @@ function draw(
   stateModel: LinearApolloDisplayRendering,
   displayedRegionIndex: number,
 ): void {
-  const { apolloRowHeight, lgv, session, theme } = stateModel
+  const { apolloRowHeight, lgv, selectedFeature, session, theme } = stateModel
   const { bpPerPx, displayedRegions, offsetPx } = lgv
   const displayedRegion = displayedRegions[displayedRegionIndex]
   const { refName, reversed } = displayedRegion
@@ -94,7 +94,6 @@ function draw(
   if (!children) {
     return
   }
-  const { apolloSelectedFeature } = session
   const { apolloDataStore } = session
   const { featureTypeOntology } = apolloDataStore.ontologyManager
   if (!featureTypeOntology) {
@@ -237,7 +236,7 @@ function draw(
             const frameColor = theme?.palette.framesCDS.at(frame)?.main
             const cdsColorCode = frameColor ?? 'rgb(171,71,188)'
             ctx.fillStyle =
-              apolloSelectedFeature && _id === apolloSelectedFeature._id
+              selectedFeature && _id === selectedFeature._id
                 ? 'rgb(0,0,0)'
                 : cdsColorCode
             ctx.fillRect(
@@ -308,11 +307,10 @@ function drawExon(
   forwardFill: CanvasPattern | null,
   backwardFill: CanvasPattern | null,
 ) {
-  const { apolloRowHeight, lgv, session, theme } = stateModel
+  const { apolloRowHeight, lgv, selectedFeature, theme } = stateModel
   const { bpPerPx, displayedRegions, offsetPx } = lgv
   const displayedRegion = displayedRegions[displayedRegionIndex]
   const { refName, reversed } = displayedRegion
-  const { apolloSelectedFeature } = session
 
   const minX =
     (lgv.bpToPx({
@@ -331,7 +329,7 @@ function drawExon(
   if (widthPx > 2) {
     ctx.clearRect(startPx + 1, exonTop + 1, widthPx - 2, exonHeight - 2)
     ctx.fillStyle =
-      apolloSelectedFeature && exon._id === apolloSelectedFeature._id
+      selectedFeature && exon._id === selectedFeature._id
         ? 'rgb(0,0,0)'
         : 'rgb(211,211,211)'
     ctx.fillRect(startPx + 1, exonTop + 1, widthPx - 2, exonHeight - 2)

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
@@ -17,8 +17,8 @@ import { type LinearApolloDisplay } from '../stateModel'
 import {
   type LinearApolloDisplayMouseEvents,
   type MousePosition,
-  type MousePositionWithFeatureAndGlyph,
-  isMousePositionWithFeatureAndGlyph,
+  type MousePositionWithFeature,
+  isMousePositionWithFeature,
 } from '../stateModel/mouseEvents'
 import { type LinearApolloDisplayRendering } from '../stateModel/rendering'
 import { type CanvasMouseEvent } from '../types'
@@ -420,8 +420,7 @@ function drawHover(
   if (!apolloHover) {
     return
   }
-  const { feature } = apolloHover
-  const position = stateModel.getFeatureLayoutPosition(feature)
+  const position = stateModel.getFeatureLayoutPosition(apolloHover)
   if (!position) {
     return
   }
@@ -429,7 +428,7 @@ function drawHover(
   const { featureRow, layoutIndex, layoutRow } = position
   const displayedRegion = displayedRegions[layoutIndex]
   const { refName, reversed } = displayedRegion
-  const { length, max, min } = feature
+  const { length, max, min } = apolloHover
   const startPx =
     (lgv.bpToPx({
       refName,
@@ -448,7 +447,7 @@ function drawHover(
     startPx,
     top,
     widthPx,
-    apolloRowHeight * getRowCount(feature, featureTypeOntology),
+    apolloRowHeight * getRowCount(apolloHover, featureTypeOntology),
   )
 }
 
@@ -613,13 +612,12 @@ function getRowForFeature(
 
 function onMouseDown(
   stateModel: LinearApolloDisplay,
-  currentMousePosition: MousePositionWithFeatureAndGlyph,
+  currentMousePosition: MousePositionWithFeature,
   event: CanvasMouseEvent,
 ) {
-  const { featureAndGlyphUnderMouse } = currentMousePosition
+  const { feature } = currentMousePosition
   // swallow the mouseDown if we are on the edge of the feature so that we
   // don't start dragging the view if we try to drag the feature edge
-  const { feature } = featureAndGlyphUnderMouse
   const draggableFeature = getDraggableFeatureInfo(
     currentMousePosition,
     feature,
@@ -640,10 +638,9 @@ function onMouseMove(
   stateModel: LinearApolloDisplay,
   mousePosition: MousePosition,
 ) {
-  if (isMousePositionWithFeatureAndGlyph(mousePosition)) {
-    const { featureAndGlyphUnderMouse } = mousePosition
-    stateModel.setApolloHover(featureAndGlyphUnderMouse)
-    const { feature } = featureAndGlyphUnderMouse
+  if (isMousePositionWithFeature(mousePosition)) {
+    const { feature } = mousePosition
+    stateModel.setApolloHover(feature)
     const draggableFeature = getDraggableFeatureInfo(
       mousePosition,
       feature,
@@ -664,11 +661,10 @@ function onMouseUp(
   if (stateModel.apolloDragging) {
     return
   }
-  const { featureAndGlyphUnderMouse } = mousePosition
-  if (!featureAndGlyphUnderMouse) {
+  const { feature } = mousePosition
+  if (!feature) {
     return
   }
-  const { feature } = featureAndGlyphUnderMouse
   stateModel.setSelectedFeature(feature)
   const { session } = stateModel
   const { apolloDataStore } = session
@@ -805,7 +801,7 @@ function isCDSFeature(
 
 function getContextMenuItems(
   display: LinearApolloDisplayMouseEvents,
-  mousePosition: MousePositionWithFeatureAndGlyph,
+  mousePosition: MousePositionWithFeature,
 ): MenuItem[] {
   const {
     apolloInternetAccount: internetAccount,
@@ -825,7 +821,7 @@ function getContextMenuItems(
   }
 
   let featuresUnderClick = getFeaturesUnderClick(mousePosition)
-  if (isCDSFeature(mousePosition.featureAndGlyphUnderMouse.feature, session)) {
+  if (isCDSFeature(mousePosition.feature, session)) {
     featuresUnderClick = getFeaturesUnderClick(mousePosition, true)
   }
 

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GenericChildGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GenericChildGlyph.ts
@@ -87,11 +87,11 @@ function drawHover(
   stateModel: LinearApolloDisplay,
   ctx: CanvasRenderingContext2D,
 ) {
-  const { apolloHover, apolloRowHeight, lgv } = stateModel
-  if (!apolloHover) {
+  const { hoveredFeature, apolloRowHeight, lgv } = stateModel
+  if (!hoveredFeature) {
     return
   }
-  const position = stateModel.getFeatureLayoutPosition(apolloHover)
+  const position = stateModel.getFeatureLayoutPosition(hoveredFeature)
   if (!position) {
     return
   }
@@ -99,7 +99,7 @@ function drawHover(
   const { bpPerPx, displayedRegions, offsetPx } = lgv
   const displayedRegion = displayedRegions[layoutIndex]
   const { refName, reversed } = displayedRegion
-  const { length, max, min } = apolloHover
+  const { length, max, min } = hoveredFeature
   const startPx =
     (lgv.bpToPx({
       refName,
@@ -113,7 +113,7 @@ function drawHover(
     startPx,
     top,
     widthPx,
-    apolloRowHeight * getRowCount(apolloHover),
+    apolloRowHeight * getRowCount(hoveredFeature),
   )
 }
 
@@ -143,9 +143,9 @@ function getContextMenuItems(
   display: LinearApolloDisplayMouseEvents,
   mousePosition: MousePositionWithFeature,
 ): MenuItem[] {
-  const { apolloHover, session } = display
+  const { hoveredFeature, session } = display
   const menuItems: MenuItem[] = []
-  if (!apolloHover) {
+  if (!hoveredFeature) {
     return menuItems
   }
   const { featureTypeOntology } = session.apolloDataStore.ontologyManager
@@ -157,11 +157,11 @@ function getContextMenuItems(
     mousePosition,
   )
   menuItems.push({
-    label: apolloHover.type,
+    label: hoveredFeature.type,
     subMenu: sourceFeatureMenuItems,
   })
   for (const relative of getFeaturesUnderClick(mousePosition)) {
-    if (relative._id === apolloHover._id) {
+    if (relative._id === hoveredFeature._id) {
       continue
     }
     const contextMenuItemsForFeature = boxGlyph.getContextMenuItemsForFeature(

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GenericChildGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GenericChildGlyph.ts
@@ -59,7 +59,7 @@ function drawFeature(
   stateModel: LinearApolloDisplayRendering,
   displayedRegionIndex: number,
 ) {
-  const { apolloRowHeight: heightPx, lgv, session } = stateModel
+  const { apolloRowHeight: heightPx, lgv, selectedFeature } = stateModel
   const { bpPerPx, displayedRegions, offsetPx } = lgv
   const displayedRegion = displayedRegions[displayedRegionIndex]
   const minX =
@@ -69,12 +69,11 @@ function drawFeature(
       regionNumber: displayedRegionIndex,
     })?.offsetPx ?? 0) - offsetPx
   const { reversed } = displayedRegion
-  const { apolloSelectedFeature } = session
   const widthPx = feature.length / bpPerPx
   const startPx = reversed ? minX - widthPx : minX
   const top = row * heightPx
   const rowCount = getRowCount(feature)
-  const isSelected = isSelectedFeature(feature, apolloSelectedFeature)
+  const isSelected = isSelectedFeature(feature, selectedFeature)
   const groupingColor = isSelected ? 'rgba(130,0,0,0.45)' : 'rgba(255,0,0,0.25)'
   if (rowCount > 1) {
     // draw background that encapsulates all child features

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GenericChildGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GenericChildGlyph.ts
@@ -5,7 +5,7 @@ import { getFeaturesUnderClick } from '../../util/annotationFeatureUtils'
 import { type LinearApolloDisplay } from '../stateModel'
 import {
   type LinearApolloDisplayMouseEvents,
-  type MousePositionWithFeatureAndGlyph,
+  type MousePositionWithFeature,
 } from '../stateModel/mouseEvents'
 import { type LinearApolloDisplayRendering } from '../stateModel/rendering'
 
@@ -91,8 +91,7 @@ function drawHover(
   if (!apolloHover) {
     return
   }
-  const { feature } = apolloHover
-  const position = stateModel.getFeatureLayoutPosition(feature)
+  const position = stateModel.getFeatureLayoutPosition(apolloHover)
   if (!position) {
     return
   }
@@ -100,7 +99,7 @@ function drawHover(
   const { bpPerPx, displayedRegions, offsetPx } = lgv
   const displayedRegion = displayedRegions[layoutIndex]
   const { refName, reversed } = displayedRegion
-  const { length, max, min } = feature
+  const { length, max, min } = apolloHover
   const startPx =
     (lgv.bpToPx({
       refName,
@@ -110,7 +109,12 @@ function drawHover(
   const top = (layoutRow + featureRow) * apolloRowHeight
   const widthPx = length / bpPerPx
   ctx.fillStyle = 'rgba(0,0,0,0.2)'
-  ctx.fillRect(startPx, top, widthPx, apolloRowHeight * getRowCount(feature))
+  ctx.fillRect(
+    startPx,
+    top,
+    widthPx,
+    apolloRowHeight * getRowCount(apolloHover),
+  )
 }
 
 function getFeatureFromLayout(
@@ -137,14 +141,13 @@ function getRowForFeature(
 
 function getContextMenuItems(
   display: LinearApolloDisplayMouseEvents,
-  mousePosition: MousePositionWithFeatureAndGlyph,
+  mousePosition: MousePositionWithFeature,
 ): MenuItem[] {
   const { apolloHover, session } = display
   const menuItems: MenuItem[] = []
   if (!apolloHover) {
     return menuItems
   }
-  const { feature: sourceFeature } = apolloHover
   const { featureTypeOntology } = session.apolloDataStore.ontologyManager
   if (!featureTypeOntology) {
     throw new Error('featureTypeOntology is undefined')
@@ -154,11 +157,11 @@ function getContextMenuItems(
     mousePosition,
   )
   menuItems.push({
-    label: sourceFeature.type,
+    label: apolloHover.type,
     subMenu: sourceFeatureMenuItems,
   })
   for (const relative of getFeaturesUnderClick(mousePosition)) {
-    if (relative._id === sourceFeature._id) {
+    if (relative._id === apolloHover._id) {
       continue
     }
     const contextMenuItemsForFeature = boxGlyph.getContextMenuItemsForFeature(

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
@@ -4,7 +4,7 @@ import { type MenuItem } from '@jbrowse/core/ui'
 import { type OntologyRecord } from '../../OntologyManager'
 import {
   type LinearApolloDisplayMouseEvents,
-  type MousePositionWithFeatureAndGlyph,
+  type MousePositionWithFeature,
 } from '../stateModel/mouseEvents'
 import { type LinearApolloDisplayRendering } from '../stateModel/rendering'
 import { type CanvasMouseEvent } from '../types'
@@ -49,25 +49,25 @@ export interface Glyph {
 
   onMouseDown(
     display: LinearApolloDisplayMouseEvents,
-    currentMousePosition: MousePositionWithFeatureAndGlyph,
+    currentMousePosition: MousePositionWithFeature,
     event: CanvasMouseEvent,
   ): void
 
   onMouseMove(
     display: LinearApolloDisplayMouseEvents,
-    currentMousePosition: MousePositionWithFeatureAndGlyph,
+    currentMousePosition: MousePositionWithFeature,
     event: CanvasMouseEvent,
   ): void
 
   onMouseLeave(
     display: LinearApolloDisplayMouseEvents,
-    currentMousePosition: MousePositionWithFeatureAndGlyph,
+    currentMousePosition: MousePositionWithFeature,
     event: CanvasMouseEvent,
   ): void
 
   onMouseUp(
     display: LinearApolloDisplayMouseEvents,
-    currentMousePosition: MousePositionWithFeatureAndGlyph,
+    currentMousePosition: MousePositionWithFeature,
     event: CanvasMouseEvent,
   ): void
 
@@ -83,6 +83,6 @@ export interface Glyph {
 
   getContextMenuItems(
     display: LinearApolloDisplayMouseEvents,
-    currentMousePosition: MousePositionWithFeatureAndGlyph,
+    currentMousePosition: MousePositionWithFeature,
   ): MenuItem[]
 }

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/base.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/base.ts
@@ -37,9 +37,6 @@ export function baseModelFactory(
       configuration: ConfigurationReference(configSchema),
       graphical: true,
       table: false,
-      showStartCodons: false,
-      showStopCodons: true,
-      highContrast: false,
       heightPreConfig: types.maybe(
         types.refinement(
           'displayHeight',
@@ -74,12 +71,12 @@ export function baseModelFactory(
           return self.heightPreConfig
         }
         if (self.graphical && self.table) {
-          return 500
+          return 400
         }
         if (self.graphical) {
-          return 200
+          return 100
         }
-        return 300
+        return 200
       },
       get loading() {
         return self.loadingState
@@ -176,15 +173,6 @@ export function baseModelFactory(
         self.graphical = true
         self.table = true
       },
-      toggleShowStartCodons() {
-        self.showStartCodons = !self.showStartCodons
-      },
-      toggleShowStopCodons() {
-        self.showStopCodons = !self.showStopCodons
-      },
-      toggleHighContrast() {
-        self.highContrast = !self.highContrast
-      },
       updateFilteredFeatureTypes(types: string[]) {
         self.filteredFeatureTypes = cast(types)
       },
@@ -196,13 +184,7 @@ export function baseModelFactory(
       const { filteredFeatureTypes, trackMenuItems: superTrackMenuItems } = self
       return {
         trackMenuItems() {
-          const {
-            graphical,
-            table,
-            showStartCodons,
-            showStopCodons,
-            highContrast,
-          } = self
+          const { graphical, table } = self
           return [
             ...superTrackMenuItems(),
             {
@@ -231,30 +213,6 @@ export function baseModelFactory(
                   checked: table && graphical,
                   onClick: () => {
                     self.showGraphicalAndTable()
-                  },
-                },
-                {
-                  label: 'Show start codons',
-                  type: 'checkbox',
-                  checked: showStartCodons,
-                  onClick: () => {
-                    self.toggleShowStartCodons()
-                  },
-                },
-                {
-                  label: 'Show stop codons',
-                  type: 'checkbox',
-                  checked: showStopCodons,
-                  onClick: () => {
-                    self.toggleShowStopCodons()
-                  },
-                },
-                {
-                  label: 'Use high contrast colors',
-                  type: 'checkbox',
-                  checked: highContrast,
-                  onClick: () => {
-                    self.toggleHighContrast()
                   },
                 },
               ],
@@ -341,11 +299,6 @@ export function baseModelFactory(
                     self.setLoading(false)
                   }, 1000)
                 })
-              if (self.lgv.bpPerPx <= 3) {
-                void (
-                  self.session as unknown as ApolloSessionModel
-                ).apolloDataStore.loadRefSeq(self.regions)
-              }
             },
             { name: 'LinearApolloDisplayLoadFeatures', delay: 1000 },
           ),

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/base.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/base.ts
@@ -146,6 +146,10 @@ export function baseModelFactory(
         return (self.session as unknown as ApolloSessionModel)
           .apolloSelectedFeature
       },
+      get hoveredFeature(): AnnotationFeature | undefined {
+        return (self.session as unknown as ApolloSessionModel)
+          .apolloHoveredFeature
+      },
     }))
     .actions((self) => ({
       setScrollTop(scrollTop: number) {
@@ -285,6 +289,11 @@ export function baseModelFactory(
         ;(
           self.session as unknown as ApolloSessionModel
         ).apolloSetSelectedFeature(feature)
+      },
+      setHoveredFeature(feature?: AnnotationFeature) {
+        ;(
+          self.session as unknown as ApolloSessionModel
+        ).apolloSetHoveredFeature(feature)
       },
       showFeatureDetailsWidget(
         feature: AnnotationFeature,

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/layouts.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/layouts.ts
@@ -63,10 +63,11 @@ export function layoutsModelFactory(
         return self.seenFeatures.get(id)
       },
       getGlyph(feature: AnnotationFeature) {
-        if (feature.looksLikeGene) {
+        const { topLevelFeature } = feature
+        if (topLevelFeature.looksLikeGene) {
           return geneGlyph
         }
-        if (feature.children?.size) {
+        if (topLevelFeature.children?.size) {
           return genericChildGlyph
         }
         return boxGlyph

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/mouseEvents.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/mouseEvents.ts
@@ -6,9 +6,7 @@ import {
 import type PluginManager from '@jbrowse/core/PluginManager'
 import { type AnyConfigurationSchemaType } from '@jbrowse/core/configuration/configurationSchema'
 import { type MenuItem } from '@jbrowse/core/ui'
-import { type Frame, getFrame } from '@jbrowse/core/util'
 import { type LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
-import { type Theme } from '@mui/material'
 import { autorun } from 'mobx'
 import { type Instance, addDisposer } from 'mobx-state-tree'
 import { type CSSProperties } from 'react'
@@ -47,60 +45,6 @@ function getMousePosition(
   const y = clientY - top
   const { coord: bp, index: regionNumber, refName } = lgv.pxToBp(x)
   return { x, y, refName, bp, regionNumber }
-}
-
-function getTranslationRow(frame: Frame, bpPerPx: number) {
-  const offset = bpPerPx <= 1 ? 2 : 0
-  switch (frame) {
-    case 3: {
-      return 0
-    }
-    case 2: {
-      return 1
-    }
-    case 1: {
-      return 2
-    }
-    case -1: {
-      return 3 + offset
-    }
-    case -2: {
-      return 4 + offset
-    }
-    case -3: {
-      return 5 + offset
-    }
-  }
-}
-
-function getSeqRow(
-  strand: 1 | -1 | undefined,
-  bpPerPx: number,
-): number | undefined {
-  if (bpPerPx > 1 || strand === undefined) {
-    return
-  }
-  return strand === 1 ? 3 : 4
-}
-
-function highlightSeq(
-  seqTrackOverlayctx: CanvasRenderingContext2D,
-  theme: Theme | undefined,
-  startPx: number,
-  sequenceRowHeight: number,
-  row: number | undefined,
-  widthPx: number,
-) {
-  if (row !== undefined) {
-    seqTrackOverlayctx.fillStyle =
-      theme?.palette.action.focus ?? 'rgba(0,0,0,0.04)'
-    seqTrackOverlayctx.fillRect(
-      startPx,
-      sequenceRowHeight * row,
-      widthPx,
-      sequenceRowHeight,
-    )
-  }
 }
 
 export function mouseEventsModelIntermediateFactory(
@@ -199,135 +143,11 @@ export function mouseEventsModelIntermediateFactory(
     }))
 }
 
-export function mouseEventsSeqHightlightModelFactory(
-  pluginManager: PluginManager,
-  configSchema: AnyConfigurationSchemaType,
-) {
-  const LinearApolloDisplayRendering = mouseEventsModelIntermediateFactory(
-    pluginManager,
-    configSchema,
-  )
-
-  return LinearApolloDisplayRendering.actions((self) => ({
-    afterAttach() {
-      addDisposer(
-        self,
-        autorun(
-          () => {
-            // This type is wrong in @jbrowse/core
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-            if (!self.lgv.initialized || self.regionCannotBeRendered()) {
-              return
-            }
-            const seqTrackOverlayctx =
-              self.seqTrackOverlayCanvas?.getContext('2d')
-            if (!seqTrackOverlayctx) {
-              return
-            }
-
-            seqTrackOverlayctx.clearRect(
-              0,
-              0,
-              self.lgv.dynamicBlocks.totalWidthPx,
-              self.lgv.bpPerPx <= 1 ? 125 : 95,
-            )
-
-            const {
-              hoveredFeature,
-              lgv,
-              regions,
-              sequenceRowHeight,
-              session,
-              theme,
-            } = self
-
-            if (!hoveredFeature) {
-              return
-            }
-
-            const { featureTypeOntology } =
-              session.apolloDataStore.ontologyManager
-            if (!featureTypeOntology) {
-              throw new Error('featureTypeOntology is undefined')
-            }
-            for (const [idx, region] of regions.entries()) {
-              if (featureTypeOntology.isTypeOf(hoveredFeature.type, 'CDS')) {
-                const parentFeature = hoveredFeature.parent
-                if (!parentFeature) {
-                  continue
-                }
-                const cdsLocs = parentFeature.cdsLocations.find(
-                  (loc) =>
-                    hoveredFeature.min === loc.at(0)?.min &&
-                    hoveredFeature.max === loc.at(-1)?.max,
-                )
-                if (!cdsLocs) {
-                  continue
-                }
-                for (const dl of cdsLocs) {
-                  const frame = getFrame(
-                    dl.min,
-                    dl.max,
-                    hoveredFeature.strand ?? 1,
-                    dl.phase,
-                  )
-                  const row = getTranslationRow(frame, lgv.bpPerPx)
-                  const offset =
-                    (lgv.bpToPx({
-                      refName: region.refName,
-                      coord: dl.min,
-                      regionNumber: idx,
-                    })?.offsetPx ?? 0) - lgv.offsetPx
-                  const widthPx = (dl.max - dl.min) / lgv.bpPerPx
-                  const startPx = lgv.displayedRegions[idx].reversed
-                    ? offset - widthPx
-                    : offset
-
-                  highlightSeq(
-                    seqTrackOverlayctx,
-                    theme,
-                    startPx,
-                    sequenceRowHeight,
-                    row,
-                    widthPx,
-                  )
-                }
-              } else {
-                const row = getSeqRow(hoveredFeature.strand, lgv.bpPerPx)
-                const offset =
-                  (lgv.bpToPx({
-                    refName: region.refName,
-                    coord: hoveredFeature.min,
-                    regionNumber: idx,
-                  })?.offsetPx ?? 0) - lgv.offsetPx
-                const widthPx = hoveredFeature.length / lgv.bpPerPx
-                const startPx = lgv.displayedRegions[idx].reversed
-                  ? offset - widthPx
-                  : offset
-
-                highlightSeq(
-                  seqTrackOverlayctx,
-                  theme,
-                  startPx,
-                  sequenceRowHeight,
-                  row,
-                  widthPx,
-                )
-              }
-            }
-          },
-          { name: 'LinearApolloDisplayRenderSeqHighlight' },
-        ),
-      )
-    },
-  }))
-}
-
 export function mouseEventsModelFactory(
   pluginManager: PluginManager,
   configSchema: AnyConfigurationSchemaType,
 ) {
-  const LinearApolloDisplayMouseEvents = mouseEventsSeqHightlightModelFactory(
+  const LinearApolloDisplayMouseEvents = mouseEventsModelIntermediateFactory(
     pluginManager,
     configSchema,
   )

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloReferenceSequenceDisplay/components/LinearApolloReferenceSequenceDisplay.tsx
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloReferenceSequenceDisplay/components/LinearApolloReferenceSequenceDisplay.tsx
@@ -1,0 +1,107 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+/* eslint-disable @typescript-eslint/no-misused-promises */
+import { getContainingView } from '@jbrowse/core/util'
+import { type LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
+import { Alert, Tooltip, useTheme } from '@mui/material'
+import { observer } from 'mobx-react'
+import React, { useEffect } from 'react'
+import { makeStyles } from 'tss-react/mui'
+
+import { type LinearApolloReferenceSequenceDisplay as LinearApolloReferenceSequenceDisplayI } from '../stateModel'
+
+interface LinearApolloReferenceSequenceDisplayProps {
+  model: LinearApolloReferenceSequenceDisplayI
+}
+export type Coord = [number, number]
+
+const useStyles = makeStyles()({
+  canvasContainer: {
+    position: 'relative',
+    left: 0,
+  },
+  canvas: {
+    position: 'absolute',
+    left: 0,
+  },
+  center: {
+    display: 'flex',
+    justifyContent: 'center',
+  },
+  ellipses: {
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
+  },
+})
+
+export const LinearApolloReferenceSequenceDisplay = observer(
+  function LinearApolloReferenceSequenceDisplay(
+    props: LinearApolloReferenceSequenceDisplayProps,
+  ) {
+    const theme = useTheme()
+    const { model } = props
+    const {
+      height,
+      regionCannotBeRendered,
+      setSeqTrackCanvas,
+      setSeqTrackOverlayCanvas,
+      setTheme,
+    } = model
+    const { classes } = useStyles()
+    useEffect(() => {
+      setTheme(theme)
+    }, [theme, setTheme])
+
+    const lgv = getContainingView(model) as unknown as LinearGenomeViewModel
+    const message = regionCannotBeRendered()
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (message) {
+      return (
+        <Alert
+          severity="warning"
+          classes={{ message: classes.ellipses }}
+          slotProps={{ root: { className: classes.center } }}
+        >
+          <Tooltip title={message}>
+            <div>{message}</div>
+          </Tooltip>
+        </Alert>
+      )
+    }
+
+    return (
+      <>
+        {3 / lgv.bpPerPx >= 1 ? (
+          <div
+            className={classes.canvasContainer}
+            style={{
+              width: lgv.dynamicBlocks.totalWidthPx,
+              height,
+            }}
+          >
+            <canvas
+              ref={async (node: HTMLCanvasElement) => {
+                await Promise.resolve()
+                setSeqTrackCanvas(node)
+              }}
+              width={lgv.dynamicBlocks.totalWidthPx}
+              height={height}
+              className={classes.canvas}
+              data-testid="seqTrackCanvas"
+            />
+            <canvas
+              ref={async (node: HTMLCanvasElement) => {
+                await Promise.resolve()
+                setSeqTrackOverlayCanvas(node)
+              }}
+              width={lgv.dynamicBlocks.totalWidthPx}
+              height={height}
+              className={classes.canvas}
+              data-testid="seqTrackOverlayCanvas"
+            />
+          </div>
+        ) : null}
+      </>
+    )
+  },
+)

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloReferenceSequenceDisplay/components/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloReferenceSequenceDisplay/components/index.ts
@@ -1,0 +1,1 @@
+export * from './LinearApolloReferenceSequenceDisplay'

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloReferenceSequenceDisplay/configSchema.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloReferenceSequenceDisplay/configSchema.ts
@@ -1,0 +1,7 @@
+import { ConfigurationSchema } from '@jbrowse/core/configuration'
+
+export const configSchema = ConfigurationSchema(
+  'LinearApolloReferenceSequenceDisplay',
+  {},
+  { explicitIdentifier: 'displayId', explicitlyTyped: true },
+)

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloReferenceSequenceDisplay/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloReferenceSequenceDisplay/index.ts
@@ -1,0 +1,3 @@
+export { configSchema } from './configSchema'
+export { stateModelFactory } from './stateModel'
+export { LinearApolloReferenceSequenceDisplay } from './components/LinearApolloReferenceSequenceDisplay'

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloReferenceSequenceDisplay/stateModel/base.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloReferenceSequenceDisplay/stateModel/base.ts
@@ -1,0 +1,227 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
+import { type AnnotationFeature } from '@apollo-annotation/mst'
+import type PluginManager from '@jbrowse/core/PluginManager'
+import { ConfigurationReference, getConf } from '@jbrowse/core/configuration'
+import { type AnyConfigurationSchemaType } from '@jbrowse/core/configuration/configurationSchema'
+import { BaseDisplay } from '@jbrowse/core/pluggableElementTypes'
+import {
+  type AbstractSessionModel,
+  getContainingView,
+  getSession,
+} from '@jbrowse/core/util'
+import { getParentRenderProps } from '@jbrowse/core/util/tracks'
+// import type LinearGenomeViewPlugin from '@jbrowse/plugin-linear-genome-view'
+import { type LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
+import { autorun } from 'mobx'
+import { addDisposer, getRoot, types } from 'mobx-state-tree'
+
+import { type ApolloInternetAccountModel } from '../../ApolloInternetAccount/model'
+import { type ApolloSessionModel } from '../../session'
+import { type ApolloRootModel } from '../../types'
+
+const minDisplayHeight = 20
+
+export function baseModelFactory(
+  _pluginManager: PluginManager,
+  configSchema: AnyConfigurationSchemaType,
+) {
+  return BaseDisplay.named('BaseLinearApolloReferenceSequenceDisplay')
+    .props({
+      type: types.literal('LinearApolloReferenceSequenceDisplay'),
+      configuration: ConfigurationReference(configSchema),
+      showStartCodons: false,
+      showStopCodons: true,
+      highContrast: false,
+      heightPreConfig: types.maybe(
+        types.refinement(
+          'displayHeight',
+          types.number,
+          (n) => n >= minDisplayHeight,
+        ),
+      ),
+      sequenceRowHeight: 15,
+    })
+    .views((self) => {
+      const { configuration, renderProps: superRenderProps } = self
+      return {
+        renderProps() {
+          return {
+            ...superRenderProps(),
+            ...getParentRenderProps(self),
+            config: configuration.renderer,
+          }
+        },
+      }
+    })
+    .views((self) => ({
+      get lgv() {
+        return getContainingView(self) as unknown as LinearGenomeViewModel
+      },
+    }))
+    .views((self) => ({
+      get rendererTypeName() {
+        return self.configuration.renderer.type
+      },
+      get session() {
+        return getSession(self) as unknown as ApolloSessionModel
+      },
+      get regions() {
+        const regions = self.lgv.dynamicBlocks.contentBlocks.map(
+          ({ assemblyName, end, refName, start }) => ({
+            assemblyName,
+            refName,
+            start: Math.round(start),
+            end: Math.round(end),
+          }),
+        )
+        return regions
+      },
+      regionCannotBeRendered(/* region */) {
+        if (self.lgv && self.lgv.bpPerPx >= 3) {
+          return 'Zoom in to see sequence'
+        }
+        return
+      },
+    }))
+    .views((self) => ({
+      get apolloInternetAccount() {
+        const [region] = self.regions
+        const { internetAccounts } = getRoot<ApolloRootModel>(self)
+        const { assemblyName } = region
+        const { assemblyManager } =
+          self.session as unknown as AbstractSessionModel
+        const assembly = assemblyManager.get(assemblyName)
+        if (!assembly) {
+          throw new Error(`No assembly found with name ${assemblyName}`)
+        }
+        const { internetAccountConfigId } = getConf(assembly, [
+          'sequence',
+          'metadata',
+        ]) as { internetAccountConfigId: string }
+        return internetAccounts.find(
+          (ia) => getConf(ia, 'internetAccountId') === internetAccountConfigId,
+        ) as ApolloInternetAccountModel | undefined
+      },
+      get changeManager() {
+        return (self.session as unknown as ApolloSessionModel).apolloDataStore
+          .changeManager
+      },
+      getAssemblyId(assemblyName: string) {
+        const { assemblyManager } =
+          self.session as unknown as AbstractSessionModel
+        const assembly = assemblyManager.get(assemblyName)
+        if (!assembly) {
+          throw new Error(`Could not find assembly named ${assemblyName}`)
+        }
+        return assembly.name
+      },
+      get selectedFeature(): AnnotationFeature | undefined {
+        return (self.session as unknown as ApolloSessionModel)
+          .apolloSelectedFeature
+      },
+      get hoveredFeature(): AnnotationFeature | undefined {
+        return (self.session as unknown as ApolloSessionModel)
+          .apolloHoveredFeature
+      },
+      get height() {
+        const { sequenceRowHeight } = self
+        return self.lgv.bpPerPx <= 1
+          ? sequenceRowHeight * 8
+          : sequenceRowHeight * 6
+      },
+    }))
+    .volatile(() => ({
+      scrollTop: 0,
+    }))
+    .actions((self) => ({
+      setScrollTop(scrollTop: number) {
+        self.scrollTop = scrollTop
+      },
+      setHeight(displayHeight: number) {
+        self.heightPreConfig = Math.max(displayHeight, minDisplayHeight)
+        return self.height
+      },
+      resizeHeight(distance: number) {
+        const oldHeight = self.height
+        const newHeight = this.setHeight(self.height + distance)
+        return newHeight - oldHeight
+      },
+      toggleShowStartCodons() {
+        self.showStartCodons = !self.showStartCodons
+      },
+      toggleShowStopCodons() {
+        self.showStopCodons = !self.showStopCodons
+      },
+      toggleHighContrast() {
+        self.highContrast = !self.highContrast
+      },
+    }))
+    .views((self) => {
+      const { trackMenuItems: superTrackMenuItems } = self
+      return {
+        trackMenuItems() {
+          const { showStartCodons, showStopCodons, highContrast } = self
+          return [
+            ...superTrackMenuItems(),
+            {
+              type: 'subMenu',
+              label: 'Appearance',
+              subMenu: [
+                {
+                  label: 'Show start codons',
+                  type: 'checkbox',
+                  checked: showStartCodons,
+                  onClick: () => {
+                    self.toggleShowStartCodons()
+                  },
+                },
+                {
+                  label: 'Show stop codons',
+                  type: 'checkbox',
+                  checked: showStopCodons,
+                  onClick: () => {
+                    self.toggleShowStopCodons()
+                  },
+                },
+                {
+                  label: 'Use high contrast colors',
+                  type: 'checkbox',
+                  checked: highContrast,
+                  onClick: () => {
+                    self.toggleHighContrast()
+                  },
+                },
+              ],
+            },
+          ]
+        },
+      }
+    })
+    .actions((self) => ({
+      afterAttach() {
+        addDisposer(
+          self,
+          autorun(
+            () => {
+              if (!self.lgv.initialized || self.regionCannotBeRendered()) {
+                return
+              }
+              if (self.lgv.bpPerPx <= 3) {
+                void (
+                  self.session as unknown as ApolloSessionModel
+                ).apolloDataStore.loadRefSeq(self.regions)
+              }
+            },
+            {
+              name: 'LinearApolloReferenceSequenceDisplayLoadFeatures',
+              delay: 1000,
+            },
+          ),
+        )
+      },
+    }))
+}

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloReferenceSequenceDisplay/stateModel/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloReferenceSequenceDisplay/stateModel/index.ts
@@ -1,0 +1,25 @@
+import type PluginManager from '@jbrowse/core/PluginManager'
+import { type AnyConfigurationSchemaType } from '@jbrowse/core/configuration/configurationSchema'
+import { type Instance } from 'mobx-state-tree'
+
+import { renderingModelFactory } from './rendering'
+
+export function stateModelFactory(
+  pluginManager: PluginManager,
+  configSchema: AnyConfigurationSchemaType,
+) {
+  // TODO: this needs to be refactored so that the final composition of the
+  // state model mixins happens here in one central place
+  return renderingModelFactory(pluginManager, configSchema).named(
+    'LinearApolloReferenceSequenceDisplay',
+  )
+}
+
+export type LinearApolloReferenceSequenceDisplayStateModel = ReturnType<
+  typeof stateModelFactory
+>
+// eslint disable because of
+// https://mobx-state-tree.js.org/tips/typescript#using-a-mst-type-at-design-time
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface LinearApolloReferenceSequenceDisplay
+  extends Instance<LinearApolloReferenceSequenceDisplayStateModel> {}

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloReferenceSequenceDisplay/stateModel/rendering.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloReferenceSequenceDisplay/stateModel/rendering.ts
@@ -1,0 +1,481 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
+import type PluginManager from '@jbrowse/core/PluginManager'
+import { type AnyConfigurationSchemaType } from '@jbrowse/core/configuration/configurationSchema'
+import {
+  type Frame,
+  defaultCodonTable,
+  getFrame,
+  revcom,
+} from '@jbrowse/core/util'
+import { type Theme } from '@mui/material'
+import { autorun } from 'mobx'
+import { type Instance, addDisposer } from 'mobx-state-tree'
+
+import { type ApolloSessionModel } from '../../session'
+
+import { baseModelFactory } from './base'
+
+function colorCode(letter: string, theme?: Theme) {
+  return (
+    theme?.palette.bases[
+      letter.toUpperCase() as keyof Theme['palette']['bases']
+    ].main.toString() ?? 'lightgray'
+  )
+}
+
+function codonColorCode(letter: string, highContrast?: boolean) {
+  const colorMap: Record<string, string | undefined> = {
+    M: '#33ee33',
+    '*': highContrast ? '#000000' : '#f44336',
+  }
+
+  return colorMap[letter.toUpperCase()]
+}
+
+function reverseCodonSeq(seq: string): string {
+  // disable because sequence is all ascii
+  // eslint-disable-next-line @typescript-eslint/no-misused-spread
+  return [...seq]
+    .map((c) => revcom(c))
+    .reverse()
+    .join('')
+}
+
+function drawLetter(
+  seqTrackctx: CanvasRenderingContext2D,
+  startPx: number,
+  widthPx: number,
+  letter: string,
+  textY: number,
+) {
+  const fontSize = Math.min(widthPx, 10)
+  seqTrackctx.fillStyle = '#000'
+  seqTrackctx.font = `${fontSize}px`
+  const textWidth = seqTrackctx.measureText(letter).width
+  const textX = startPx + (widthPx - textWidth) / 2
+  seqTrackctx.fillText(letter, textX, textY + 10)
+}
+
+function drawTranslation(
+  seqTrackctx: CanvasRenderingContext2D,
+  bpPerPx: number,
+  trnslStartPx: number,
+  trnslY: number,
+  trnslWidthPx: number,
+  sequenceRowHeight: number,
+  seq: string,
+  i: number,
+  reverse: boolean,
+  showStartCodons: boolean,
+  showStopCodons: boolean,
+  highContrast: boolean,
+) {
+  let codonSeq: string = seq.slice(i, i + 3).toUpperCase()
+  if (reverse) {
+    codonSeq = reverseCodonSeq(codonSeq)
+  }
+  const codonLetter =
+    defaultCodonTable[codonSeq as keyof typeof defaultCodonTable]
+  if (!codonLetter) {
+    return
+  }
+  const fillColor = codonColorCode(codonLetter, highContrast)
+  if (
+    fillColor &&
+    ((showStopCodons && codonLetter == '*') ||
+      (showStartCodons && codonLetter != '*'))
+  ) {
+    seqTrackctx.fillStyle = fillColor
+    seqTrackctx.fillRect(trnslStartPx, trnslY, trnslWidthPx, sequenceRowHeight)
+  }
+  if (bpPerPx <= 0.1) {
+    seqTrackctx.rect(trnslStartPx, trnslY, trnslWidthPx, sequenceRowHeight)
+    seqTrackctx.stroke()
+    drawLetter(seqTrackctx, trnslStartPx, trnslWidthPx, codonLetter, trnslY)
+  }
+}
+
+function getTranslationRow(frame: Frame, bpPerPx: number) {
+  const offset = bpPerPx <= 1 ? 2 : 0
+  switch (frame) {
+    case 3: {
+      return 0
+    }
+    case 2: {
+      return 1
+    }
+    case 1: {
+      return 2
+    }
+    case -1: {
+      return 3 + offset
+    }
+    case -2: {
+      return 4 + offset
+    }
+    case -3: {
+      return 5 + offset
+    }
+  }
+}
+
+function getSeqRow(
+  strand: 1 | -1 | undefined,
+  bpPerPx: number,
+): number | undefined {
+  if (bpPerPx > 1 || strand === undefined) {
+    return
+  }
+  return strand === 1 ? 3 : 4
+}
+
+function highlightSeq(
+  seqTrackOverlayctx: CanvasRenderingContext2D,
+  theme: Theme | undefined,
+  startPx: number,
+  sequenceRowHeight: number,
+  row: number | undefined,
+  widthPx: number,
+) {
+  if (row !== undefined) {
+    seqTrackOverlayctx.fillStyle =
+      theme?.palette.action.focus ?? 'rgba(0,0,0,0.04)'
+    seqTrackOverlayctx.fillRect(
+      startPx,
+      sequenceRowHeight * row,
+      widthPx,
+      sequenceRowHeight,
+    )
+  }
+}
+
+export function renderingModelFactory(
+  pluginManager: PluginManager,
+  configSchema: AnyConfigurationSchemaType,
+) {
+  const BaseLinearApolloReferenceSequenceDisplay = baseModelFactory(
+    pluginManager,
+    configSchema,
+  )
+
+  return BaseLinearApolloReferenceSequenceDisplay.named(
+    'LinearApolloReferenceSequenceDisplayRendering',
+  )
+    .volatile(() => ({
+      seqTrackCanvas: null as HTMLCanvasElement | null,
+      seqTrackOverlayCanvas: null as HTMLCanvasElement | null,
+      theme: undefined as Theme | undefined,
+    }))
+    .actions((self) => ({
+      setSeqTrackCanvas(canvas: HTMLCanvasElement | null) {
+        self.seqTrackCanvas = canvas
+      },
+      setSeqTrackOverlayCanvas(canvas: HTMLCanvasElement | null) {
+        self.seqTrackOverlayCanvas = canvas
+      },
+      setTheme(theme: Theme) {
+        self.theme = theme
+      },
+      afterAttach() {
+        addDisposer(
+          self,
+          autorun(
+            () => {
+              const { theme } = self
+              if (!self.lgv.initialized || self.regionCannotBeRendered()) {
+                return
+              }
+              const trnslWidthPx = 3 / self.lgv.bpPerPx
+              if (trnslWidthPx < 1) {
+                return
+              }
+              const seqTrackctx = self.seqTrackCanvas?.getContext('2d')
+              if (!seqTrackctx) {
+                return
+              }
+
+              seqTrackctx.clearRect(
+                0,
+                0,
+                self.lgv.dynamicBlocks.totalWidthPx,
+                self.height,
+              )
+              const frames =
+                self.lgv.bpPerPx <= 1
+                  ? [3, 2, 1, 0, 0, -1, -2, -3]
+                  : [3, 2, 1, -1, -2, -3]
+              let height = 0
+              if (theme) {
+                for (const frame of frames) {
+                  let frameColor = theme.palette.framesCDS.at(frame)?.main
+                  if (frameColor) {
+                    let offsetPx = 0
+                    if (self.highContrast) {
+                      frameColor = 'white'
+                      offsetPx = 1
+                      // eslint-disable-next-line prefer-destructuring
+                      seqTrackctx.fillStyle = theme.palette.grey[200]
+                      seqTrackctx.fillRect(
+                        0,
+                        height,
+                        self.lgv.dynamicBlocks.totalWidthPx,
+                        self.sequenceRowHeight,
+                      )
+                    }
+                    seqTrackctx.fillStyle = frameColor
+                    seqTrackctx.fillRect(
+                      0 + offsetPx,
+                      height + offsetPx,
+                      self.lgv.dynamicBlocks.totalWidthPx - 2 * offsetPx,
+                      self.sequenceRowHeight - 2 * offsetPx,
+                    )
+                  }
+                  height += self.sequenceRowHeight
+                }
+              }
+
+              for (const [idx, region] of self.regions.entries()) {
+                const { apolloDataStore } =
+                  self.session as unknown as ApolloSessionModel
+                const assembly = apolloDataStore.assemblies.get(
+                  region.assemblyName,
+                )
+                const ref = assembly?.getByRefName(region.refName)
+                const seq = ref?.getSequence(region.start, region.end)
+                if (!seq) {
+                  return
+                }
+                // disable because sequence is all ascii
+                // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                for (const [i, letter] of [...seq].entries()) {
+                  const trnslXOffset =
+                    (self.lgv.bpToPx({
+                      refName: region.refName,
+                      coord: region.start + i,
+                      regionNumber: idx,
+                    })?.offsetPx ?? 0) - self.lgv.offsetPx
+                  const trnslStartPx = self.lgv.displayedRegions[idx].reversed
+                    ? trnslXOffset - trnslWidthPx
+                    : trnslXOffset
+
+                  // Draw translation forward
+                  for (let j = 2; j >= 0; j--) {
+                    if ((region.start + i) % 3 === j) {
+                      drawTranslation(
+                        seqTrackctx,
+                        self.lgv.bpPerPx,
+                        trnslStartPx,
+                        self.sequenceRowHeight * (2 - j),
+                        trnslWidthPx,
+                        self.sequenceRowHeight,
+                        seq,
+                        i,
+                        false,
+                        self.showStartCodons,
+                        self.showStopCodons,
+                        self.highContrast,
+                      )
+                    }
+                  }
+
+                  if (self.lgv.bpPerPx <= 1) {
+                    const xOffset =
+                      (self.lgv.bpToPx({
+                        refName: region.refName,
+                        coord: region.start + i,
+                        regionNumber: idx,
+                      })?.offsetPx ?? 0) - self.lgv.offsetPx
+                    const widthPx = 1 / self.lgv.bpPerPx
+                    const startPx = self.lgv.displayedRegions[idx].reversed
+                      ? xOffset - widthPx
+                      : xOffset
+
+                    // Draw forward
+                    seqTrackctx.beginPath()
+                    seqTrackctx.fillStyle = colorCode(letter, self.theme)
+                    seqTrackctx.rect(
+                      startPx,
+                      self.sequenceRowHeight * 3,
+                      widthPx,
+                      self.sequenceRowHeight,
+                    )
+                    seqTrackctx.fill()
+                    if (self.lgv.bpPerPx <= 0.1) {
+                      seqTrackctx.stroke()
+                      drawLetter(
+                        seqTrackctx,
+                        startPx,
+                        widthPx,
+                        letter,
+                        self.sequenceRowHeight * 3,
+                      )
+                    }
+
+                    // Draw reverse
+                    const revLetter = revcom(letter)
+                    seqTrackctx.beginPath()
+                    seqTrackctx.fillStyle = colorCode(revLetter, self.theme)
+                    seqTrackctx.rect(
+                      startPx,
+                      self.sequenceRowHeight * 4,
+                      widthPx,
+                      self.sequenceRowHeight,
+                    )
+                    seqTrackctx.fill()
+                    if (self.lgv.bpPerPx <= 0.1) {
+                      seqTrackctx.stroke()
+                      drawLetter(
+                        seqTrackctx,
+                        startPx,
+                        widthPx,
+                        revLetter,
+                        self.sequenceRowHeight * 4,
+                      )
+                    }
+                  }
+
+                  // Draw translation reverse
+                  for (let k = 0; k <= 2; k++) {
+                    const rowOffset = self.lgv.bpPerPx <= 1 ? 5 : 3
+                    if ((region.start + i) % 3 === k) {
+                      drawTranslation(
+                        seqTrackctx,
+                        self.lgv.bpPerPx,
+                        trnslStartPx,
+                        self.sequenceRowHeight * (rowOffset + k),
+                        trnslWidthPx,
+                        self.sequenceRowHeight,
+                        seq,
+                        i,
+                        true,
+                        self.showStartCodons,
+                        self.showStopCodons,
+                        self.highContrast,
+                      )
+                    }
+                  }
+                }
+              }
+            },
+            { name: 'LinearApolloReferenceSequenceDisplayRenderSequence' },
+          ),
+        )
+        addDisposer(
+          self,
+          autorun(
+            () => {
+              if (!self.lgv.initialized || self.regionCannotBeRendered()) {
+                return
+              }
+              const seqTrackOverlayctx =
+                self.seqTrackOverlayCanvas?.getContext('2d')
+              if (!seqTrackOverlayctx) {
+                return
+              }
+
+              seqTrackOverlayctx.clearRect(
+                0,
+                0,
+                self.lgv.dynamicBlocks.totalWidthPx,
+                self.height,
+              )
+
+              const {
+                hoveredFeature,
+                lgv,
+                regions,
+                sequenceRowHeight,
+                session,
+                theme,
+              } = self
+
+              if (!hoveredFeature) {
+                return
+              }
+
+              const { featureTypeOntology } =
+                session.apolloDataStore.ontologyManager
+              if (!featureTypeOntology) {
+                throw new Error('featureTypeOntology is undefined')
+              }
+              for (const [idx, region] of regions.entries()) {
+                if (featureTypeOntology.isTypeOf(hoveredFeature.type, 'CDS')) {
+                  const parentFeature = hoveredFeature.parent
+                  if (!parentFeature) {
+                    continue
+                  }
+                  const cdsLocs = parentFeature.cdsLocations.find(
+                    (loc) =>
+                      hoveredFeature.min === loc.at(0)?.min &&
+                      hoveredFeature.max === loc.at(-1)?.max,
+                  )
+                  if (!cdsLocs) {
+                    continue
+                  }
+                  for (const dl of cdsLocs) {
+                    const frame = getFrame(
+                      dl.min,
+                      dl.max,
+                      hoveredFeature.strand ?? 1,
+                      dl.phase,
+                    )
+                    const row = getTranslationRow(frame, lgv.bpPerPx)
+                    const offset =
+                      (lgv.bpToPx({
+                        refName: region.refName,
+                        coord: dl.min,
+                        regionNumber: idx,
+                      })?.offsetPx ?? 0) - lgv.offsetPx
+                    const widthPx = (dl.max - dl.min) / lgv.bpPerPx
+                    const startPx = lgv.displayedRegions[idx].reversed
+                      ? offset - widthPx
+                      : offset
+
+                    highlightSeq(
+                      seqTrackOverlayctx,
+                      theme,
+                      startPx,
+                      sequenceRowHeight,
+                      row,
+                      widthPx,
+                    )
+                  }
+                } else {
+                  const row = getSeqRow(hoveredFeature.strand, lgv.bpPerPx)
+                  const offset =
+                    (lgv.bpToPx({
+                      refName: region.refName,
+                      coord: hoveredFeature.min,
+                      regionNumber: idx,
+                    })?.offsetPx ?? 0) - lgv.offsetPx
+                  const widthPx = hoveredFeature.length / lgv.bpPerPx
+                  const startPx = lgv.displayedRegions[idx].reversed
+                    ? offset - widthPx
+                    : offset
+
+                  highlightSeq(
+                    seqTrackOverlayctx,
+                    theme,
+                    startPx,
+                    sequenceRowHeight,
+                    row,
+                    widthPx,
+                  )
+                }
+              }
+            },
+            { name: 'LinearApolloDisplayRenderSeqHighlight' },
+          ),
+        )
+      },
+    }))
+}
+
+export type LinearApolloReferenceSequenceDisplayRenderingModel = ReturnType<
+  typeof renderingModelFactory
+>
+// eslint disable because of
+// https://mobx-state-tree.js.org/tips/typescript#using-a-mst-type-at-design-time
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface LinearApolloReferenceSequenceDisplayRendering
+  extends Instance<LinearApolloReferenceSequenceDisplayRenderingModel> {}

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/glyphs/GeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/glyphs/GeneGlyph.ts
@@ -133,6 +133,7 @@ function draw(
     theme,
     highestRow,
     filteredTranscripts,
+    selectedFeature,
     showFeatureLabels,
   } = stateModel
   const { bpPerPx, displayedRegions, offsetPx } = lgv
@@ -148,7 +149,6 @@ function draw(
   if (!children) {
     return
   }
-  const { apolloSelectedFeature } = session
   const { apolloDataStore } = session
   const { featureTypeOntology } = apolloDataStore.ontologyManager
   if (!featureTypeOntology) {
@@ -177,7 +177,7 @@ function draw(
     topLevelFeatureHeight,
   )
 
-  ctx.fillStyle = isSelectedFeature(topLevelFeature, apolloSelectedFeature)
+  ctx.fillStyle = isSelectedFeature(topLevelFeature, selectedFeature)
     ? alpha('rgb(0,0,0)', 0.7)
     : alpha(theme?.palette.background.paper ?? '#ffffff', 0.7)
   ctx.fillRect(
@@ -187,7 +187,7 @@ function draw(
     topLevelFeatureHeight - 2,
   )
 
-  const isSelected = isSelectedFeature(topLevelFeature, apolloSelectedFeature)
+  const isSelected = isSelectedFeature(topLevelFeature, selectedFeature)
   const label: Label = {
     x: topLevelFeatureStartPx,
     y: topLevelFeatureTop,
@@ -269,7 +269,7 @@ function draw(
 
       const exonTop =
         topLevelFeatureTop + (topLevelFeatureHeight - exonHeight) / 2
-      const isSelected = isSelectedFeature(exon, apolloSelectedFeature)
+      const isSelected = isSelectedFeature(exon, selectedFeature)
       ctx.fillStyle = theme?.palette.text.primary ?? 'black'
       ctx.fillRect(startPx, exonTop, widthPx, exonHeight)
       if (widthPx > 2) {
@@ -309,7 +309,7 @@ function draw(
       }
     }
 
-    const isSelected = isSelectedFeature(child, apolloSelectedFeature?.parent)
+    const isSelected = isSelectedFeature(child, selectedFeature?.parent)
     let cdsStartPx = 0
     let cdsTop = 0
     for (const cdsRow of cdsLocations) {
@@ -318,9 +318,9 @@ function draw(
       let counter = 1
       for (const cds of cdsRow.sort((a, b) => a.max - b.max)) {
         if (
-          (apolloSelectedFeature &&
+          (selectedFeature &&
             isSelected &&
-            featureTypeOntology.isTypeOf(apolloSelectedFeature.type, 'CDS')) ||
+            featureTypeOntology.isTypeOf(selectedFeature.type, 'CDS')) ||
           !deepSetHas(renderedCDS, cds)
         ) {
           const cdsWidthPx = (cds.max - cds.min) / bpPerPx
@@ -349,9 +349,9 @@ function draw(
             const cdsColorCode = frameColor ?? 'rgb(171,71,188)'
             ctx.fillStyle = cdsColorCode
             ctx.fillStyle =
-              apolloSelectedFeature &&
+              selectedFeature &&
               isSelected &&
-              featureTypeOntology.isTypeOf(apolloSelectedFeature.type, 'CDS')
+              featureTypeOntology.isTypeOf(selectedFeature.type, 'CDS')
                 ? 'rgb(0,0,0)'
                 : cdsColorCode
             ctx.fillRect(

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/stateModel/base.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/stateModel/base.ts
@@ -140,6 +140,10 @@ export function baseModelFactory(
         return (self.session as unknown as ApolloSessionModel)
           .apolloSelectedFeature
       },
+      get hoveredFeature(): AnnotationFeature | undefined {
+        return (self.session as unknown as ApolloSessionModel)
+          .apolloHoveredFeature
+      },
     }))
     .actions((self) => ({
       setScrollTop(scrollTop: number) {
@@ -248,6 +252,11 @@ export function baseModelFactory(
         ;(
           self.session as unknown as ApolloSessionModel
         ).apolloSetSelectedFeature(feature)
+      },
+      setHoveredFeature(feature?: AnnotationFeature) {
+        ;(
+          self.session as unknown as ApolloSessionModel
+        ).apolloSetHoveredFeature(feature)
       },
       showFeatureDetailsWidget(
         feature: AnnotationFeature,

--- a/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/Feature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/Feature.tsx
@@ -84,14 +84,6 @@ function makeContextMenuItems(
   )
 }
 
-function getTopLevelFeature(feature: AnnotationFeature): AnnotationFeature {
-  let cur = feature
-  while (cur.parent) {
-    cur = cur.parent
-  }
-  return cur
-}
-
 export const Feature = observer(function Feature({
   depth,
   feature,

--- a/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/Feature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/Feature.tsx
@@ -111,8 +111,8 @@ export const Feature = observer(function Feature({
 }) {
   const { classes } = useStyles()
   const {
-    apolloHover,
     changeManager,
+    hoveredFeature,
     selectedFeature,
     session,
     tabularEditor: tabularEditorState,
@@ -134,12 +134,7 @@ export const Feature = observer(function Feature({
     <>
       <tr
         onMouseEnter={(_e) => {
-          displayState.setApolloHover({
-            feature,
-            topLevelFeature: getTopLevelFeature(feature),
-            // @ts-expect-error TODO fix in future when moving hover logic to session.
-            glyph: displayState.getGlyph(getTopLevelFeature(feature)),
-          })
+          displayState.setHoveredFeature(feature)
         }}
         className={
           classes.feature +
@@ -258,10 +253,6 @@ export const Feature = observer(function Feature({
               return text.includes(filterText)
             })
             .map(([featureId, childFeature]) => {
-              const hoveredFeature =
-                apolloHover && 'feature' in apolloHover
-                  ? apolloHover.feature
-                  : apolloHover
               const childHovered = hoveredFeature?._id === childFeature._id
               const childSelected = selectedFeature?._id === childFeature._id
               return (

--- a/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/Feature.tsx
+++ b/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/Feature.tsx
@@ -258,7 +258,11 @@ export const Feature = observer(function Feature({
               return text.includes(filterText)
             })
             .map(([featureId, childFeature]) => {
-              const childHovered = apolloHover?.feature._id === childFeature._id
+              const hoveredFeature =
+                apolloHover && 'feature' in apolloHover
+                  ? apolloHover.feature
+                  : apolloHover
+              const childHovered = hoveredFeature?._id === childFeature._id
               const childSelected = selectedFeature?._id === childFeature._id
               return (
                 <Feature

--- a/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/HybridGrid.tsx
+++ b/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/HybridGrid.tsx
@@ -37,7 +37,7 @@ const HybridGrid = observer(function HybridGrid({
 }: {
   model: DisplayStateModel
 }) {
-  const { apolloHover, seenFeatures, selectedFeature, tabularEditor } = model
+  const { hoveredFeature, seenFeatures, selectedFeature, tabularEditor } = model
   const theme = useTheme()
   const { classes } = useStyles()
   const scrollContainerRef = useRef<HTMLDivElement>(null)
@@ -96,10 +96,6 @@ const HybridGrid = observer(function HybridGrid({
             })
             .map(([featureId, feature]) => {
               const isSelected = selectedFeature?._id === featureId
-              const hoveredFeature =
-                apolloHover && 'feature' in apolloHover
-                  ? apolloHover.feature
-                  : apolloHover
               const isHovered = hoveredFeature?._id === featureId
               return (
                 <Feature

--- a/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/HybridGrid.tsx
+++ b/packages/jbrowse-plugin-apollo/src/TabularEditor/HybridGrid/HybridGrid.tsx
@@ -96,7 +96,11 @@ const HybridGrid = observer(function HybridGrid({
             })
             .map(([featureId, feature]) => {
               const isSelected = selectedFeature?._id === featureId
-              const isHovered = apolloHover?.feature._id === featureId
+              const hoveredFeature =
+                apolloHover && 'feature' in apolloHover
+                  ? apolloHover.feature
+                  : apolloHover
+              const isHovered = hoveredFeature?._id === featureId
               return (
                 <Feature
                   key={featureId}

--- a/packages/jbrowse-plugin-apollo/src/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/index.ts
@@ -52,6 +52,11 @@ import {
   stateModelFactory as LinearApolloDisplayStateModelFactory,
 } from './LinearApolloDisplay'
 import {
+  LinearApolloReferenceSequenceDisplay,
+  configSchema as linearApolloReferenceSequenceDisplayConfigSchema,
+  stateModelFactory as LinearApolloReferenceSequenceDisplayStateModelFactory,
+} from './LinearApolloReferenceSequenceDisplay'
+import {
   configSchema as linearApolloSixFrameDisplayConfigSchema,
   stateModelFactory as LinearApolloSixFrameDisplayStateModelFactory,
 } from './LinearApolloSixFrameDisplay'
@@ -198,6 +203,22 @@ export default class ApolloPlugin extends Plugin {
         trackType: 'ApolloTrack',
         viewType: 'LinearGenomeView',
         ReactComponent: LinearApolloSixFrameDisplayComponent,
+      })
+    })
+
+    pluginManager.addDisplayType(() => {
+      const configSchema = linearApolloReferenceSequenceDisplayConfigSchema
+      return new DisplayType({
+        name: 'LinearApolloReferenceSequenceDisplay',
+        configSchema,
+        stateModel: LinearApolloReferenceSequenceDisplayStateModelFactory(
+          pluginManager,
+          configSchema,
+        ),
+        displayName: 'Apollo reference sequence display',
+        trackType: 'ReferenceSequenceTrack',
+        viewType: 'LinearGenomeView',
+        ReactComponent: LinearApolloReferenceSequenceDisplay,
       })
     })
 

--- a/packages/jbrowse-plugin-apollo/src/makeDisplayComponent.tsx
+++ b/packages/jbrowse-plugin-apollo/src/makeDisplayComponent.tsx
@@ -19,7 +19,6 @@ const accordionControlHeight = 12
 const useStyles = makeStyles()((theme) => ({
   shading: {
     background: alpha(theme.palette.primary.main, 0.2),
-    overflowY: 'scroll',
     overflowX: 'hidden',
   },
   details: {

--- a/packages/jbrowse-plugin-apollo/src/session/session.ts
+++ b/packages/jbrowse-plugin-apollo/src/session/session.ts
@@ -71,6 +71,9 @@ export function extendSession(
       apolloSelectedFeature: types.safeReference(AnnotationFeatureExtended),
       jobsManager: types.optional(ApolloJobModel, {}),
     })
+    .volatile(() => ({
+      apolloHoveredFeature: undefined as AnnotationFeature | undefined,
+    }))
     .extend(() => {
       const collabs = observable.array<Collaborator>([])
 
@@ -98,6 +101,9 @@ export function extendSession(
       apolloSetSelectedFeature(feature?: AnnotationFeature) {
         // @ts-expect-error Not sure why TS thinks these MST types don't match
         self.apolloSelectedFeature = feature
+      },
+      apolloSetHoveredFeature(feature?: AnnotationFeature) {
+        self.apolloHoveredFeature = feature
       },
       addApolloTrackConfig(assembly: AssemblyModel, baseURL?: string) {
         const trackId = `apollo_track_${assembly.name}`

--- a/packages/jbrowse-plugin-apollo/src/util/annotationFeatureUtils.ts
+++ b/packages/jbrowse-plugin-apollo/src/util/annotationFeatureUtils.ts
@@ -80,15 +80,15 @@ export function getFeaturesUnderClick(
   includeSiblings = false,
 ): AnnotationFeature[] {
   const clickedFeatures: AnnotationFeature[] = []
-  if (!mousePosition.featureAndGlyphUnderMouse) {
+  if (!mousePosition.feature) {
     return clickedFeatures
   }
-  clickedFeatures.push(mousePosition.featureAndGlyphUnderMouse.feature)
-  for (const x of getParents(mousePosition.featureAndGlyphUnderMouse.feature)) {
+  clickedFeatures.push(mousePosition.feature)
+  for (const x of getParents(mousePosition.feature)) {
     clickedFeatures.push(x)
   }
   const { bp } = mousePosition
-  const children = getChildren(mousePosition.featureAndGlyphUnderMouse.feature)
+  const children = getChildren(mousePosition.feature)
   for (const child of children) {
     if (child.min < bp && child.max >= bp) {
       clickedFeatures.push(child)
@@ -100,12 +100,11 @@ export function getFeaturesUnderClick(
 
   // Also add siblings , i.e. features having the same parent as the clicked
   // one and intersecting the click position
-  if (mousePosition.featureAndGlyphUnderMouse.feature.parent) {
-    const siblings =
-      mousePosition.featureAndGlyphUnderMouse.feature.parent.children
+  if (mousePosition.feature.parent) {
+    const siblings = mousePosition.feature.parent.children
     if (siblings) {
       for (const [, sib] of siblings) {
-        if (sib._id == mousePosition.featureAndGlyphUnderMouse.feature._id) {
+        if (sib._id == mousePosition.feature._id) {
           continue
         }
         if (sib.min < bp && sib.max >= bp) {


### PR DESCRIPTION
Depends on #641 

This change makes it so that instead of rendering the sequence and protein translation lines as part of the Apollo track default display, it renders them in a custom display of the reference sequence track.

##### Before

<img width="989" height="460" alt="image" src="https://github.com/user-attachments/assets/d2a5323c-d30a-43cb-8b6d-984bfe30f006" />

##### After

<img width="986" height="372" alt="image" src="https://github.com/user-attachments/assets/0ae31cb6-2973-4f3f-b779-8c77969c23aa" />
