### PR TITLE
Context menu list for LASFD

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
@@ -1,9 +1,8 @@
 import { type AnnotationFeature } from '@apollo-annotation/mst'
 import { type MenuItem } from '@jbrowse/core/ui'
-import { type AbstractSessionModel } from '@jbrowse/core/util'
 import { type Theme, alpha } from '@mui/material'
 
-import { AddChildFeature, CopyFeature, DeleteFeature } from '../../components'
+import { getContextMenuItemsForFeature } from '../../util'
 import { type LinearApolloDisplay } from '../stateModel'
 import {
   type LinearApolloDisplayMouseEvents,
@@ -260,123 +259,6 @@ function getContextMenuItems(
   }
   const { feature: sourceFeature } = apolloHover
   return getContextMenuItemsForFeature(display, sourceFeature)
-}
-
-function makeFeatureLabel(feature: AnnotationFeature) {
-  let name: string | undefined
-  if (feature.attributes.get('gff_name')) {
-    name = feature.attributes.get('gff_name')?.join(',')
-  } else if (feature.attributes.get('gff_id')) {
-    name = feature.attributes.get('gff_id')?.join(',')
-  } else {
-    name = feature._id
-  }
-  const coords = `(${(feature.min + 1).toLocaleString('en')}..${feature.max.toLocaleString('en')})`
-  const maxLen = 60
-  if (name && name.length + coords.length > maxLen + 5) {
-    const trim = maxLen - coords.length
-    name = trim > 0 ? name.slice(0, trim) : ''
-    name = `${name}[...]`
-  }
-  return `${name} ${coords}`
-}
-
-function getContextMenuItemsForFeature(
-  display: LinearApolloDisplayMouseEvents,
-  sourceFeature: AnnotationFeature,
-): MenuItem[] {
-  const {
-    apolloInternetAccount: internetAccount,
-    changeManager,
-    regions,
-    selectedFeature,
-    session,
-  } = display
-  const menuItems: MenuItem[] = []
-  const role = internetAccount ? internetAccount.role : 'admin'
-  const admin = role === 'admin'
-  const readOnly = !(role && ['admin', 'user'].includes(role))
-  const [region] = regions
-  const sourceAssemblyId = display.getAssemblyId(region.assemblyName)
-  const currentAssemblyId = display.getAssemblyId(region.assemblyName)
-  const { featureTypeOntology } = session.apolloDataStore.ontologyManager
-  if (!featureTypeOntology) {
-    throw new Error('featureTypeOntology is undefined')
-  }
-
-  // Add only relevant options
-  menuItems.push(
-    {
-      label: makeFeatureLabel(sourceFeature),
-      type: 'subHeader',
-    },
-    {
-      label: 'Add child feature',
-      disabled: readOnly,
-      onClick: () => {
-        ;(session as unknown as AbstractSessionModel).queueDialog(
-          (doneCallback) => [
-            AddChildFeature,
-            {
-              session,
-              handleClose: () => {
-                doneCallback()
-              },
-              changeManager,
-              sourceFeature,
-              sourceAssemblyId,
-              internetAccount,
-            },
-          ],
-        )
-      },
-    },
-    {
-      label: 'Copy features and annotations',
-      disabled: readOnly,
-      onClick: () => {
-        ;(session as unknown as AbstractSessionModel).queueDialog(
-          (doneCallback) => [
-            CopyFeature,
-            {
-              session,
-              handleClose: () => {
-                doneCallback()
-              },
-              changeManager,
-              sourceFeature,
-              sourceAssemblyId: currentAssemblyId,
-            },
-          ],
-        )
-      },
-    },
-    {
-      label: 'Delete feature',
-      disabled: !admin,
-      onClick: () => {
-        ;(session as unknown as AbstractSessionModel).queueDialog(
-          (doneCallback) => [
-            DeleteFeature,
-            {
-              session,
-              handleClose: () => {
-                doneCallback()
-              },
-              changeManager,
-              sourceFeature,
-              sourceAssemblyId: currentAssemblyId,
-              selectedFeature,
-              setSelectedFeature: (feature?: AnnotationFeature) => {
-                display.setSelectedFeature(feature)
-              },
-            },
-          ],
-        )
-      },
-    },
-  )
-  return menuItems
 }
 
 function getFeatureFromLayout(

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GenericChildGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GenericChildGlyph.ts
@@ -1,11 +1,12 @@
 import { type AnnotationFeature } from '@apollo-annotation/mst'
 import { type MenuItem } from '@jbrowse/core/ui'
 
-import { getFeaturesUnderClick } from '../../util/annotationFeatureUtils'
+import { getRelatedFeatures } from '../../util/annotationFeatureUtils'
 import { type LinearApolloDisplay } from '../stateModel'
 import {
   type LinearApolloDisplayMouseEvents,
   type MousePositionWithFeatureAndGlyph,
+  isMousePositionWithFeatureAndGlyph,
 } from '../stateModel/mouseEvents'
 import { type LinearApolloDisplayRendering } from '../stateModel/rendering'
 
@@ -158,18 +159,24 @@ function getContextMenuItems(
     label: sourceFeature.type,
     subMenu: sourceFeatureMenuItems,
   })
-  for (const relative of getFeaturesUnderClick(mousePosition)) {
-    if (relative._id === sourceFeature._id) {
-      continue
+  if (isMousePositionWithFeatureAndGlyph(mousePosition)) {
+    const { bp, featureAndGlyphUnderMouse } = mousePosition
+    for (const relative of getRelatedFeatures(
+      featureAndGlyphUnderMouse.feature,
+      bp,
+    )) {
+      if (relative._id === sourceFeature._id) {
+        continue
+      }
+      const contextMenuItemsForFeature = boxGlyph.getContextMenuItemsForFeature(
+        display,
+        relative,
+      )
+      menuItems.push({
+        label: relative.type,
+        subMenu: contextMenuItemsForFeature,
+      })
     }
-    const contextMenuItemsForFeature = boxGlyph.getContextMenuItemsForFeature(
-      display,
-      relative,
-    )
-    menuItems.push({
-      label: relative.type,
-      subMenu: contextMenuItemsForFeature,
-    })
   }
   return menuItems
 }

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/components/LinearApolloSixFrameDisplay.tsx
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/components/LinearApolloSixFrameDisplay.tsx
@@ -95,7 +95,7 @@ export const LinearApolloSixFrameDisplay = observer(
             } else {
               const coord: [number, number] = [event.clientX, event.clientY]
               setContextCoord(coord)
-              setContextMenuItems(getContextMenuItems(coord))
+              setContextMenuItems(getContextMenuItems(event))
             }
           }}
         >

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/glyphs/GeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/glyphs/GeneGlyph.ts
@@ -13,9 +13,12 @@ import { alpha } from '@mui/material'
 import equal from 'fast-deep-equal/es6'
 import { getSnapshot } from 'mobx-state-tree'
 
-import { AddChildFeature, CopyFeature, DeleteFeature } from '../../components'
 import { FilterTranscripts } from '../../components/FilterTranscripts'
-import { getMinAndMaxPx, getOverlappingEdge } from '../../util'
+import {
+  getContextMenuItemsForFeature,
+  getMinAndMaxPx,
+  getOverlappingEdge,
+} from '../../util'
 import { type LinearApolloSixFrameDisplay } from '../stateModel'
 import {
   type LinearApolloSixFrameDisplayMouseEvents,
@@ -807,92 +810,14 @@ function drawTooltip(
 function getContextMenuItems(
   display: LinearApolloSixFrameDisplayMouseEvents,
 ): MenuItem[] {
-  const {
-    apolloHover,
-    apolloInternetAccount: internetAccount,
-    changeManager,
-    filteredTranscripts,
-    regions,
-    selectedFeature,
-    session,
-  } = display
-  const menuItems: MenuItem[] = []
+  const { apolloHover, filteredTranscripts, session } = display
   if (!apolloHover) {
-    return menuItems
+    return []
   }
   const { feature: sourceFeature } = apolloHover
-  const role = internetAccount ? internetAccount.role : 'admin'
-  const admin = role === 'admin'
-  const readOnly = !(role && ['admin', 'user'].includes(role))
-  const [region] = regions
-  const sourceAssemblyId = display.getAssemblyId(region.assemblyName)
-  const currentAssemblyId = display.getAssemblyId(region.assemblyName)
-  menuItems.push(
-    {
-      label: 'Add child feature',
-      disabled: readOnly,
-      onClick: () => {
-        ;(session as unknown as AbstractSessionModel).queueDialog(
-          (doneCallback) => [
-            AddChildFeature,
-            {
-              session,
-              handleClose: () => {
-                doneCallback()
-              },
-              changeManager,
-              sourceFeature,
-              sourceAssemblyId,
-              internetAccount,
-            },
-          ],
-        )
-      },
-    },
-    {
-      label: 'Copy features and annotations',
-      disabled: readOnly,
-      onClick: () => {
-        ;(session as unknown as AbstractSessionModel).queueDialog(
-          (doneCallback) => [
-            CopyFeature,
-            {
-              session,
-              handleClose: () => {
-                doneCallback()
-              },
-              changeManager,
-              sourceFeature,
-              sourceAssemblyId: currentAssemblyId,
-            },
-          ],
-        )
-      },
-    },
-    {
-      label: 'Delete feature',
-      disabled: !admin,
-      onClick: () => {
-        ;(session as unknown as AbstractSessionModel).queueDialog(
-          (doneCallback) => [
-            DeleteFeature,
-            {
-              session,
-              handleClose: () => {
-                doneCallback()
-              },
-              changeManager,
-              sourceFeature,
-              sourceAssemblyId: currentAssemblyId,
-              selectedFeature,
-              setSelectedFeature: (feature?: AnnotationFeature) => {
-                display.setSelectedFeature(feature)
-              },
-            },
-          ],
-        )
-      },
-    },
+  const menuItems: MenuItem[] = getContextMenuItemsForFeature(
+    display,
+    sourceFeature,
   )
   const { featureTypeOntology } = session.apolloDataStore.ontologyManager
   if (!featureTypeOntology) {
@@ -933,6 +858,7 @@ export const geneGlyph: Glyph = {
   drawHover,
   drawTooltip,
   getContextMenuItems,
+  getContextMenuItemsForFeature,
   onMouseDown,
   onMouseLeave,
   onMouseMove,

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/glyphs/Glyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/glyphs/Glyph.ts
@@ -57,6 +57,11 @@ export interface Glyph {
     context: CanvasRenderingContext2D,
   ): void
 
+  getContextMenuItemsForFeature(
+    display: LinearApolloSixFrameDisplayMouseEvents,
+    sourceFeature: AnnotationFeature,
+  ): MenuItem[]
+
   getContextMenuItems(
     display: LinearApolloSixFrameDisplayMouseEvents,
   ): MenuItem[]

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/glyphs/Glyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/glyphs/Glyph.ts
@@ -64,5 +64,6 @@ export interface Glyph {
 
   getContextMenuItems(
     display: LinearApolloSixFrameDisplayMouseEvents,
+    currentMousePosition: MousePositionWithFeatureAndGlyph,
   ): MenuItem[]
 }

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/stateModel/mouseEvents.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/stateModel/mouseEvents.ts
@@ -15,7 +15,6 @@ import { type Instance, addDisposer, cast } from 'mobx-state-tree'
 import { type CSSProperties } from 'react'
 
 import { type Edge, getPropagatedLocationChanges } from '../../util'
-import { type Coord } from '../components'
 import { type Glyph } from '../glyphs/Glyph'
 import { type CanvasMouseEvent } from '../types'
 
@@ -47,7 +46,7 @@ export function isMousePositionWithFeatureAndGlyph(
 }
 
 function getMousePosition(
-  event: CanvasMouseEvent,
+  event: React.MouseEvent,
   lgv: LinearGenomeViewModel,
 ): MousePosition {
   const canvas = event.currentTarget
@@ -83,7 +82,7 @@ export function mouseEventsModelIntermediateFactory(
       apolloHover: undefined as FeatureAndGlyphUnderMouse | undefined,
     }))
     .views((self) => ({
-      getMousePosition(event: CanvasMouseEvent): MousePosition {
+      getMousePosition(event: React.MouseEvent): MousePosition {
         const mousePosition = getMousePosition(event, self.lgv)
         const { bp, regionNumber, y } = mousePosition
         const row = Math.floor(y / self.apolloRowHeight) + 1
@@ -172,14 +171,18 @@ export function mouseEventsModelFactory(
     mouseEventsModelIntermediateFactory(pluginManager, configSchema)
 
   return LinearApolloSixFrameDisplayMouseEvents.views((self) => ({
-    contextMenuItems(contextCoord?: Coord): MenuItem[] {
+    contextMenuItems(event: React.MouseEvent<HTMLDivElement>): MenuItem[] {
       const { apolloHover } = self
-      if (!(apolloHover && contextCoord)) {
+      if (!apolloHover) {
         return []
       }
+      const mousePosition = self.getMousePosition(event)
       const { topLevelFeature } = apolloHover
       const glyph = self.getGlyph(topLevelFeature)
-      return glyph.getContextMenuItems(self)
+      if (isMousePositionWithFeatureAndGlyph(mousePosition)) {
+        return glyph.getContextMenuItems(self, mousePosition)
+      }
+      return []
     },
   }))
     .actions((self) => ({

--- a/packages/jbrowse-plugin-apollo/src/util/annotationFeatureUtils.ts
+++ b/packages/jbrowse-plugin-apollo/src/util/annotationFeatureUtils.ts
@@ -116,3 +116,41 @@ export function getFeaturesUnderClick(
   }
   return clickedFeatures
 }
+
+export function getRelatedFeatures(
+  feature: AnnotationFeature,
+  bp: number,
+  includeSiblings = false,
+): AnnotationFeature[] {
+  const relatedFeatures: AnnotationFeature[] = []
+  relatedFeatures.push(feature)
+  for (const x of getParents(feature)) {
+    relatedFeatures.push(x)
+  }
+  const children = getChildren(feature)
+  for (const child of children) {
+    if (child.min < bp && child.max >= bp) {
+      relatedFeatures.push(child)
+    }
+  }
+  if (!includeSiblings) {
+    return relatedFeatures
+  }
+
+  // Also add siblings , i.e. features having the same parent as the clicked
+  // one and intersecting the click position
+  if (feature.parent) {
+    const siblings = feature.parent.children
+    if (siblings) {
+      for (const [, sib] of siblings) {
+        if (sib._id == feature._id) {
+          continue
+        }
+        if (sib.min < bp && sib.max >= bp) {
+          relatedFeatures.push(sib)
+        }
+      }
+    }
+  }
+  return relatedFeatures
+}

--- a/packages/jbrowse-plugin-apollo/src/util/annotationFeatureUtils.ts
+++ b/packages/jbrowse-plugin-apollo/src/util/annotationFeatureUtils.ts
@@ -1,7 +1,5 @@
 import { type AnnotationFeature } from '@apollo-annotation/mst'
 
-import { type MousePosition } from '../LinearApolloDisplay/stateModel/mouseEvents'
-
 export function getFeatureName(feature: AnnotationFeature) {
   const { attributes } = feature
   const name = attributes.get('gff_name')

--- a/packages/jbrowse-plugin-apollo/src/util/annotationFeatureUtils.ts
+++ b/packages/jbrowse-plugin-apollo/src/util/annotationFeatureUtils.ts
@@ -75,48 +75,6 @@ function getParents(feature: AnnotationFeature): AnnotationFeature[] {
   return parents
 }
 
-export function getFeaturesUnderClick(
-  mousePosition: MousePosition,
-  includeSiblings = false,
-): AnnotationFeature[] {
-  const clickedFeatures: AnnotationFeature[] = []
-  if (!mousePosition.featureAndGlyphUnderMouse) {
-    return clickedFeatures
-  }
-  clickedFeatures.push(mousePosition.featureAndGlyphUnderMouse.feature)
-  for (const x of getParents(mousePosition.featureAndGlyphUnderMouse.feature)) {
-    clickedFeatures.push(x)
-  }
-  const { bp } = mousePosition
-  const children = getChildren(mousePosition.featureAndGlyphUnderMouse.feature)
-  for (const child of children) {
-    if (child.min < bp && child.max >= bp) {
-      clickedFeatures.push(child)
-    }
-  }
-  if (!includeSiblings) {
-    return clickedFeatures
-  }
-
-  // Also add siblings , i.e. features having the same parent as the clicked
-  // one and intersecting the click position
-  if (mousePosition.featureAndGlyphUnderMouse.feature.parent) {
-    const siblings =
-      mousePosition.featureAndGlyphUnderMouse.feature.parent.children
-    if (siblings) {
-      for (const [, sib] of siblings) {
-        if (sib._id == mousePosition.featureAndGlyphUnderMouse.feature._id) {
-          continue
-        }
-        if (sib.min < bp && sib.max >= bp) {
-          clickedFeatures.push(sib)
-        }
-      }
-    }
-  }
-  return clickedFeatures
-}
-
 export function getRelatedFeatures(
   feature: AnnotationFeature,
   bp: number,

--- a/packages/jbrowse-plugin-apollo/src/util/glyphUtils.ts
+++ b/packages/jbrowse-plugin-apollo/src/util/glyphUtils.ts
@@ -2,7 +2,13 @@ import {
   type AnnotationFeature,
   type TranscriptPartCoding,
 } from '@apollo-annotation/mst'
+import { type MenuItem } from '@jbrowse/core/ui'
+import { type AbstractSessionModel } from '@jbrowse/core/util'
 import { type LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
+
+import { type LinearApolloDisplayMouseEvents } from '../LinearApolloDisplay/stateModel/mouseEvents'
+import { type LinearApolloSixFrameDisplayMouseEvents } from '../LinearApolloSixFrameDisplay/stateModel/mouseEvents'
+import { AddChildFeature, CopyFeature, DeleteFeature } from '../components'
 
 export function getMinAndMaxPx(
   feature: AnnotationFeature | TranscriptPartCoding,
@@ -46,4 +52,117 @@ export function getOverlappingEdge(
     return { feature, edge: 'max' }
   }
   return
+}
+
+function makeFeatureLabel(feature: AnnotationFeature) {
+  let name: string | undefined
+  if (feature.attributes.get('gff_name')) {
+    name = feature.attributes.get('gff_name')?.join(',')
+  } else if (feature.attributes.get('gff_id')) {
+    name = feature.attributes.get('gff_id')?.join(',')
+  } else {
+    name = feature._id
+  }
+  const coords = `(${(feature.min + 1).toLocaleString('en')}..${feature.max.toLocaleString('en')})`
+  const maxLen = 60
+  if (name && name.length + coords.length > maxLen + 5) {
+    const trim = maxLen - coords.length
+    name = trim > 0 ? name.slice(0, trim) : ''
+    name = `${name}[...]`
+  }
+  return `${name} ${coords}`
+}
+
+export function getContextMenuItemsForFeature(
+  display:
+    | LinearApolloSixFrameDisplayMouseEvents
+    | LinearApolloDisplayMouseEvents,
+  sourceFeature: AnnotationFeature,
+): MenuItem[] {
+  const {
+    apolloInternetAccount: internetAccount,
+    changeManager,
+    regions,
+    selectedFeature,
+    session,
+  } = display
+  const menuItems: MenuItem[] = []
+  const role = internetAccount ? internetAccount.role : 'admin'
+  const admin = role === 'admin'
+  const readOnly = !(role && ['admin', 'user'].includes(role))
+  const [region] = regions
+  const sourceAssemblyId = display.getAssemblyId(region.assemblyName)
+  const currentAssemblyId = display.getAssemblyId(region.assemblyName)
+  menuItems.push(
+    {
+      label: makeFeatureLabel(sourceFeature),
+      type: 'subHeader',
+    },
+    {
+      label: 'Add child feature',
+      disabled: readOnly,
+      onClick: () => {
+        ;(session as unknown as AbstractSessionModel).queueDialog(
+          (doneCallback) => [
+            AddChildFeature,
+            {
+              session,
+              handleClose: () => {
+                doneCallback()
+              },
+              changeManager,
+              sourceFeature,
+              sourceAssemblyId,
+              internetAccount,
+            },
+          ],
+        )
+      },
+    },
+    {
+      label: 'Copy features and annotations',
+      disabled: readOnly,
+      onClick: () => {
+        ;(session as unknown as AbstractSessionModel).queueDialog(
+          (doneCallback) => [
+            CopyFeature,
+            {
+              session,
+              handleClose: () => {
+                doneCallback()
+              },
+              changeManager,
+              sourceFeature,
+              sourceAssemblyId: currentAssemblyId,
+            },
+          ],
+        )
+      },
+    },
+    {
+      label: 'Delete feature',
+      disabled: !admin,
+      onClick: () => {
+        ;(session as unknown as AbstractSessionModel).queueDialog(
+          (doneCallback) => [
+            DeleteFeature,
+            {
+              session,
+              handleClose: () => {
+                doneCallback()
+              },
+              changeManager,
+              sourceFeature,
+              sourceAssemblyId: currentAssemblyId,
+              selectedFeature,
+              setSelectedFeature: (feature?: AnnotationFeature) => {
+                display.setSelectedFeature(feature)
+              },
+            },
+          ],
+        )
+      },
+    },
+  )
+  return menuItems
 }


### PR DESCRIPTION
For #643.

I've made some tweaks to general utilities that affect both displays:
* Moved `getContextMenuItemsForFeature` to util as it is common to both
* Transformed `getFeaturesUnderClick` -> `getRelatedFeatures`. This was primarily because one of the arguments, `MousePosition`, is different for each display's state model, yet it was only the `featureAndGlyphUnderMouse.feature` and `bp` that were being used, so I pass them in directly. Otherwise, I believe it now has a more appropriate function name.

I'm aware that a lot of this will need to be updated again for #641; I wanted to make sure these underlying changes were in place before contributing to that PR.