### PR TITLE
Fix file path retrieval in desktop

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/components/OpenLocalFile.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/OpenLocalFile.tsx
@@ -87,6 +87,13 @@ export function OpenLocalFile({ handleClose, session }: OpenLocalFileProps) {
       return
     }
 
+    const fileMetadata: { file?: string } = {}
+    if (isElectron) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const { webUtils } = globalThis.require('electron')
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      fileMetadata.file = webUtils.getPathForFile(file) as string
+    }
     const assemblyConfig = {
       name: assemblyId,
       aliases: [assemblyName],
@@ -95,12 +102,7 @@ export function OpenLocalFile({ handleClose, session }: OpenLocalFileProps) {
         trackId: `sequenceConfigId-${assemblyName}`,
         type: 'ReferenceSequenceTrack',
         adapter: { type: 'ApolloSequenceAdapter', assemblyId },
-        metadata: {
-          apollo: true,
-          ...(isElectron
-            ? { file: (file as File & { path: string }).path }
-            : {}),
-        },
+        metadata: { apollo: true, ...fileMetadata },
       },
     }
 


### PR DESCRIPTION
Electron v33 removed the method we used of getting the GFF3 file path when running in desktop: https://www.electronjs.org/docs/latest/breaking-changes#removed-filepath

This change uses the now-recommended `webUtils.getPathForFile(file)` instead.