### PR TITLE
Add menu item to hide/show check results

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/LinearApolloDisplay.tsx
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/LinearApolloDisplay.tsx
@@ -81,6 +81,7 @@ export const LinearApolloDisplay = observer(function LinearApolloDisplay(
     setCollaboratorCanvas,
     setOverlayCanvas,
     setTheme,
+    showCheckResults,
   } = model
   const { classes } = useStyles()
   const lgv = getContainingView(model) as unknown as LinearGenomeViewModel
@@ -171,54 +172,61 @@ export const LinearApolloDisplay = observer(function LinearApolloDisplay(
             />
             {lgv.displayedRegions.flatMap((region, idx) => {
               const assembly = assemblyManager.get(region.assemblyName)
-              return [...session.apolloDataStore.checkResults.values()]
-                .filter(
-                  (checkResult) =>
-                    assembly?.isValidRefName(checkResult.refSeq) &&
-                    assembly.getCanonicalRefName(checkResult.refSeq) ===
-                      region.refName &&
-                    doesIntersect2(
-                      region.start,
-                      region.end,
-                      checkResult.start,
-                      checkResult.end,
-                    ),
-                )
-                .map((checkResult) => {
-                  const left =
-                    (lgv.bpToPx({
-                      refName: region.refName,
-                      coord: checkResult.start,
-                      regionNumber: idx,
-                    })?.offsetPx ?? 0) - lgv.offsetPx
-                  const [feature] = checkResult.ids
-                  if (!feature) {
-                    return null
-                  }
-                  let row = 0
-                  const featureLayout = model.getFeatureLayoutPosition(feature)
-                  if (featureLayout) {
-                    row = featureLayout.layoutRow + featureLayout.featureRow
-                  }
-                  const top = row * apolloRowHeight
-                  const height = apolloRowHeight
-                  return (
-                    <Tooltip key={checkResult._id} title={checkResult.message}>
-                      <Avatar
-                        className={classes.avatar}
-                        style={{
-                          top,
-                          left,
-                          height,
-                          width: height,
-                          pointerEvents: apolloDragging ? 'none' : 'auto',
-                        }}
-                      >
-                        <ErrorIcon data-testid="ErrorIcon" />
-                      </Avatar>
-                    </Tooltip>
+              if (showCheckResults) {
+                return [...session.apolloDataStore.checkResults.values()]
+                  .filter(
+                    (checkResult) =>
+                      assembly?.isValidRefName(checkResult.refSeq) &&
+                      assembly.getCanonicalRefName(checkResult.refSeq) ===
+                        region.refName &&
+                      doesIntersect2(
+                        region.start,
+                        region.end,
+                        checkResult.start,
+                        checkResult.end,
+                      ),
                   )
-                })
+                  .map((checkResult) => {
+                    const left =
+                      (lgv.bpToPx({
+                        refName: region.refName,
+                        coord: checkResult.start,
+                        regionNumber: idx,
+                      })?.offsetPx ?? 0) - lgv.offsetPx
+                    const [feature] = checkResult.ids
+                    if (!feature) {
+                      return null
+                    }
+                    let row = 0
+                    const featureLayout =
+                      model.getFeatureLayoutPosition(feature)
+                    if (featureLayout) {
+                      row = featureLayout.layoutRow + featureLayout.featureRow
+                    }
+                    const top = row * apolloRowHeight
+                    const height = apolloRowHeight
+                    return (
+                      <Tooltip
+                        key={checkResult._id}
+                        title={checkResult.message}
+                      >
+                        <Avatar
+                          className={classes.avatar}
+                          style={{
+                            top,
+                            left,
+                            height,
+                            width: height,
+                            pointerEvents: apolloDragging ? 'none' : 'auto',
+                          }}
+                        >
+                          <ErrorIcon data-testid="ErrorIcon" />
+                        </Avatar>
+                      </Tooltip>
+                    )
+                  })
+              }
+              return null
             })}
             <Menu
               open={contextMenuItems.length > 0}

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/base.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/base.ts
@@ -37,6 +37,7 @@ export function baseModelFactory(
       configuration: ConfigurationReference(configSchema),
       graphical: true,
       table: false,
+      showCheckResults: true,
       heightPreConfig: types.maybe(
         types.refinement(
           'displayHeight',
@@ -173,6 +174,9 @@ export function baseModelFactory(
         self.graphical = true
         self.table = true
       },
+      toggleShowCheckResults() {
+        self.showCheckResults = !self.showCheckResults
+      },
       updateFilteredFeatureTypes(types: string[]) {
         self.filteredFeatureTypes = cast(types)
       },
@@ -184,7 +188,7 @@ export function baseModelFactory(
       const { filteredFeatureTypes, trackMenuItems: superTrackMenuItems } = self
       return {
         trackMenuItems() {
-          const { graphical, table } = self
+          const { graphical, table, showCheckResults } = self
           return [
             ...superTrackMenuItems(),
             {
@@ -213,6 +217,14 @@ export function baseModelFactory(
                   checked: table && graphical,
                   onClick: () => {
                     self.showGraphicalAndTable()
+                  },
+                },
+                {
+                  label: 'Check Results',
+                  type: 'checkbox',
+                  checked: showCheckResults,
+                  onClick: () => {
+                    self.toggleShowCheckResults()
                   },
                 },
               ],

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/components/LinearApolloSixFrameDisplay.tsx
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/components/LinearApolloSixFrameDisplay.tsx
@@ -65,6 +65,7 @@ export const LinearApolloSixFrameDisplay = observer(
       setCollaboratorCanvas,
       setOverlayCanvas,
       setTheme,
+      showCheckResults,
     } = model
     const { classes } = useStyles()
     const lgv = getContainingView(model) as unknown as LinearGenomeViewModel
@@ -153,46 +154,49 @@ export const LinearApolloSixFrameDisplay = observer(
               />
               {lgv.displayedRegions.flatMap((region, idx) => {
                 const assembly = assemblyManager.get(region.assemblyName)
-                return [...session.apolloDataStore.checkResults.values()]
-                  .filter(
-                    (checkResult) =>
-                      assembly?.isValidRefName(checkResult.refSeq) &&
-                      assembly.getCanonicalRefName(checkResult.refSeq) ===
-                        region.refName &&
-                      doesIntersect2(
-                        region.start,
-                        region.end,
-                        checkResult.start,
-                        checkResult.end,
-                      ),
-                  )
-                  .map((checkResult) => {
-                    const left =
-                      (lgv.bpToPx({
-                        refName: region.refName,
-                        coord: checkResult.start,
-                        regionNumber: idx,
-                      })?.offsetPx ?? 0) - lgv.offsetPx
-                    const [feature] = checkResult.ids
-                    if (!feature || !feature.parent?.looksLikeGene) {
-                      return null
-                    }
-                    const top = 0
-                    const height = apolloRowHeight
-                    return (
-                      <Tooltip
-                        key={checkResult._id}
-                        title={checkResult.message}
-                      >
-                        <Avatar
-                          className={classes.avatar}
-                          style={{ top, left, height, width: height }}
-                        >
-                          <ErrorIcon />
-                        </Avatar>
-                      </Tooltip>
+                if (showCheckResults) {
+                  return [...session.apolloDataStore.checkResults.values()]
+                    .filter(
+                      (checkResult) =>
+                        assembly?.isValidRefName(checkResult.refSeq) &&
+                        assembly.getCanonicalRefName(checkResult.refSeq) ===
+                          region.refName &&
+                        doesIntersect2(
+                          region.start,
+                          region.end,
+                          checkResult.start,
+                          checkResult.end,
+                        ),
                     )
-                  })
+                    .map((checkResult) => {
+                      const left =
+                        (lgv.bpToPx({
+                          refName: region.refName,
+                          coord: checkResult.start,
+                          regionNumber: idx,
+                        })?.offsetPx ?? 0) - lgv.offsetPx
+                      const [feature] = checkResult.ids
+                      if (!feature || !feature.parent?.looksLikeGene) {
+                        return null
+                      }
+                      const top = 0
+                      const height = apolloRowHeight
+                      return (
+                        <Tooltip
+                          key={checkResult._id}
+                          title={checkResult.message}
+                        >
+                          <Avatar
+                            className={classes.avatar}
+                            style={{ top, left, height, width: height }}
+                          >
+                            <ErrorIcon />
+                          </Avatar>
+                        </Tooltip>
+                      )
+                    })
+                }
+                return null
               })}
               <Menu
                 open={contextMenuItems.length > 0}

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/stateModel/base.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/stateModel/base.ts
@@ -38,6 +38,7 @@ export function baseModelFactory(
       graphical: true,
       table: false,
       showFeatureLabels: true,
+      showCheckResults: true,
       heightPreConfig: types.maybe(
         types.refinement(
           'displayHeight',
@@ -173,6 +174,9 @@ export function baseModelFactory(
       toggleShowFeatureLabels() {
         self.showFeatureLabels = !self.showFeatureLabels
       },
+      toggleShowCheckResults() {
+        self.showCheckResults = !self.showCheckResults
+      },
       updateFilteredFeatureTypes(types: string[]) {
         self.filteredFeatureTypes = cast(types)
       },
@@ -181,7 +185,7 @@ export function baseModelFactory(
       const { filteredFeatureTypes, trackMenuItems: superTrackMenuItems } = self
       return {
         trackMenuItems() {
-          const { graphical, table, showFeatureLabels } = self
+          const { graphical, table, showFeatureLabels, showCheckResults } = self
           return [
             ...superTrackMenuItems(),
             {
@@ -218,6 +222,14 @@ export function baseModelFactory(
                   checked: showFeatureLabels,
                   onClick: () => {
                     self.toggleShowFeatureLabels()
+                  },
+                },
+                {
+                  label: 'Check Results',
+                  type: 'checkbox',
+                  checked: showCheckResults,
+                  onClick: () => {
+                    self.toggleShowCheckResults()
                   },
                 },
               ],


### PR DESCRIPTION
I've added a "Check Results" toggle in the Appearance options of both main linear displays (LinearApolloDisplay and LinearApolloSixFrameDisplay).

In testing, unchecking appears to improve performance somewhat, but despite the getting of checkResults values being skipped (see e.g. https://github.com/GMOD/Apollo3/compare/hide-check-results?expand=1#diff-6d7898214bb6134d9daa555085c24057ac55db0b0388d4249eca51b4ebd55f44R176), there is still a process in the session that is iterating over each checkResult value every time the region window changes (see https://github.com/GMOD/Apollo3/blob/main/packages/jbrowse-plugin-apollo/src/session/session.ts#L463). I suppose this can be better solved as part of #594 though.