### PR TITLE
Change strand of transcript and its children to destination gene strand

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/components/CreateApolloAnnotation.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/CreateApolloAnnotation.tsx
@@ -193,11 +193,8 @@ export function CreateApolloAnnotation({
         continue
       }
 
-      // Destination feature should be of type gene amd should be on the same strand as the source feature
-      if (
-        featureTypeOntology?.isTypeOf(f.type, 'gene') &&
-        f.strand === annotationFeature.strand
-      ) {
+      // Destination feature should be of type gene
+      if (featureTypeOntology?.isTypeOf(f.type, 'gene')) {
         const featureSnapshot = getSnapshot(f)
         filteredFeatures.push(featureSnapshot)
       }
@@ -384,6 +381,15 @@ export function CreateApolloAnnotation({
     }
     for (const transcriptId of Object.keys(transcripts)) {
       const transcript = transcripts[transcriptId]
+      transcript.strand = selectedDestinationFeature.strand
+
+      // update strand of transcript children if they exist
+      if (transcript.children) {
+        for (const childId of Object.keys(transcript.children)) {
+          transcript.children[childId].strand =
+            selectedDestinationFeature.strand
+        }
+      }
       const change = new AddFeatureChange({
         parentFeatureId: selectedDestinationFeature._id,
         changedIds: [selectedDestinationFeature._id],


### PR DESCRIPTION
#### Details

While creating annotation from Jbrowse gff/bam track, allow copying to any gene in the region irrespective of strand but change the strand of copying transcripts and their children to same strand as destination gene.