### PR TITLE
Bring LASFD into line with recent changes to reference sequence track

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/components/LinearApolloSixFrameDisplay.tsx
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/components/LinearApolloSixFrameDisplay.tsx
@@ -32,6 +32,10 @@ const useStyles = makeStyles()((theme) => ({
     position: 'absolute',
     left: 0,
   },
+  center: {
+    display: 'flex',
+    justifyContent: 'center',
+  },
   ellipses: {
     textOverflow: 'ellipsis',
     overflow: 'hidden',
@@ -100,7 +104,11 @@ export const LinearApolloSixFrameDisplay = observer(
           }}
         >
           {message ? (
-            <Alert severity="warning" classes={{ message: classes.ellipses }}>
+            <Alert
+              severity="warning"
+              classes={{ message: classes.ellipses }}
+              slotProps={{ root: { className: classes.center } }}
+            >
               <Tooltip title={message}>
                 <div>{message}</div>
               </Tooltip>

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/stateModel/base.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/stateModel/base.ts
@@ -71,12 +71,12 @@ export function baseModelFactory(
           return self.heightPreConfig
         }
         if (self.graphical && self.table) {
-          return 500
+          return 400
         }
         if (self.graphical) {
-          return self.showFeatureLabels ? 400 : 200
+          return self.showFeatureLabels ? 200 : 100
         }
-        return 300
+        return 200
       },
     }))
     .views((self) => ({

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/stateModel/base.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/stateModel/base.ts
@@ -71,12 +71,12 @@ export function baseModelFactory(
           return self.heightPreConfig
         }
         if (self.graphical && self.table) {
-          return 400
+          return 500
         }
         if (self.graphical) {
-          return self.showFeatureLabels ? 200 : 100
+          return self.showFeatureLabels ? 400 : 200
         }
-        return 200
+        return 300
       },
     }))
     .views((self) => ({


### PR DESCRIPTION
I've made a few tweaks to the actual LASFD component, reflecting what was changed in LAD in #642.

A lot of the stripping out that had been performed in #642 happened to already have been accomplished with LASFD due to my earlier decision to remove the embedded sequence display from the annotations track due to a sense it was redundant.