### PR TITLE
Introduce locked annotation mode (#659)

### DIFF
--- a/packages/jbrowse-plugin-apollo/cypress/e2e/lockSession.cy.ts
+++ b/packages/jbrowse-plugin-apollo/cypress/e2e/lockSession.cy.ts
@@ -1,0 +1,50 @@
+describe('Warning signs', () => {
+  beforeEach(() => {
+    cy.loginAsGuest()
+  })
+  afterEach(() => {
+    cy.deleteAssemblies()
+  })
+  it('Lock session prevents editing', () => {
+    cy.addAssemblyFromGff(
+      'SM_V10_3.fasta.gff3.gz',
+      'test_data/SM_V10_3.fasta.gff3.gz',
+    )
+    cy.selectAssemblyToView('SM_V10_3.fasta.gff3.gz')
+    cy.searchFeatures('gene:Smp_313440', 1)
+    cy.annotationTrackAppearance('Show both graphical and table display')
+    cy.get('input[type="text"][value="192150"]')
+      .first()
+      .type('{selectall}{backspace}192140{enter}', {
+        force: true,
+      })
+    // Refresh table editor
+    cy.annotationTrackAppearance('Show graphical display')
+    cy.annotationTrackAppearance('Show both graphical and table display')
+
+    // Lock session
+    cy.selectFromApolloMenu('Lock/Unlock session')
+    cy.get('input[type="text"][value="192140"]')
+      .first()
+      .type('{selectall}{backspace}192130{enter}', {
+        force: true,
+      })
+    cy.annotationTrackAppearance('Show graphical display')
+    cy.annotationTrackAppearance('Show both graphical and table display')
+    cy.contains('Cannot submit changes in locked mode')
+    cy.contains('192140')
+    cy.get('[data-testid="lock-icon"]').should('exist')
+
+    // Unlock session
+    cy.selectFromApolloMenu('Lock/Unlock session')
+    cy.get('input[type="text"][value="192140"]')
+      .first()
+      .type('{selectall}{backspace}192130{enter}', {
+        force: true,
+      })
+    cy.annotationTrackAppearance('Show graphical display')
+    cy.annotationTrackAppearance('Show both graphical and table display')
+    cy.contains('192130')
+    cy.get('[data-testid="lock-icon"]').should('not.exist')
+  })
+})

--- a/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/addMenuItems.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/addMenuItems.ts
@@ -130,4 +130,10 @@ export function addMenuItems(rootModel: AbstractMenuManager) {
       void apolloDataStore.changeManager.redoLastChange()
     },
   })
+  rootModel.appendToMenu('Apollo', {
+    label: 'Lock/Unlock session',
+    onClick: (session: ApolloSessionModel) => {
+      session.toggleLocked()
+    },
+  })
 }

--- a/packages/jbrowse-plugin-apollo/src/ChangeManager.ts
+++ b/packages/jbrowse-plugin-apollo/src/ChangeManager.ts
@@ -42,9 +42,14 @@ export class ChangeManager {
     const session = getSession(this.dataStore)
     const controller = new AbortController()
 
-    const { jobsManager } = getSession(
+    const { jobsManager, isLocked } = getSession(
       this.dataStore,
     ) as unknown as ApolloSessionModel
+
+    if (isLocked) {
+      session.notify('Cannot submit changes in locked mode')
+      return
+    }
 
     const job = {
       name: change.typeName,

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/LinearApolloDisplay.tsx
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/LinearApolloDisplay.tsx
@@ -10,6 +10,7 @@ import {
 } from '@jbrowse/core/util'
 import { type LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
 import ErrorIcon from '@mui/icons-material/Error'
+import LockIcon from '@mui/icons-material/Lock'
 import {
   Alert,
   Avatar,
@@ -32,6 +33,8 @@ import { type LinearApolloDisplay as LinearApolloDisplayI } from '../stateModel'
 interface LinearApolloDisplayProps {
   model: LinearApolloDisplayI
 }
+
+// Lock icon when isLocked === true
 
 export const LinearApolloDisplay = observer(function LinearApolloDisplay(
   props: LinearApolloDisplayProps,
@@ -91,6 +94,11 @@ export const LinearApolloDisplay = observer(function LinearApolloDisplay(
           }
         }}
       >
+        {session.isLocked ? (
+          <div className={classes.locked} data-testid="lock-icon">
+            <LockIcon />
+          </div>
+        ) : null}
         {loading ? (
           <div className={classes.loading}>
             <CircularProgress size="18px" />

--- a/packages/jbrowse-plugin-apollo/src/session/session.ts
+++ b/packages/jbrowse-plugin-apollo/src/session/session.ts
@@ -75,6 +75,7 @@ export function extendSession(
       apolloDataStore: types.optional(ClientDataStore, { typeName: 'Client' }),
       apolloSelectedFeature: types.safeReference(AnnotationFeatureExtended),
       jobsManager: types.optional(ApolloJobModel, {}),
+      isLocked: types.optional(types.boolean, false),
     })
     .volatile(() => ({
       apolloHoveredFeature: undefined as HoveredFeature | undefined,
@@ -137,6 +138,9 @@ export function extendSession(
             },
           })
         }
+      },
+      toggleLocked() {
+        self.isLocked = !self.isLocked
       },
       broadcastLocations() {
         const { internetAccounts } = getRoot<ApolloRootModel>(self)

--- a/packages/jbrowse-plugin-apollo/src/util/displayUtils.ts
+++ b/packages/jbrowse-plugin-apollo/src/util/displayUtils.ts
@@ -44,6 +44,14 @@ export const useStyles = makeStyles()((theme) => ({
     pointerEvents: 'none',
     textAlign: 'right',
   },
+  locked: {
+    position: 'absolute',
+    right: theme.spacing(3),
+    top: theme.spacing(6),
+    zIndex: 1,
+    pointerEvents: 'none',
+    textAlign: 'right',
+  },
 }))
 
 export interface CheckResultCluster<T> {


### PR DESCRIPTION
This PR introduces the "locked session" option (issue #659). This is how it looks at the moment (note lock icon on the right):

<img width="813" height="587" alt="image" src="https://github.com/user-attachments/assets/8f80692c-3704-421f-9356-d203585cb218" />

There is a test in `cypress/e2e/lockSession.cy.ts`.
