### PR TITLE
Fix assembly not persisting in desktop when opened vi UI

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/components/OpenLocalFile.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/OpenLocalFile.tsx
@@ -107,7 +107,9 @@ export function OpenLocalFile({ handleClose, session }: OpenLocalFileProps) {
     }
 
     // Save assembly into session
-    await (addSessionAssembly || addAssembly)(assemblyConfig)
+    await (isElectron
+      ? addAssembly?.(assemblyConfig)
+      : (addSessionAssembly || addAssembly)(assemblyConfig))
     const a = await assemblyManager.waitForAssembly(assemblyConfig.name)
     if (a) {
       // @ts-expect-error MST type coercion problem?


### PR DESCRIPTION
If you opened an assembly from "Open local GFF3" in desktop, it didn't persist since it was getting added as a session assembly. This PR adds it as a standard assembly in desktop instead, so it persist after closing an opening JBrowse Desktop.