### PR TITLE
Add more custom component extension points to the transcript widget

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/ApolloTranscriptDetailsWidget.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/ApolloTranscriptDetailsWidget.tsx
@@ -144,13 +144,13 @@ export const ApolloTranscriptDetailsWidget = observer(
     ) as React.ElementType<CustomComponentProps>
 
     const CustomComponentInsideSequence = pluginManager.evaluateExtensionPoint(
-      'Apollo-TranscriptDetailsCustomComponent-InsideAttributes',
+      'Apollo-TranscriptDetailsCustomComponent-InsideSequence',
       NoOpCustomComponent,
       { feature, session },
     ) as React.ElementType<CustomComponentProps>
 
     const CustomComponentAfterSequence = pluginManager.evaluateExtensionPoint(
-      'Apollo-TranscriptDetailsCustomComponent-AfterAttributes',
+      'Apollo-TranscriptDetailsCustomComponent-AfterSequence',
       NoOpCustomComponent,
       { feature, session },
     ) as React.ElementType<CustomComponentProps>


### PR DESCRIPTION
This adds the ability to add custom components to any part of the transcript widget UI by adding an extension point for both inside and after each major section.