### PR TITLE
Simplify CDS editing in transcript details widget

### DIFF
--- a/packages/apollo-shared/src/Checks/CDSCheck.ts
+++ b/packages/apollo-shared/src/Checks/CDSCheck.ts
@@ -189,7 +189,7 @@ async function checkMRNA(
           refSeq: refSeq.toString(),
           start: cdsEnd,
           end: cdsEnd,
-          message: `Missing stop codon for feature "${_id}"`,
+          message: `Missing stop codon in feature "${_id}"`,
         })
       }
     } else {
@@ -201,7 +201,7 @@ async function checkMRNA(
         refSeq: refSeq.toString(),
         start: cdsEnd,
         end: cdsEnd,
-        message: `Missing stop codon: The coding sequence for feature "${_id}" is not a multiple of three`,
+        message: `Missing stop codon in feature "${_id}"`,
       })
     }
     for (const [idx, codon] of codons.entries()) {
@@ -220,7 +220,7 @@ async function checkMRNA(
           refSeq: refSeq.toString(),
           start: codonStart,
           end: codonEnd,
-          message: `The coding sequence for feature "${_id}" has an internal stop codon`,
+          message: `Internal stop codon in feature "${_id}"`,
         })
       }
     }

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/BasicInformation.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/BasicInformation.tsx
@@ -66,7 +66,7 @@ export const BasicInformation = observer(function BasicInformation({
     return changeManager.submit(change)
   }
 
-  function handleStartChange(newStart: number) {
+  function handleStartChange(newStart: number): boolean {
     newStart--
     const change = new LocationStartChange({
       typeName: 'LocationStartChange',
@@ -76,10 +76,11 @@ export const BasicInformation = observer(function BasicInformation({
       newStart,
       assembly,
     })
-    return changeManager.submit(change)
+    void changeManager.submit(change)
+    return true
   }
 
-  function handleEndChange(newEnd: number) {
+  function handleEndChange(newEnd: number): boolean {
     const change = new LocationEndChange({
       typeName: 'LocationEndChange',
       changedIds: [_id],
@@ -88,7 +89,8 @@ export const BasicInformation = observer(function BasicInformation({
       newEnd,
       assembly,
     })
-    return changeManager.submit(change)
+    void changeManager.submit(change)
+    return true
   }
 
   async function fetchValidTerms(

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/NumberTextField.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/NumberTextField.tsx
@@ -15,7 +15,7 @@ interface NumberTextFieldProps
     | 'error'
     | 'helperText'
   > {
-  onChangeCommitted(newValue: number): void
+  onChangeCommitted(newValue: number): boolean
   value: unknown
 }
 
@@ -65,7 +65,10 @@ export const NumberTextField = observer(function NumberTextField({
           if (Number.isNaN(valueAsNumber)) {
             setValue(String(initialValue))
           } else {
-            onChangeCommitted(valueAsNumber)
+            const success = onChangeCommitted(valueAsNumber)
+            if (!success) {
+              setValue(String(initialValue))
+            }
           }
         }
       }}

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptWidgetEditLocation.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptWidgetEditLocation.tsx
@@ -155,12 +155,12 @@ export const TranscriptWidgetEditLocation = observer(
       feature: AnnotationFeature,
       isMin: boolean,
       onComplete?: () => void,
-    ) => {
+    ): boolean => {
       if (!feature.children) {
         throw new Error('Transcript should have child features')
       }
       if (oldLocation === newLocation) {
-        return
+        return true
       }
 
       const cdsFeature = getMatchingCDSFeature(
@@ -171,12 +171,12 @@ export const TranscriptWidgetEditLocation = observer(
       )
       if (!cdsFeature) {
         notify('No matching CDS feature found', 'error')
-        return
+        return false
       }
 
       if (isMin && newLocation >= cdsFeature.max) {
         notify('Start location should be less than CDS end location', 'error')
-        return
+        return false
       }
 
       if (!isMin && newLocation <= cdsFeature.min) {
@@ -184,7 +184,7 @@ export const TranscriptWidgetEditLocation = observer(
           'End location should be greater than CDS start location',
           'error',
         )
-        return
+        return false
       }
 
       // overlapping exon of new CDS location
@@ -200,7 +200,7 @@ export const TranscriptWidgetEditLocation = observer(
           'There should be an overlapping exon for the new CDS location',
           'error',
         )
-        return
+        return false
       }
 
       const change = isMin
@@ -231,6 +231,7 @@ export const TranscriptWidgetEditLocation = observer(
         .catch(() => {
           notify('Error updating feature CDS position', 'error')
         })
+      return true
     }
 
     function handleExonLocationChange(
@@ -238,7 +239,7 @@ export const TranscriptWidgetEditLocation = observer(
       newLocation: number,
       feature: AnnotationFeature,
       isMin: boolean,
-    ) {
+    ): boolean {
       if (!feature.children) {
         throw new Error('Transcript should have child features')
       }
@@ -251,28 +252,28 @@ export const TranscriptWidgetEditLocation = observer(
 
       if (!matchingExon) {
         notify('No matching exon found', 'error')
-        return
+        return false
       }
 
       // Start location should be less than end location
       if (isMin && newLocation >= matchingExon.max) {
         notify(`Start location should be less than end location`, 'error')
-        return
+        return false
       }
       // End location should be greater than start location
       if (!isMin && newLocation <= matchingExon.min) {
         notify(`End location should be greater than start location`, 'error')
-        return
+        return false
       }
       // Changed location should be greater than end location of previous exon - give 2bp buffer
       if (prevExon && prevExon.max + 2 > newLocation) {
         notify(`Error while changing start location`, 'error')
-        return
+        return false
       }
       // Changed location should be less than start location of next exon - give 2bp buffer
       if (nextExon && nextExon.min - 2 < newLocation) {
         notify(`Error while changing end location`, 'error')
-        return
+        return false
       }
 
       const exonFeature = getExonFeature(
@@ -283,7 +284,7 @@ export const TranscriptWidgetEditLocation = observer(
       )
       if (!exonFeature) {
         notify('No matching exon feature found', 'error')
-        return
+        return false
       }
 
       const cdsFeature = getFirstCDSFeature(feature, featureTypeOntology)
@@ -411,6 +412,7 @@ export const TranscriptWidgetEditLocation = observer(
           notify('Error updating feature exon end position', 'error')
         })
       }
+      return true
     }
 
     const appendEndLocationChange = (
@@ -1004,7 +1006,12 @@ export const TranscriptWidgetEditLocation = observer(
                     variant="outlined"
                     value={cdsMin + 1}
                     onChangeCommitted={(newLocation: number) => {
-                      updateCDSLocation(cdsMin, newLocation - 1, feature, true)
+                      return updateCDSLocation(
+                        cdsMin,
+                        newLocation - 1,
+                        feature,
+                        true,
+                      )
                     }}
                     style={{ border: '1px solid black', borderRadius: 5 }}
                   />
@@ -1016,7 +1023,12 @@ export const TranscriptWidgetEditLocation = observer(
                     variant="outlined"
                     value={cdsMax}
                     onChangeCommitted={(newLocation: number) => {
-                      updateCDSLocation(cdsMax, newLocation, feature, false)
+                      return updateCDSLocation(
+                        cdsMax,
+                        newLocation,
+                        feature,
+                        false,
+                      )
                     }}
                     style={{ border: '1px solid black', borderRadius: 5 }}
                   />
@@ -1032,7 +1044,12 @@ export const TranscriptWidgetEditLocation = observer(
                     variant="outlined"
                     value={cdsMax}
                     onChangeCommitted={(newLocation: number) => {
-                      updateCDSLocation(cdsMax, newLocation, feature, false)
+                      return updateCDSLocation(
+                        cdsMax,
+                        newLocation,
+                        feature,
+                        false,
+                      )
                     }}
                     style={{ border: '1px solid black', borderRadius: 5 }}
                   />
@@ -1044,7 +1061,12 @@ export const TranscriptWidgetEditLocation = observer(
                     variant="outlined"
                     value={cdsMin + 1}
                     onChangeCommitted={(newLocation: number) => {
-                      updateCDSLocation(cdsMin, newLocation - 1, feature, true)
+                      return updateCDSLocation(
+                        cdsMin,
+                        newLocation - 1,
+                        feature,
+                        true,
+                      )
                     }}
                     style={{ border: '1px solid black', borderRadius: 5 }}
                   />
@@ -1084,7 +1106,7 @@ export const TranscriptWidgetEditLocation = observer(
                           variant="outlined"
                           value={loc.min + 1}
                           onChangeCommitted={(newLocation: number) => {
-                            handleExonLocationChange(
+                            return handleExonLocationChange(
                               loc.min,
                               newLocation - 1,
                               feature,
@@ -1100,7 +1122,7 @@ export const TranscriptWidgetEditLocation = observer(
                           variant="outlined"
                           value={loc.max}
                           onChangeCommitted={(newLocation: number) => {
-                            handleExonLocationChange(
+                            return handleExonLocationChange(
                               loc.max,
                               newLocation,
                               feature,
@@ -1120,7 +1142,7 @@ export const TranscriptWidgetEditLocation = observer(
                           variant="outlined"
                           value={loc.max}
                           onChangeCommitted={(newLocation: number) => {
-                            handleExonLocationChange(
+                            return handleExonLocationChange(
                               loc.max,
                               newLocation,
                               feature,
@@ -1136,7 +1158,7 @@ export const TranscriptWidgetEditLocation = observer(
                           variant="outlined"
                           value={loc.min + 1}
                           onChangeCommitted={(newLocation: number) => {
-                            handleExonLocationChange(
+                            return handleExonLocationChange(
                               loc.min,
                               newLocation - 1,
                               feature,

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptWidgetEditLocation.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/TranscriptWidgetEditLocation.tsx
@@ -149,201 +149,6 @@ export const TranscriptWidgetEditLocation = observer(
       cdsMax = sortedCDSLocations[sortedCDSLocations.length - 1].max
     }
 
-    function handleCDSLocationChange(
-      oldLocation: number,
-      newLocation: number,
-      feature: AnnotationFeature,
-      isMin: boolean,
-    ) {
-      if (!feature.children) {
-        throw new Error('Transcript should have child features')
-      }
-
-      const overlappingExon = getOverlappingExonForCDS(
-        feature,
-        featureTypeOntology,
-        oldLocation,
-        isMin,
-      )
-      if (!overlappingExon) {
-        notify('No matching exon found', 'error')
-        return
-      }
-      const oldExonLocation = isMin ? overlappingExon.min : overlappingExon.max
-      const { prevExon, nextExon } = getNeighboringExonParts(
-        feature,
-        featureTypeOntology,
-        oldExonLocation,
-        isMin,
-      )
-
-      // Start location should be less than end location
-      if (isMin && newLocation >= overlappingExon.max) {
-        notify(
-          'Start location should be less than overlapping exon end location',
-          'error',
-        )
-        return
-      }
-
-      // End location should be greater than start location
-      if (!isMin && newLocation <= overlappingExon.min) {
-        notify(
-          'End location should be greater than overlapping exon start location',
-          'error',
-        )
-        return
-      }
-      // Changed location should be greater than end location of previous exon - give 2bp buffer
-      if (prevExon && prevExon.max + 2 > newLocation) {
-        notify(
-          'Start location should be greater than previous exon end location',
-          'error',
-        )
-        return
-      }
-      // Changed location should be less than start location of next exon
-      if (nextExon && nextExon.min - 2 < newLocation) {
-        notify(
-          'End location should be less than next exon start location',
-          'error',
-        )
-        return
-      }
-
-      const cdsFeature = getMatchingCDSFeature(
-        feature,
-        featureTypeOntology,
-        oldLocation,
-        isMin,
-      )
-
-      if (!cdsFeature) {
-        notify('No matching CDS feature found', 'error')
-        return
-      }
-
-      if (!isMin && newLocation <= cdsFeature.min) {
-        notify(
-          'End location should be greater than CDS start location',
-          'error',
-        )
-        return
-      }
-      if (isMin && newLocation >= cdsFeature.max) {
-        notify('Start location should be less than CDS end location', 'error')
-        return
-      }
-
-      const overlappingExonFeature = getExonFeature(
-        feature,
-        overlappingExon.min,
-        overlappingExon.max,
-        featureTypeOntology,
-      )
-
-      if (!overlappingExonFeature) {
-        notify('No matching exon feature found', 'error')
-        return
-      }
-
-      if (isMin && newLocation !== cdsFeature.min) {
-        const startChange: LocationStartChange = new LocationStartChange({
-          typeName: 'LocationStartChange',
-          changedIds: [],
-          changes: [],
-          assembly,
-        })
-
-        if (newLocation < overlappingExon.min) {
-          if (prevExon) {
-            // update exon start location
-            appendStartLocationChange(
-              overlappingExonFeature,
-              startChange,
-              newLocation,
-            )
-            // update CDS start location
-            appendStartLocationChange(cdsFeature, startChange, newLocation)
-          } else {
-            const transcriptStart = feature.min
-            const gene = feature.parent
-            if (newLocation < transcriptStart) {
-              if (gene && newLocation < gene.min) {
-                // update gene start location
-                appendStartLocationChange(gene, startChange, newLocation)
-              }
-              // update transcript start location
-              appendStartLocationChange(feature, startChange, newLocation)
-              // update exon start location
-              appendStartLocationChange(
-                overlappingExonFeature,
-                startChange,
-                newLocation,
-              )
-              // update CDS start location
-              appendStartLocationChange(cdsFeature, startChange, newLocation)
-            }
-          }
-        } else {
-          // update CDS start location
-          appendStartLocationChange(cdsFeature, startChange, newLocation)
-        }
-
-        void changeManager.submit(startChange).catch(() => {
-          notify('Error updating feature CDS start position', 'error')
-        })
-      }
-
-      if (!isMin && newLocation !== cdsFeature.max) {
-        const endChange: LocationEndChange = new LocationEndChange({
-          typeName: 'LocationEndChange',
-          changedIds: [],
-          changes: [],
-          assembly,
-        })
-
-        if (newLocation > overlappingExon.max) {
-          if (nextExon) {
-            // update exon end location
-            appendEndLocationChange(
-              overlappingExonFeature,
-              endChange,
-              newLocation,
-            )
-            // update CDS end location
-            appendEndLocationChange(cdsFeature, endChange, newLocation)
-          } else {
-            const transcriptEnd = feature.max
-            const gene = feature.parent
-            if (newLocation > transcriptEnd) {
-              if (gene && newLocation > gene.max) {
-                // update gene end location
-                appendEndLocationChange(gene, endChange, newLocation)
-              }
-              // update transcript end location
-              appendEndLocationChange(feature, endChange, newLocation)
-              // update exon end location
-              appendEndLocationChange(
-                overlappingExonFeature,
-                endChange,
-                newLocation,
-              )
-              // update CDS end location
-              appendEndLocationChange(cdsFeature, endChange, newLocation)
-            }
-          }
-        } else {
-          // update CDS end location
-          appendEndLocationChange(cdsFeature, endChange, newLocation)
-        }
-
-        void changeManager.submit(endChange).catch(() => {
-          notify('Error updating feature CDS end position', 'error')
-        })
-      }
-    }
-
     const updateCDSLocation = (
       oldLocation: number,
       newLocation: number,
@@ -366,6 +171,35 @@ export const TranscriptWidgetEditLocation = observer(
       )
       if (!cdsFeature) {
         notify('No matching CDS feature found', 'error')
+        return
+      }
+
+      if (isMin && newLocation >= cdsFeature.max) {
+        notify('Start location should be less than CDS end location', 'error')
+        return
+      }
+
+      if (!isMin && newLocation <= cdsFeature.min) {
+        notify(
+          'End location should be greater than CDS start location',
+          'error',
+        )
+        return
+      }
+
+      // overlapping exon of new CDS location
+      const overlappingExon = getOverlappingExonForCDS(
+        feature,
+        featureTypeOntology,
+        newLocation,
+        isMin,
+      )
+
+      if (!overlappingExon) {
+        notify(
+          'There should be an overlapping exon for the new CDS location',
+          'error',
+        )
         return
       }
 
@@ -1170,12 +1004,7 @@ export const TranscriptWidgetEditLocation = observer(
                     variant="outlined"
                     value={cdsMin + 1}
                     onChangeCommitted={(newLocation: number) => {
-                      handleCDSLocationChange(
-                        cdsMin,
-                        newLocation - 1,
-                        feature,
-                        true,
-                      )
+                      updateCDSLocation(cdsMin, newLocation - 1, feature, true)
                     }}
                     style={{ border: '1px solid black', borderRadius: 5 }}
                   />
@@ -1187,12 +1016,7 @@ export const TranscriptWidgetEditLocation = observer(
                     variant="outlined"
                     value={cdsMax}
                     onChangeCommitted={(newLocation: number) => {
-                      handleCDSLocationChange(
-                        cdsMax,
-                        newLocation,
-                        feature,
-                        false,
-                      )
+                      updateCDSLocation(cdsMax, newLocation, feature, false)
                     }}
                     style={{ border: '1px solid black', borderRadius: 5 }}
                   />
@@ -1208,12 +1032,7 @@ export const TranscriptWidgetEditLocation = observer(
                     variant="outlined"
                     value={cdsMax}
                     onChangeCommitted={(newLocation: number) => {
-                      handleCDSLocationChange(
-                        cdsMax,
-                        newLocation,
-                        feature,
-                        false,
-                      )
+                      updateCDSLocation(cdsMax, newLocation, feature, false)
                     }}
                     style={{ border: '1px solid black', borderRadius: 5 }}
                   />
@@ -1225,12 +1044,7 @@ export const TranscriptWidgetEditLocation = observer(
                     variant="outlined"
                     value={cdsMin + 1}
                     onChangeCommitted={(newLocation: number) => {
-                      handleCDSLocationChange(
-                        cdsMin,
-                        newLocation - 1,
-                        feature,
-                        true,
-                      )
+                      updateCDSLocation(cdsMin, newLocation - 1, feature, true)
                     }}
                     style={{ border: '1px solid black', borderRadius: 5 }}
                   />


### PR DESCRIPTION
### Details

Make CDS editing in input boxes similar to translation panel. Checks If there is a underlying exon and if start/end of CDS don't overlap. 

Requested by Havana