### PR TITLE
Reorganize and add icons to top-level Apollo menu

### DIFF
--- a/packages/jbrowse-plugin-apollo/cypress/e2e/addAssembly.cy.ts
+++ b/packages/jbrowse-plugin-apollo/cypress/e2e/addAssembly.cy.ts
@@ -7,7 +7,7 @@ describe('Add Assembly', () => {
   })
 
   it('Can add assembly from non-editable fasta', () => {
-    cy.selectFromApolloMenu('Add Assembly')
+    cy.selectFromApolloMenu(['Admin', 'Add Assembly'])
     cy.get('form[data-testid="submit-form"]').within(() => {
       cy.get('input[type="TextField"]').type('volvox')
       cy.get('Button[data-testid="submit-button"]').should('be.disabled')
@@ -44,7 +44,7 @@ describe('Add Assembly', () => {
   })
 
   it('Can add assembly from editable gzip fasta', () => {
-    cy.selectFromApolloMenu('Add Assembly')
+    cy.selectFromApolloMenu(['Admin', 'Add Assembly'])
     cy.get('form[data-testid="submit-form"]').within(() => {
       cy.get('input[type="TextField"]').type('volvox')
       cy.get('[data-testid="sequence-is-editable-checkbox"]').within(() => {
@@ -66,7 +66,7 @@ describe('Add Assembly', () => {
   })
 
   it('Can add assembly from editable uncompressed fasta', () => {
-    cy.selectFromApolloMenu('Add Assembly')
+    cy.selectFromApolloMenu(['Admin', 'Add Assembly'])
     cy.get('form[data-testid="submit-form"]').within(() => {
       cy.get('input[type="TextField"]').type('volvox')
       cy.get('[data-testid="sequence-is-editable-checkbox"]').within(() => {
@@ -91,7 +91,7 @@ describe('Add Assembly', () => {
   })
 
   it('Can add assembly from remote url', () => {
-    cy.selectFromApolloMenu('Add Assembly')
+    cy.selectFromApolloMenu(['Admin', 'Add Assembly'])
     cy.get('form[data-testid="submit-form"]').within(() => {
       cy.get('input[type="TextField"]').type('volvox')
       cy.get('[data-testid="files-on-url-checkbox"]').within(() => {
@@ -126,7 +126,7 @@ describe('Add Assembly', () => {
   })
 
   it('Can add assembly and features from gff3', () => {
-    cy.selectFromApolloMenu('Add Assembly')
+    cy.selectFromApolloMenu(['Admin', 'Add Assembly'])
     cy.get('form[data-testid="submit-form"]').within(() => {
       cy.get('input[type="TextField"]').type('volvox')
       cy.contains('GFF3 input')
@@ -155,7 +155,7 @@ describe('Add Assembly', () => {
   })
 
   it('Can add assembly from gff3 wihtout importing features', () => {
-    cy.selectFromApolloMenu('Add Assembly')
+    cy.selectFromApolloMenu(['Admin', 'Add Assembly'])
     cy.get('form[data-testid="submit-form"]').within(() => {
       cy.get('input[type="TextField"]').type('volvox')
       cy.contains('GFF3 input')
@@ -190,7 +190,7 @@ describe('Add Assembly', () => {
     // We select, but don't submit, a gff3 input. This should switch to "sequence is editable" mode.
     // Then we select fasta input: Ensure "Allow sequence to be edited" is unchecked and index files are required.
     // Basically, defaults don't change after having implicitly switched to editable mode.
-    cy.selectFromApolloMenu('Add Assembly')
+    cy.selectFromApolloMenu(['Admin', 'Add Assembly'])
     cy.get('form[data-testid="submit-form"]').within(() => {
       cy.get('input[type="TextField"]').type('volvox')
       cy.contains('GFF3 input')
@@ -232,7 +232,7 @@ describe('Add Assembly', () => {
 
   it('Can override autodetection of gzip compression in FASTA', () => {
     cy.exec('cp test_data/volvox.fa test_data/tmp.fake.gz')
-    cy.selectFromApolloMenu('Add Assembly')
+    cy.selectFromApolloMenu(['Admin', 'Add Assembly'])
     cy.get('form[data-testid="submit-form"]').within(() => {
       cy.get('input[type="TextField"]').type('volvox')
       cy.get('[data-testid="sequence-is-editable-checkbox"]').within(() => {
@@ -258,7 +258,7 @@ describe('Add Assembly', () => {
 
   it('Can override autodetection of gzip compression in GFF3', () => {
     cy.exec('cp test_data/volvox.fasta.gff3 test_data/tmp.fake.gz')
-    cy.selectFromApolloMenu('Add Assembly')
+    cy.selectFromApolloMenu(['Admin', 'Add Assembly'])
     cy.get('form[data-testid="submit-form"]').within(() => {
       cy.get('input[type="TextField"]').type('volvox')
       cy.contains('GFF3 input')

--- a/packages/jbrowse-plugin-apollo/cypress/e2e/showWarnings.cy.ts
+++ b/packages/jbrowse-plugin-apollo/cypress/e2e/showWarnings.cy.ts
@@ -137,7 +137,7 @@ describe('Warning signs', () => {
       .should('satisfy', (n) => n >= 3)
 
     // Unregister all checks
-    cy.selectFromApolloMenu('Manage Checks')
+    cy.selectFromApolloMenu(['Admin', 'Manage Checks'])
     cy.contains('Manage Checks')
       .parent()
       .within(() => {
@@ -156,7 +156,7 @@ describe('Warning signs', () => {
     cy.get('[data-testid^="ErrorIcon-"]', { timeout: 5000 }).should('not.exist')
 
     // Register CDSCheck and count warning(s):
-    cy.selectFromApolloMenu('Manage Checks')
+    cy.selectFromApolloMenu(['Admin', 'Manage Checks'])
     cy.contains('Manage Checks')
       .parent()
       .within(() => {

--- a/packages/jbrowse-plugin-apollo/cypress/support/commands.ts
+++ b/packages/jbrowse-plugin-apollo/cypress/support/commands.ts
@@ -116,21 +116,35 @@ Cypress.Commands.add(
   },
 )
 
-Cypress.Commands.add('selectFromApolloMenu', (menuItemName) => {
-  cy.wrap(Cypress.$('body')).within(() => {
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(1000)
-    cy.get('button[data-testid="dropDownMenuButton"]', { timeout: 10_000 })
-      .contains('Apollo')
-      .click({ force: true, timeout: 10_000 })
-    cy.contains(menuItemName, { timeout: 10_000 }).click()
-  })
-})
+Cypress.Commands.add(
+  'selectFromApolloMenu',
+  (menuItemNameOrPath: string | string[]) => {
+    const menuItemPath = Array.isArray(menuItemNameOrPath)
+      ? menuItemNameOrPath
+      : [menuItemNameOrPath]
+    const menuItemName = menuItemPath.at(-1)
+    if (!menuItemName) {
+      return
+    }
+    const menuItemPathPrefix = menuItemPath.slice(0, -1)
+    cy.wrap(Cypress.$('body')).within(() => {
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(1000)
+      cy.get('button[data-testid="dropDownMenuButton"]', { timeout: 10_000 })
+        .contains('Apollo')
+        .click({ force: true, timeout: 10_000 })
+      for (const pathPart of menuItemPathPrefix) {
+        cy.contains(pathPart, { timeout: 10_000 }).click()
+      }
+      cy.contains(menuItemName, { timeout: 10_000 }).click()
+    })
+  },
+)
 
 Cypress.Commands.add(
   'addAssemblyFromGff',
   (assemblyName, fin, launch = true, loadFeatures = true) => {
-    cy.selectFromApolloMenu('Add Assembly')
+    cy.selectFromApolloMenu(['Admin', 'Add Assembly'])
     cy.get('form[data-testid="submit-form"]').within(() => {
       cy.get('input[type="TextField"]').type(assemblyName)
       cy.contains('GFF3 input')
@@ -247,7 +261,7 @@ Cypress.Commands.add(
 Cypress.Commands.add(
   'importFeatures',
   (gffFile, assemblyName, deleteExistingFeatures) => {
-    cy.selectFromApolloMenu('Import Features')
+    cy.selectFromApolloMenu(['Admin', 'Import Features'])
     cy.contains('Import Features from GFF3 file', { matchCase: false })
       .parent()
       .within(() => {

--- a/packages/jbrowse-plugin-apollo/cypress/support/index.d.ts
+++ b/packages/jbrowse-plugin-apollo/cypress/support/index.d.ts
@@ -5,7 +5,7 @@ declare namespace Cypress {
     addOntologies(): Chainable<void>
     loginAsGuest(): Chainable<void>
     deleteAssemblies(): Chainable<void>
-    selectFromApolloMenu(menuItemName: string): Chainable<void>
+    selectFromApolloMenu(menuItemNameOrPath: string | string[]): Chainable<void>
     annotationTrackAppearance(
       appearance:
         | 'Show both graphical and table display'

--- a/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
@@ -26,11 +26,11 @@ import { autorun } from 'mobx'
 import { type Instance, flow, getRoot, isAlive, types } from 'mobx-state-tree'
 import { io } from 'socket.io-client'
 
+import { addTopLevelAdminMenus } from '../menus/topLevelMenuAdmin'
 import { type Collaborator } from '../session'
 import { type ApolloRootModel } from '../types'
 import { createFetchErrorMessage } from '../util'
 
-import { addMenuItems } from './addMenuItems'
 import { AuthTypeSelector } from './components/AuthTypeSelector'
 import { type ApolloInternetAccountConfigModel } from './configSchema'
 
@@ -423,7 +423,7 @@ const stateModelFactory = (configSchema: ApolloInternetAccountConfigModel) => {
         if (role === 'admin') {
           const rootModel = getRoot(self)
           if (isAbstractMenuManager(rootModel)) {
-            addMenuItems(rootModel)
+            addTopLevelAdminMenus(rootModel)
           }
         }
         // Get and set server last change sequence into session storage

--- a/packages/jbrowse-plugin-apollo/src/components/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from './AddAssembly'
+export * from './AddAssemblyAliases'
 export * from './AddChildFeature'
 export * from './AddFeature'
 export * from './CopyFeature'

--- a/packages/jbrowse-plugin-apollo/src/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/index.ts
@@ -61,15 +61,7 @@ import {
   configSchema as linearApolloSixFrameDisplayConfigSchema,
   stateModelFactory as LinearApolloSixFrameDisplayStateModelFactory,
 } from './LinearApolloSixFrameDisplay'
-import {
-  AddFeature,
-  DownloadGFF3,
-  LogOut,
-  ManageChecks,
-  OpenLocalFile,
-  ViewChangeLog,
-  ViewCheckResults,
-} from './components'
+import { AddFeature } from './components'
 import ApolloPluginConfigurationSchema from './config'
 import {
   annotationFromJBrowseFeature,
@@ -79,6 +71,7 @@ import {
   LinearApolloDisplayComponent,
   LinearApolloSixFrameDisplayComponent,
 } from './makeDisplayComponent'
+import { addTopLevelMenus } from './menus'
 import { type ApolloSessionModel, extendSession } from './session'
 
 interface RpcHandle {
@@ -383,103 +376,7 @@ export default class ApolloPlugin extends Plugin {
 
   configure(pluginManager: PluginManager) {
     if (isAbstractMenuManager(pluginManager.rootModel)) {
-      pluginManager.rootModel.appendToMenu('Apollo', {
-        label: 'Download GFF3',
-        onClick: (session: ApolloSessionModel) => {
-          ;(session as unknown as AbstractSessionModel).queueDialog(
-            (doneCallback) => [
-              DownloadGFF3,
-              {
-                session,
-                handleClose: () => {
-                  doneCallback()
-                },
-              },
-            ],
-          )
-        },
-      })
-      pluginManager.rootModel.appendToMenu('Apollo', {
-        label: 'Manage Checks',
-        onClick: (session: ApolloSessionModel) => {
-          ;(session as unknown as AbstractSessionModel).queueDialog(
-            (doneCallback) => [
-              ManageChecks,
-              {
-                session,
-                handleClose: () => {
-                  doneCallback()
-                },
-              },
-            ],
-          )
-        },
-      })
-      pluginManager.rootModel.appendToMenu('Apollo', {
-        label: 'View Change Log',
-        onClick: (session: ApolloSessionModel) => {
-          ;(session as unknown as AbstractSessionModel).queueDialog(
-            (doneCallback) => [
-              ViewChangeLog,
-              {
-                session,
-                handleClose: () => {
-                  doneCallback()
-                },
-              },
-            ],
-          )
-        },
-      })
-      pluginManager.rootModel.appendToMenu('Apollo', {
-        label: 'Open local GFF3 file',
-        onClick: (session: ApolloSessionModel) => {
-          ;(session as unknown as AbstractSessionModel).queueDialog(
-            (doneCallback) => [
-              OpenLocalFile,
-              {
-                session,
-                handleClose: () => {
-                  doneCallback()
-                },
-                inMemoryFileDriver: session.apolloDataStore.inMemoryFileDriver,
-              },
-            ],
-          )
-        },
-      })
-      pluginManager.rootModel.appendToMenu('Apollo', {
-        label: 'View check results',
-        onClick: (session: ApolloSessionModel) => {
-          ;(session as unknown as AbstractSessionModel).queueDialog(
-            (doneCallback) => [
-              ViewCheckResults,
-              {
-                session,
-                handleClose: () => {
-                  doneCallback()
-                },
-              },
-            ],
-          )
-        },
-      })
-      pluginManager.rootModel.appendToMenu('Apollo', {
-        label: 'Log out',
-        onClick: (session: ApolloSessionModel) => {
-          ;(session as unknown as AbstractSessionModel).queueDialog(
-            (doneCallback) => [
-              LogOut,
-              {
-                session,
-                handleClose: () => {
-                  doneCallback()
-                },
-              },
-            ],
-          )
-        },
-      })
+      addTopLevelMenus(pluginManager.rootModel)
     }
   }
 }

--- a/packages/jbrowse-plugin-apollo/src/menus/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/menus/index.ts
@@ -1,0 +1,1 @@
+export { addTopLevelMenus } from './topLevelMenu'

--- a/packages/jbrowse-plugin-apollo/src/menus/topLevelMenu.ts
+++ b/packages/jbrowse-plugin-apollo/src/menus/topLevelMenu.ts
@@ -2,138 +2,139 @@ import {
   type AbstractMenuManager,
   type AbstractSessionModel,
 } from '@jbrowse/core/util'
+import DownloadIcon from '@mui/icons-material/Download'
+import FactCheckIcon from '@mui/icons-material/FactCheck'
+import FileOpenIcon from '@mui/icons-material/FileOpen'
+import LogoutIcon from '@mui/icons-material/Logout'
+import RedoIcon from '@mui/icons-material/Redo'
+import TrackChangesIcon from '@mui/icons-material/TrackChanges'
+import UndoIcon from '@mui/icons-material/Undo'
 
 import {
-  AddAssembly,
-  AddRefSeqAliases,
-  DeleteAssembly,
-  ImportFeatures,
-  ManageUsers,
+  DownloadGFF3,
+  LogOut,
+  OpenLocalFile,
+  ViewChangeLog,
+  ViewCheckResults,
 } from '../components'
-import { AddAssemblyAliases } from '../components/AddAssemblyAliases'
 import { type ApolloSessionModel } from '../session'
 
-export function addMenuItems(rootModel: AbstractMenuManager) {
+export function addTopLevelMenus(rootModel: AbstractMenuManager) {
+  rootModel.insertInMenu(
+    'Apollo',
+    {
+      label: 'Redo',
+      icon: RedoIcon,
+      onClick(session: ApolloSessionModel) {
+        const { apolloDataStore } = session
+        void apolloDataStore.changeManager.redoLastChange()
+      },
+    },
+    0,
+  )
+  rootModel.insertInMenu(
+    'Apollo',
+    {
+      label: 'Undo',
+      icon: UndoIcon,
+      onClick(session: ApolloSessionModel) {
+        const { apolloDataStore } = session
+        void apolloDataStore.changeManager.undoLastChange()
+      },
+    },
+    0,
+  )
+
   rootModel.appendToMenu('Apollo', {
-    label: 'Add Assembly',
+    label: 'Download GFF3',
+    icon: DownloadIcon,
     onClick: (session: ApolloSessionModel) => {
       ;(session as unknown as AbstractSessionModel).queueDialog(
         (doneCallback) => [
-          AddAssembly,
+          DownloadGFF3,
           {
             session,
             handleClose: () => {
               doneCallback()
             },
-            changeManager: session.apolloDataStore.changeManager,
           },
         ],
       )
     },
   })
   rootModel.appendToMenu('Apollo', {
-    label: 'Delete Assembly',
+    label: 'View Change Log',
+    icon: TrackChangesIcon,
     onClick: (session: ApolloSessionModel) => {
       ;(session as unknown as AbstractSessionModel).queueDialog(
         (doneCallback) => [
-          DeleteAssembly,
+          ViewChangeLog,
           {
             session,
             handleClose: () => {
               doneCallback()
             },
-            changeManager: session.apolloDataStore.changeManager,
           },
         ],
       )
     },
   })
   rootModel.appendToMenu('Apollo', {
-    label: 'Import Features',
+    label: 'Open local GFF3 file',
+    icon: FileOpenIcon,
     onClick: (session: ApolloSessionModel) => {
       ;(session as unknown as AbstractSessionModel).queueDialog(
         (doneCallback) => [
-          ImportFeatures,
+          OpenLocalFile,
           {
             session,
             handleClose: () => {
               doneCallback()
             },
-            changeManager: session.apolloDataStore.changeManager,
+            inMemoryFileDriver: session.apolloDataStore.inMemoryFileDriver,
           },
         ],
       )
     },
   })
   rootModel.appendToMenu('Apollo', {
-    label: 'Add reference sequence aliases',
+    label: 'View check results',
+    icon: FactCheckIcon,
     onClick: (session: ApolloSessionModel) => {
       ;(session as unknown as AbstractSessionModel).queueDialog(
         (doneCallback) => [
-          AddRefSeqAliases,
+          ViewCheckResults,
           {
             session,
             handleClose: () => {
               doneCallback()
             },
-            changeManager: session.apolloDataStore.changeManager,
           },
         ],
       )
-    },
-  })
-  rootModel.appendToMenu('Apollo', {
-    label: 'Add Assembly aliases',
-    onClick: (session: ApolloSessionModel) => {
-      ;(session as unknown as AbstractSessionModel).queueDialog(
-        (doneCallback) => [
-          AddAssemblyAliases,
-          {
-            session,
-            handleClose: () => {
-              doneCallback()
-            },
-            changeManager: session.apolloDataStore.changeManager,
-          },
-        ],
-      )
-    },
-  })
-  rootModel.appendToMenu('Apollo', {
-    label: 'Manage Users',
-    onClick: (session: ApolloSessionModel) => {
-      ;(session as unknown as AbstractSessionModel).queueDialog(
-        (doneCallback) => [
-          ManageUsers,
-          {
-            session,
-            handleClose: () => {
-              doneCallback()
-            },
-            changeManager: session.apolloDataStore.changeManager,
-          },
-        ],
-      )
-    },
-  })
-  rootModel.appendToMenu('Apollo', {
-    label: 'Undo',
-    onClick: (session: ApolloSessionModel) => {
-      const { apolloDataStore } = session
-      void apolloDataStore.changeManager.undoLastChange()
-    },
-  })
-  rootModel.appendToMenu('Apollo', {
-    label: 'Redo',
-    onClick: (session: ApolloSessionModel) => {
-      const { apolloDataStore } = session
-      void apolloDataStore.changeManager.redoLastChange()
     },
   })
   rootModel.appendToMenu('Apollo', {
     label: 'Lock/Unlock session',
     onClick: (session: ApolloSessionModel) => {
       session.toggleLocked()
+    },
+  })
+  rootModel.appendToMenu('Apollo', {
+    label: 'Log out',
+    icon: LogoutIcon,
+    onClick: (session: ApolloSessionModel) => {
+      ;(session as unknown as AbstractSessionModel).queueDialog(
+        (doneCallback) => [
+          LogOut,
+          {
+            session,
+            handleClose: () => {
+              doneCallback()
+            },
+          },
+        ],
+      )
     },
   })
 }

--- a/packages/jbrowse-plugin-apollo/src/menus/topLevelMenuAdmin.ts
+++ b/packages/jbrowse-plugin-apollo/src/menus/topLevelMenuAdmin.ts
@@ -1,0 +1,154 @@
+import {
+  type AbstractMenuManager,
+  type AbstractSessionModel,
+} from '@jbrowse/core/util'
+import AddIcon from '@mui/icons-material/Add'
+import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings'
+import DeleteIcon from '@mui/icons-material/Delete'
+import InputIcon from '@mui/icons-material/Input'
+import PersonIcon from '@mui/icons-material/Person'
+import RuleIcon from '@mui/icons-material/Rule'
+
+import {
+  AddAssembly,
+  AddAssemblyAliases,
+  AddRefSeqAliases,
+  DeleteAssembly,
+  ImportFeatures,
+  ManageChecks,
+  ManageUsers,
+} from '../components'
+import { type ApolloSessionModel } from '../session'
+
+export function addTopLevelAdminMenus(rootModel: AbstractMenuManager) {
+  rootModel.appendToMenu('Apollo', {
+    label: 'Admin',
+    type: 'subMenu',
+    icon: AdminPanelSettingsIcon,
+    subMenu: [
+      {
+        label: 'Add Assembly',
+        icon: AddIcon,
+        onClick: (session: ApolloSessionModel) => {
+          ;(session as unknown as AbstractSessionModel).queueDialog(
+            (doneCallback) => [
+              AddAssembly,
+              {
+                session,
+                handleClose: () => {
+                  doneCallback()
+                },
+                changeManager: session.apolloDataStore.changeManager,
+              },
+            ],
+          )
+        },
+      },
+      {
+        label: 'Delete Assembly',
+        icon: DeleteIcon,
+        onClick: (session: ApolloSessionModel) => {
+          ;(session as unknown as AbstractSessionModel).queueDialog(
+            (doneCallback) => [
+              DeleteAssembly,
+              {
+                session,
+                handleClose: () => {
+                  doneCallback()
+                },
+                changeManager: session.apolloDataStore.changeManager,
+              },
+            ],
+          )
+        },
+      },
+      {
+        label: 'Import Features',
+        icon: InputIcon,
+        onClick: (session: ApolloSessionModel) => {
+          ;(session as unknown as AbstractSessionModel).queueDialog(
+            (doneCallback) => [
+              ImportFeatures,
+              {
+                session,
+                handleClose: () => {
+                  doneCallback()
+                },
+                changeManager: session.apolloDataStore.changeManager,
+              },
+            ],
+          )
+        },
+      },
+      {
+        label: 'Add reference sequence aliases',
+        onClick: (session: ApolloSessionModel) => {
+          ;(session as unknown as AbstractSessionModel).queueDialog(
+            (doneCallback) => [
+              AddRefSeqAliases,
+              {
+                session,
+                handleClose: () => {
+                  doneCallback()
+                },
+                changeManager: session.apolloDataStore.changeManager,
+              },
+            ],
+          )
+        },
+      },
+      {
+        label: 'Add Assembly aliases',
+        onClick: (session: ApolloSessionModel) => {
+          ;(session as unknown as AbstractSessionModel).queueDialog(
+            (doneCallback) => [
+              AddAssemblyAliases,
+              {
+                session,
+                handleClose: () => {
+                  doneCallback()
+                },
+                changeManager: session.apolloDataStore.changeManager,
+              },
+            ],
+          )
+        },
+      },
+      {
+        label: 'Manage Users',
+        icon: PersonIcon,
+        onClick: (session: ApolloSessionModel) => {
+          ;(session as unknown as AbstractSessionModel).queueDialog(
+            (doneCallback) => [
+              ManageUsers,
+              {
+                session,
+                handleClose: () => {
+                  doneCallback()
+                },
+                changeManager: session.apolloDataStore.changeManager,
+              },
+            ],
+          )
+        },
+      },
+      {
+        label: 'Manage Checks',
+        icon: RuleIcon,
+        onClick: (session: ApolloSessionModel) => {
+          ;(session as unknown as AbstractSessionModel).queueDialog(
+            (doneCallback) => [
+              ManageChecks,
+              {
+                session,
+                handleClose: () => {
+                  doneCallback()
+                },
+              },
+            ],
+          )
+        },
+      },
+    ],
+  })
+}


### PR DESCRIPTION
This re-organizes the menus, moving admin-specific actions into an "Admin" sub-menu, and adds some icons to the menu entries.

Before
<img width="215" height="478" alt="image" src="https://github.com/user-attachments/assets/c191104b-c791-44f6-b6e0-1dbdd5c0e4e2" />

After
<img width="434" height="350" alt="image" src="https://github.com/user-attachments/assets/d2b75f9a-e010-4a18-b1be-2807f8698ac8" />