### PR TITLE
Add ability to change zoom display threshold

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/base.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/base.ts
@@ -39,7 +39,7 @@ export function baseModelFactory(
       graphical: true,
       table: false,
       showCheckResults: true,
-      zoomThreshold: 20,
+      zoomThreshold: 200,
       heightPreConfig: types.maybe(
         types.refinement(
           'displayHeight',

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/base.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/base.ts
@@ -236,7 +236,7 @@ export function baseModelFactory(
                   },
                 },
                 {
-                  label: 'Change Zoom threshold',
+                  label: 'Change zoom threshold',
                   onClick: () => {
                     getSession(self).queueDialog((handleClose) => [
                       EditZoomThresholdDialog,

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/stateModel/base.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/stateModel/base.ts
@@ -241,7 +241,7 @@ export function baseModelFactory(
                   },
                 },
                 {
-                  label: 'Change Zoom threshold',
+                  label: 'Change zoom threshold',
                   onClick: () => {
                     getSession(self).queueDialog((handleClose) => [
                       EditZoomThresholdDialog,

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/stateModel/base.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/stateModel/base.ts
@@ -40,7 +40,7 @@ export function baseModelFactory(
       table: false,
       showFeatureLabels: true,
       showCheckResults: true,
-      zoomThreshold: 20,
+      zoomThreshold: 200,
       heightPreConfig: types.maybe(
         types.refinement(
           'displayHeight',

--- a/packages/jbrowse-plugin-apollo/src/components/EditZoomThresholdDialog.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/EditZoomThresholdDialog.tsx
@@ -1,0 +1,69 @@
+import { Dialog } from '@jbrowse/core/ui'
+import {
+  Button,
+  DialogActions,
+  DialogContent,
+  TextField,
+  Typography,
+} from '@mui/material'
+import { observer } from 'mobx-react'
+import React, { useState } from 'react'
+
+const EditZoomThresholdDialog = observer(function ({
+  model,
+  handleClose,
+}: {
+  model: {
+    zoomThresholdSetting: number
+    setZoomThresholdSetting: (a: { zoomThreshold: number }) => void
+  }
+  handleClose: () => void
+}) {
+  const [zoomThreshold, setZoomThreshold] = useState(
+    `${model.zoomThresholdSetting}`,
+  )
+
+  return (
+    <Dialog open onClose={handleClose} title="Edit Zoom threshold setting">
+      <DialogContent>
+        <Typography>
+          The Zoom level in base pairs (bp) per pixel at which features are
+          rendered in this Annotations track. Increasing the value will allow
+          features to render when zooming out, but might impact performance.
+        </Typography>
+        <TextField
+          label="Threshold value (bpPerPx)"
+          value={zoomThreshold}
+          onChange={(event) => {
+            setZoomThreshold(event.target.value)
+          }}
+        />
+
+        <DialogActions>
+          <Button
+            variant="contained"
+            onClick={() => {
+              model.setZoomThresholdSetting({
+                zoomThreshold: +zoomThreshold,
+              })
+              handleClose()
+            }}
+          >
+            Submit
+          </Button>
+          <Button
+            variant="contained"
+            color="secondary"
+            onClick={() => {
+              handleClose()
+            }}
+          >
+            Cancel
+          </Button>
+        </DialogActions>
+      </DialogContent>
+    </Dialog>
+  )
+})
+
+export default EditZoomThresholdDialog

--- a/packages/jbrowse-plugin-apollo/src/components/EditZoomThresholdDialog.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/EditZoomThresholdDialog.tsx
@@ -24,10 +24,10 @@ const EditZoomThresholdDialog = observer(function ({
   )
 
   return (
-    <Dialog open onClose={handleClose} title="Edit Zoom threshold setting">
+    <Dialog open onClose={handleClose} title="Edit zoom threshold setting">
       <DialogContent>
         <Typography>
-          The Zoom level in base pairs (bp) per pixel at which features are
+          The zoom level in base pairs (bp) per pixel at which features are
           rendered in this Annotations track. Increasing the value will allow
           features to render when zooming out, but might impact performance.
         </Typography>

--- a/packages/jbrowse-plugin-apollo/src/util/displayUtils.ts
+++ b/packages/jbrowse-plugin-apollo/src/util/displayUtils.ts
@@ -1,5 +1,10 @@
 import { type CheckResultIdsType } from '@apollo-annotation/mst'
+import { lazy } from 'react'
 import { makeStyles } from 'tss-react/mui'
+
+export const EditZoomThresholdDialog = lazy(
+  () => import('../components/EditZoomThresholdDialog'),
+)
 
 export type Coord = [number, number]
 

--- a/packages/jbrowse-plugin-apollo/src/util/displayUtils.ts
+++ b/packages/jbrowse-plugin-apollo/src/util/displayUtils.ts
@@ -1,10 +1,7 @@
 import { type CheckResultIdsType } from '@apollo-annotation/mst'
-import { lazy } from 'react'
 import { makeStyles } from 'tss-react/mui'
 
-export const EditZoomThresholdDialog = lazy(
-  () => import('../components/EditZoomThresholdDialog'),
-)
+export { default as EditZoomThresholdDialog } from '../components/EditZoomThresholdDialog'
 
 export type Coord = [number, number]
 


### PR DESCRIPTION
Fixes #637.

I've currently implemented a dialog box inspired by EditGCContentParamsDialog from jbrowse-components. It's accessed via the Appearance sub-menu in the Annotations track. Two questions: 
1) Is this a bit heavy handed for what is a simple numeric parameter?
2) Do we want to abstract the parameter more? Currently we're presenting the raw bpPerPx unit, which might be confusing? But hopefully the explanatory text in the dialog box demystifies it somewhat.

<img width="722" height="345" alt="image" src="https://github.com/user-attachments/assets/5bf7c469-1762-4565-8fef-082d5afd267d" />
