### PR TITLE
Fix ManageChecks when collaboration server is in subdirectory

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/components/ManageChecks.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/ManageChecks.tsx
@@ -111,7 +111,7 @@ export function ManageChecks({ handleClose, session }: ManageChecksProps) {
         return
       }
       const { baseURL, getFetcher } = selectedInternetAccount
-      const uri = new URL(`/assemblies/${selectedAssembly.name}`, baseURL).href
+      const uri = new URL(`assemblies/${selectedAssembly.name}`, baseURL).href
       const apolloFetch = getFetcher({ locationType: 'UriLocation', uri })
       const response = await apolloFetch(uri, { method: 'GET' })
       if (!response.ok) {


### PR DESCRIPTION
In the `ManageChecks` component, a query that should have been to a relative URL was instead to an absolute one.

Fixes #701