### PR TITLE
Websocket fixes

### DIFF
--- a/packages/apollo-collaboration-server/src/changes/changes.service.ts
+++ b/packages/apollo-collaboration-server/src/changes/changes.service.ts
@@ -266,13 +266,25 @@ export class ChangesService {
     const messages: ChangeMessage[] = []
 
     const userSessionId = makeUserSessionId(user)
-    messages.push({
-      changeInfo: change.toJSON(),
-      userName: user.username,
-      userSessionId,
-      channel: 'COMMON',
-      changeSequence: changeDoc.sequence,
-    })
+    if (isFeatureChange(change)) {
+      for (const refName of refNames) {
+        messages.push({
+          changeInfo: change.toJSON(),
+          userName: user.username,
+          userSessionId,
+          channel: `${change.assembly}-${refName}`,
+          changeSequence: changeDoc.sequence,
+        })
+      }
+    } else {
+      messages.push({
+        changeInfo: change.toJSON(),
+        userName: user.username,
+        userSessionId,
+        channel: 'COMMON',
+        changeSequence: changeDoc.sequence,
+      })
+    }
 
     for (const message of messages) {
       this.logger.debug(

--- a/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
@@ -300,6 +300,8 @@ const stateModelFactory = (configSchema: ApolloInternetAccountConfigModel) => {
         if (!token) {
           throw new Error('No Token found')
         }
+        const user = getDecodedToken(token)
+        const localSessionId = makeUserSessionId(user)
         const { socket } = self
         const { addCheckResult, changeManager, deleteCheckResult } =
           session.apolloDataStore
@@ -324,7 +326,7 @@ const stateModelFactory = (configSchema: ApolloInternetAccountConfigModel) => {
             'LastChangeSequence',
             String(message.changeSequence),
           )
-          if (message.userSessionId === token) {
+          if (message.userSessionId === localSessionId) {
             return // we did this change, no need to apply it again
           }
           const change = Change.fromJSON(message.changeInfo)
@@ -332,8 +334,6 @@ const stateModelFactory = (configSchema: ApolloInternetAccountConfigModel) => {
         })
         socket.on('USER_LOCATION', (message: UserLocationMessage) => {
           const { channel, locations, userName, userSessionId } = message
-          const user = getDecodedToken(token)
-          const localSessionId = makeUserSessionId(user)
           if (channel === 'USER_LOCATION' && userSessionId !== localSessionId) {
             const collaborator: Collaborator = {
               name: userName,

--- a/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
@@ -23,7 +23,7 @@ import {
   isElectron,
 } from '@jbrowse/core/util'
 import { autorun } from 'mobx'
-import { type Instance, flow, getRoot, types } from 'mobx-state-tree'
+import { type Instance, flow, getRoot, isAlive, types } from 'mobx-state-tree'
 import { io } from 'socket.io-client'
 
 import { type Collaborator } from '../session'
@@ -61,7 +61,9 @@ const stateModelFactory = (configSchema: ApolloInternetAccountConfigModel) => {
     }))
     .volatile(() => ({
       role: undefined as Role | undefined,
+      controller: new AbortController(),
     }))
+
     .actions((self) => {
       let roleNotificationSent = false
       return {
@@ -205,7 +207,7 @@ const stateModelFactory = (configSchema: ApolloInternetAccountConfigModel) => {
         const searchParams = new URLSearchParams({ type: authType })
         url.search = searchParams.toString()
         const uri = url.toString()
-        const response = await fetch(uri)
+        const response = await fetch(uri, { signal: self.controller.signal })
         if (!response.ok) {
           const errorMessage = await createFetchErrorMessage(
             response,
@@ -239,7 +241,10 @@ const stateModelFactory = (configSchema: ApolloInternetAccountConfigModel) => {
             uri,
           })
 
-          const response = yield apolloFetch(uri, { method: 'GET' })
+          const response = yield apolloFetch(uri, {
+            method: 'GET',
+            signal: self.controller.signal,
+          })
           if (!response.ok) {
             const errorMessage = yield createFetchErrorMessage(
               response,
@@ -274,7 +279,10 @@ const stateModelFactory = (configSchema: ApolloInternetAccountConfigModel) => {
           uri,
         })
 
-        const response = yield apolloFetch(uri, { method: 'GET' })
+        const response = yield apolloFetch(uri, {
+          method: 'GET',
+          signal: self.controller.signal,
+        })
         if (!response.ok) {
           console.error(
             `Error when fetching the last updates to recover socket connection — ${response.status}`,
@@ -356,7 +364,10 @@ const stateModelFactory = (configSchema: ApolloInternetAccountConfigModel) => {
     }))
     .actions((self) => {
       async function postUserLocation(userLoc: UserLocation[]) {
-        const { baseURL } = self
+        if (!isAlive(self)) {
+          return
+        }
+        const { baseURL, controller } = self
         const url = new URL('users/userLocation', baseURL).href
         const userLocation = new URLSearchParams(JSON.stringify(userLoc))
 
@@ -368,6 +379,7 @@ const stateModelFactory = (configSchema: ApolloInternetAccountConfigModel) => {
           const response = await apolloFetch(url, {
             method: 'POST',
             body: userLocation,
+            signal: controller.signal,
           })
           if (!response.ok) {
             throw new Error('ignore') // ignore message, will get caught by "catch"
@@ -409,7 +421,10 @@ const stateModelFactory = (configSchema: ApolloInternetAccountConfigModel) => {
           locationType: 'UriLocation',
           uri,
         })
-        yield apolloFetch(uri, { method: 'GET' })
+        yield apolloFetch(uri, {
+          method: 'GET',
+          signal: self.controller.signal,
+        })
         window.addEventListener('beforeunload', () => {
           self.postUserLocation([])
         })
@@ -448,6 +463,10 @@ const stateModelFactory = (configSchema: ApolloInternetAccountConfigModel) => {
           },
           { name: 'ApolloInternetAccount' },
         )
+      },
+      beforeDestroy() {
+        self.controller.abort()
+        self.socket.close()
       },
     }))
 }


### PR DESCRIPTION
Fixes a few things with web sockets:

- Fixes the comparison that makes sure we don't try to apply our own changes that are echoes on the web socket
- Restores individual channels for feature-specific changes to avoid errors from other users on different assemblies or reference sequences
- Clean up unused web sockets (needs https://github.com/GMOD/jbrowse-components/issues/5139 to be fixed before these changes will have any effect)

Fixes #623 