### PR TITLE
Add a featureId to each annotation feature

### DIFF
--- a/packages/apollo-mst/src/AnnotationFeatureModel.ts
+++ b/packages/apollo-mst/src/AnnotationFeatureModel.ts
@@ -41,6 +41,11 @@ type TranscriptParts = TranscriptPart[]
 export const AnnotationFeatureModel = types
   .model('AnnotationFeatureModel', {
     _id: types.identifier,
+    /**
+     * User-facing identifier for this feature (where _id is the internal
+     * identifier)
+     */
+    featureId: types.maybe(types.string),
     /** Unique ID of the reference sequence on which this feature is located */
     refSeq: types.string,
     /**

--- a/packages/apollo-schemas/src/feature.schema.ts
+++ b/packages/apollo-schemas/src/feature.schema.ts
@@ -25,6 +25,9 @@ export class Feature
   @Prop({ type: [String], required: true, index: true })
   allIds: string[]
 
+  @Prop()
+  featureId?: string
+
   @Prop({ required: true })
   type: string
 

--- a/packages/apollo-shared/src/GFF3/annotationFeatureToGFF3.ts
+++ b/packages/apollo-shared/src/GFF3/annotationFeatureToGFF3.ts
@@ -24,8 +24,10 @@ export function annotationFeatureToGFF3(
   if (parentId) {
     attributes.Parent = [parentId]
   }
+  if (feature.featureId) {
+    attributes.ID = [feature.featureId]
+  }
   if (attributes.gff_id) {
-    attributes.ID = attributes.gff_id
     delete attributes.gff_id
   } else if (feature.children) {
     attributes.ID = [feature._id]

--- a/packages/apollo-shared/src/GFF3/gff3ToAnnotationFeature.test.ts
+++ b/packages/apollo-shared/src/GFF3/gff3ToAnnotationFeature.test.ts
@@ -36,6 +36,7 @@ ctgA	est	match_part	3000	3202	.	+	.	Parent=Match1;Name=agt830.5;Target=agt830.5 
 `,
     {
       _id: '66cf9fbb4e947fa2c27d3d6a',
+      featureId: 'Match1',
       refSeq: 'ctgA',
       type: 'EST_match',
       min: 1049,
@@ -71,7 +72,6 @@ ctgA	est	match_part	3000	3202	.	+	.	Parent=Match1;Name=agt830.5;Target=agt830.5 
       },
       attributes: {
         gff_source: ['est'],
-        gff_id: ['Match1'],
         gff_name: ['agt830.5'],
         gff_target: ['agt830.5 1 654'],
       },

--- a/packages/apollo-shared/src/GFF3/gff3ToAnnotationFeature.ts
+++ b/packages/apollo-shared/src/GFF3/gff3ToAnnotationFeature.ts
@@ -58,7 +58,11 @@ export function gff3ToAnnotationFeature(
     feature.children = convertedChildren
   }
   if (convertedAttributes) {
-    feature.attributes = convertedAttributes
+    const [att, id] = convertedAttributes
+    feature.attributes = att
+    if (id) {
+      feature.featureId = id
+    }
   }
   return feature
 }
@@ -76,7 +80,7 @@ function getFeatureMinMax(gff3Feature: GFF3Feature): [number, number] {
 
 function convertFeatureAttributes(
   gff3Feature: GFF3Feature,
-): Record<string, string[] | undefined> | undefined {
+): [Record<string, string[] | undefined>, string | undefined] | undefined {
   const convertedAttributes: Record<string, string[] | undefined> | undefined =
     {}
   const scores = gff3Feature
@@ -108,10 +112,15 @@ function convertFeatureAttributes(
     }
     convertedAttributes.gff_source = [source]
   }
+  let id: string | undefined
   if (attributesCollections.length > 0) {
     for (const attributesCollection of attributesCollections) {
       for (const [key, val] of Object.entries(attributesCollection)) {
         if (key === 'Parent') {
+          continue
+        }
+        if (key === 'ID') {
+          ;[id] = attributesCollection[key]
           continue
         }
         const newKey = isGFFReservedAttribute(key) ? gffToInternal[key] : key
@@ -129,7 +138,7 @@ function convertFeatureAttributes(
     }
   }
   if (Object.keys(convertedAttributes).length > 0) {
-    return convertedAttributes
+    return [convertedAttributes, id]
   }
   return
 }

--- a/packages/apollo-shared/test_data/cds_without_exon.json
+++ b/packages/apollo-shared/test_data/cds_without_exon.json
@@ -21,7 +21,10 @@
           "min": 1200,
           "max": 1500,
           "strand": 1,
-          "attributes": { "gff_source": ["example"], "gff_id": ["exon1"] }
+          "attributes": {
+            "gff_source": ["example"]
+          },
+          "featureId": "exon1"
         },
         "67581b7d5890a8eb1bedab67": {
           "_id": "67581b7d5890a8eb1bedab67",
@@ -30,7 +33,10 @@
           "min": 1210,
           "max": 1710,
           "strand": 1,
-          "attributes": { "gff_source": ["example"], "gff_id": ["cds2"] }
+          "attributes": {
+            "gff_source": ["example"]
+          },
+          "featureId": "cds2"
         },
         "67581b7d5890a8eb1bedab68": {
           "_id": "67581b7d5890a8eb1bedab68",
@@ -39,7 +45,10 @@
           "min": 1200,
           "max": 1700,
           "strand": 1,
-          "attributes": { "gff_source": ["example"], "gff_id": ["cds1"] }
+          "attributes": {
+            "gff_source": ["example"]
+          },
+          "featureId": "cds1"
         },
         "67581b7d5890a8eb1bedab69": {
           "_id": "67581b7d5890a8eb1bedab69",
@@ -58,7 +67,10 @@
           "strand": 1
         }
       },
-      "attributes": { "gff_source": ["example"], "gff_id": ["eden.1"] }
+      "attributes": {
+        "gff_source": ["example"]
+      },
+      "featureId": "eden.1"
     },
     "67581b7d5890a8eb1bedab6d": {
       "_id": "67581b7d5890a8eb1bedab6d",
@@ -67,8 +79,13 @@
       "min": 1049,
       "max": 1100,
       "strand": 1,
-      "attributes": { "gff_source": ["example"] }
+      "attributes": {
+        "gff_source": ["example"]
+      }
     }
   },
-  "attributes": { "gff_source": ["example"], "gff_id": ["eden"] }
+  "attributes": {
+    "gff_source": ["example"]
+  },
+  "featureId": "eden"
 }

--- a/packages/apollo-shared/test_data/cds_without_exon_spliced_utr.json
+++ b/packages/apollo-shared/test_data/cds_without_exon_spliced_utr.json
@@ -20,10 +20,7 @@
           "type": "CDS",
           "min": 3300,
           "max": 7600,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["cds00003"]
-          }
+          "strand": 1
         },
         "675ad4e6a5abb3a5087c064a": {
           "_id": "675ad4e6a5abb3a5087c064a",
@@ -65,9 +62,7 @@
           "max": 8900,
           "strand": 1
         }
-      },
-      "attributes": { "gff_id": ["mRNA00003"] }
+      }
     }
-  },
-  "attributes": { "gff_id": ["gene00001"] }
+  }
 }

--- a/packages/apollo-shared/test_data/example01.json
+++ b/packages/apollo-shared/test_data/example01.json
@@ -12,10 +12,7 @@
       "type": "TF_binding_site",
       "min": 999,
       "max": 1012,
-      "strand": 1,
-      "attributes": {
-        "gff_id": ["tfbs00001"]
-      }
+      "strand": 1
     },
     "66e049f17b9cedae9ad890fb": {
       "_id": "66e049f17b9cedae9ad890fb",
@@ -31,10 +28,7 @@
           "type": "exon",
           "min": 1049,
           "max": 1499,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon00002"]
-          }
+          "strand": 1
         },
         "66e049f17b9cedae9ad890f7": {
           "_id": "66e049f17b9cedae9ad890f7",
@@ -42,10 +36,7 @@
           "type": "exon",
           "min": 2999,
           "max": 3902,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon00003"]
-          }
+          "strand": 1
         },
         "66e049f17b9cedae9ad890f8": {
           "_id": "66e049f17b9cedae9ad890f8",
@@ -53,10 +44,7 @@
           "type": "exon",
           "min": 4999,
           "max": 5500,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon00004"]
-          }
+          "strand": 1
         },
         "66e049f17b9cedae9ad890f9": {
           "_id": "66e049f17b9cedae9ad890f9",
@@ -64,10 +52,7 @@
           "type": "exon",
           "min": 6999,
           "max": 9000,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon00005"]
-          }
+          "strand": 1
         },
         "66e049f17b9cedae9ad890fa": {
           "_id": "66e049f17b9cedae9ad890fa",
@@ -77,15 +62,15 @@
           "max": 7600,
           "strand": 1,
           "attributes": {
-            "gff_id": ["cds00001"],
             "gff_name": ["edenprotein.1"]
-          }
+          },
+          "featureId": "cds00001"
         }
       },
       "attributes": {
-        "gff_id": ["mRNA00001"],
         "gff_name": ["EDEN.1"]
-      }
+      },
+      "featureId": "mRNA00001"
     },
     "66e049f17b9cedae9ad89100": {
       "_id": "66e049f17b9cedae9ad89100",
@@ -101,10 +86,7 @@
           "type": "exon",
           "min": 1049,
           "max": 1499,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon00002"]
-          }
+          "strand": 1
         },
         "66e049f17b9cedae9ad890fd": {
           "_id": "66e049f17b9cedae9ad890fd",
@@ -112,10 +94,7 @@
           "type": "exon",
           "min": 4999,
           "max": 5500,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon00004"]
-          }
+          "strand": 1
         },
         "66e049f17b9cedae9ad890fe": {
           "_id": "66e049f17b9cedae9ad890fe",
@@ -123,10 +102,7 @@
           "type": "exon",
           "min": 6999,
           "max": 9000,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon00005"]
-          }
+          "strand": 1
         },
         "66e049f17b9cedae9ad890ff": {
           "_id": "66e049f17b9cedae9ad890ff",
@@ -136,15 +112,15 @@
           "max": 7600,
           "strand": 1,
           "attributes": {
-            "gff_id": ["cds00002"],
             "gff_name": ["edenprotein.2"]
-          }
+          },
+          "featureId": "cds00002"
         }
       },
       "attributes": {
-        "gff_id": ["mRNA00002"],
         "gff_name": ["EDEN.2"]
-      }
+      },
+      "featureId": "mRNA00002"
     },
     "66e049f17b9cedae9ad89107": {
       "_id": "66e049f17b9cedae9ad89107",
@@ -160,10 +136,7 @@
           "type": "exon",
           "min": 1299,
           "max": 1499,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon00001"]
-          }
+          "strand": 1
         },
         "66e049f17b9cedae9ad89102": {
           "_id": "66e049f17b9cedae9ad89102",
@@ -171,10 +144,7 @@
           "type": "exon",
           "min": 2999,
           "max": 3902,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon00003"]
-          }
+          "strand": 1
         },
         "66e049f17b9cedae9ad89103": {
           "_id": "66e049f17b9cedae9ad89103",
@@ -182,10 +152,7 @@
           "type": "exon",
           "min": 4999,
           "max": 5500,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon00004"]
-          }
+          "strand": 1
         },
         "66e049f17b9cedae9ad89104": {
           "_id": "66e049f17b9cedae9ad89104",
@@ -193,10 +160,7 @@
           "type": "exon",
           "min": 6999,
           "max": 9000,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon00005"]
-          }
+          "strand": 1
         },
         "66e049f17b9cedae9ad89105": {
           "_id": "66e049f17b9cedae9ad89105",
@@ -206,9 +170,9 @@
           "max": 7600,
           "strand": 1,
           "attributes": {
-            "gff_id": ["cds00003"],
             "gff_name": ["edenprotein.3"]
-          }
+          },
+          "featureId": "cds00003"
         },
         "66e049f17b9cedae9ad89106": {
           "_id": "66e049f17b9cedae9ad89106",
@@ -218,19 +182,19 @@
           "max": 7600,
           "strand": 1,
           "attributes": {
-            "gff_id": ["cds00004"],
             "gff_name": ["edenprotein.4"]
-          }
+          },
+          "featureId": "cds00004"
         }
       },
       "attributes": {
-        "gff_id": ["mRNA00003"],
         "gff_name": ["EDEN.3"]
-      }
+      },
+      "featureId": "mRNA00003"
     }
   },
   "attributes": {
-    "gff_id": ["gene00001"],
     "gff_name": ["EDEN"]
-  }
+  },
+  "featureId": "gene00001"
 }

--- a/packages/apollo-shared/test_data/example02.json
+++ b/packages/apollo-shared/test_data/example02.json
@@ -20,10 +20,7 @@
           "type": "exon",
           "min": 21049,
           "max": 21499,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon20001"]
-          }
+          "strand": 1
         },
         "66e049609048deab4117a32d": {
           "_id": "66e049609048deab4117a32d",
@@ -31,10 +28,7 @@
           "type": "exon",
           "min": 22999,
           "max": 23902,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon20004"]
-          }
+          "strand": 1
         },
         "66e049609048deab4117a32e": {
           "_id": "66e049609048deab4117a32e",
@@ -42,10 +36,7 @@
           "type": "exon",
           "min": 24999,
           "max": 25500,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon20006"]
-          }
+          "strand": 1
         },
         "66e049609048deab4117a32f": {
           "_id": "66e049609048deab4117a32f",
@@ -53,10 +44,7 @@
           "type": "exon",
           "min": 26999,
           "max": 29000,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon20009"]
-          }
+          "strand": 1
         },
         "66e049609048deab4117a330": {
           "_id": "66e049609048deab4117a330",
@@ -66,15 +54,15 @@
           "max": 27600,
           "strand": 1,
           "attributes": {
-            "gff_id": ["cds20001"],
             "gff_name": ["edenprotein.1"]
-          }
+          },
+          "featureId": "cds20001"
         }
       },
       "attributes": {
-        "gff_id": ["mRNA20001"],
         "gff_name": ["EDEN.1"]
-      }
+      },
+      "featureId": "mRNA20001"
     },
     "66e049609048deab4117a336": {
       "_id": "66e049609048deab4117a336",
@@ -90,10 +78,7 @@
           "type": "exon",
           "min": 21049,
           "max": 21499,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon20002"]
-          }
+          "strand": 1
         },
         "66e049609048deab4117a333": {
           "_id": "66e049609048deab4117a333",
@@ -101,10 +86,7 @@
           "type": "exon",
           "min": 24999,
           "max": 25500,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon20007"]
-          }
+          "strand": 1
         },
         "66e049609048deab4117a334": {
           "_id": "66e049609048deab4117a334",
@@ -112,10 +94,7 @@
           "type": "exon",
           "min": 26999,
           "max": 29000,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon20010"]
-          }
+          "strand": 1
         },
         "66e049609048deab4117a335": {
           "_id": "66e049609048deab4117a335",
@@ -125,15 +104,15 @@
           "max": 27600,
           "strand": 1,
           "attributes": {
-            "gff_id": ["cds20002"],
             "gff_name": ["edenprotein.2"]
-          }
+          },
+          "featureId": "cds20002"
         }
       },
       "attributes": {
-        "gff_id": ["mRNA20002"],
         "gff_name": ["EDEN.2"]
-      }
+      },
+      "featureId": "mRNA20002"
     },
     "66e049609048deab4117a33d": {
       "_id": "66e049609048deab4117a33d",
@@ -149,10 +128,7 @@
           "type": "exon",
           "min": 21299,
           "max": 21499,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon20003"]
-          }
+          "strand": 1
         },
         "66e049609048deab4117a338": {
           "_id": "66e049609048deab4117a338",
@@ -160,10 +136,7 @@
           "type": "exon",
           "min": 22999,
           "max": 23902,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon20005"]
-          }
+          "strand": 1
         },
         "66e049609048deab4117a339": {
           "_id": "66e049609048deab4117a339",
@@ -171,10 +144,7 @@
           "type": "exon",
           "min": 24999,
           "max": 25500,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon20008"]
-          }
+          "strand": 1
         },
         "66e049609048deab4117a33a": {
           "_id": "66e049609048deab4117a33a",
@@ -182,10 +152,7 @@
           "type": "exon",
           "min": 26999,
           "max": 29000,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon20011"]
-          }
+          "strand": 1
         },
         "66e049609048deab4117a33b": {
           "_id": "66e049609048deab4117a33b",
@@ -195,9 +162,9 @@
           "max": 27600,
           "strand": 1,
           "attributes": {
-            "gff_id": ["cds20003"],
             "gff_name": ["edenprotein.3"]
-          }
+          },
+          "featureId": "cds20003"
         },
         "66e049609048deab4117a33c": {
           "_id": "66e049609048deab4117a33c",
@@ -207,19 +174,19 @@
           "max": 27600,
           "strand": 1,
           "attributes": {
-            "gff_id": ["cds20004"],
             "gff_name": ["edenprotein.4"]
-          }
+          },
+          "featureId": "cds20004"
         }
       },
       "attributes": {
-        "gff_id": ["mRNA20003"],
         "gff_name": ["EDEN.3"]
-      }
+      },
+      "featureId": "mRNA20003"
     }
   },
   "attributes": {
-    "gff_id": ["gene20001"],
     "gff_name": ["EDEN"]
-  }
+  },
+  "featureId": "gene20001"
 }

--- a/packages/apollo-shared/test_data/example04.json
+++ b/packages/apollo-shared/test_data/example04.json
@@ -20,10 +20,7 @@
           "type": "exon",
           "min": 61049,
           "max": 61499,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon60001"]
-          }
+          "strand": 1
         },
         "66e0555fae0bd7cfcd69911c": {
           "_id": "66e0555fae0bd7cfcd69911c",
@@ -31,10 +28,7 @@
           "type": "exon",
           "min": 62999,
           "max": 63902,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon60003"]
-          }
+          "strand": 1
         },
         "66e0555fae0bd7cfcd69911d": {
           "_id": "66e0555fae0bd7cfcd69911d",
@@ -42,10 +36,7 @@
           "type": "exon",
           "min": 64999,
           "max": 65500,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon60004"]
-          }
+          "strand": 1
         },
         "66e0555fae0bd7cfcd69911e": {
           "_id": "66e0555fae0bd7cfcd69911e",
@@ -53,10 +44,7 @@
           "type": "exon",
           "min": 66999,
           "max": 69000,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon60005"]
-          }
+          "strand": 1
         },
         "66e0555fae0bd7cfcd69911f": {
           "_id": "66e0555fae0bd7cfcd69911f",
@@ -66,15 +54,15 @@
           "max": 67600,
           "strand": 1,
           "attributes": {
-            "gff_id": ["cds60001"],
             "gff_name": ["edenprotein.1"]
-          }
+          },
+          "featureId": "cds60001"
         }
       },
       "attributes": {
-        "gff_id": ["mRNA60001"],
         "gff_name": ["EDEN.1"]
-      }
+      },
+      "featureId": "mRNA60001"
     },
     "66e0555fae0bd7cfcd699125": {
       "_id": "66e0555fae0bd7cfcd699125",
@@ -90,10 +78,7 @@
           "type": "exon",
           "min": 61049,
           "max": 61499,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon60001"]
-          }
+          "strand": 1
         },
         "66e0555fae0bd7cfcd699122": {
           "_id": "66e0555fae0bd7cfcd699122",
@@ -101,10 +86,7 @@
           "type": "exon",
           "min": 64999,
           "max": 65500,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon60004"]
-          }
+          "strand": 1
         },
         "66e0555fae0bd7cfcd699123": {
           "_id": "66e0555fae0bd7cfcd699123",
@@ -112,10 +94,7 @@
           "type": "exon",
           "min": 66999,
           "max": 69000,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon60005"]
-          }
+          "strand": 1
         },
         "66e0555fae0bd7cfcd699124": {
           "_id": "66e0555fae0bd7cfcd699124",
@@ -125,15 +104,15 @@
           "max": 67600,
           "strand": 1,
           "attributes": {
-            "gff_id": ["cds60002"],
             "gff_name": ["edenprotein.2"]
-          }
+          },
+          "featureId": "cds60002"
         }
       },
       "attributes": {
-        "gff_id": ["mRNA60002"],
         "gff_name": ["EDEN.2"]
-      }
+      },
+      "featureId": "mRNA60002"
     },
     "66e0555fae0bd7cfcd69912c": {
       "_id": "66e0555fae0bd7cfcd69912c",
@@ -149,10 +128,7 @@
           "type": "exon",
           "min": 61299,
           "max": 61499,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon60002"]
-          }
+          "strand": 1
         },
         "66e0555fae0bd7cfcd699127": {
           "_id": "66e0555fae0bd7cfcd699127",
@@ -160,10 +136,7 @@
           "type": "exon",
           "min": 62999,
           "max": 63902,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon60003"]
-          }
+          "strand": 1
         },
         "66e0555fae0bd7cfcd699128": {
           "_id": "66e0555fae0bd7cfcd699128",
@@ -171,10 +144,7 @@
           "type": "exon",
           "min": 64999,
           "max": 65500,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon60004"]
-          }
+          "strand": 1
         },
         "66e0555fae0bd7cfcd699129": {
           "_id": "66e0555fae0bd7cfcd699129",
@@ -182,10 +152,7 @@
           "type": "exon",
           "min": 66999,
           "max": 69000,
-          "strand": 1,
-          "attributes": {
-            "gff_id": ["exon60005"]
-          }
+          "strand": 1
         },
         "66e0555fae0bd7cfcd69912a": {
           "_id": "66e0555fae0bd7cfcd69912a",
@@ -195,9 +162,9 @@
           "max": 67600,
           "strand": 1,
           "attributes": {
-            "gff_id": ["cds60003"],
             "gff_name": ["edenprotein.3"]
-          }
+          },
+          "featureId": "cds60003"
         },
         "66e0555fae0bd7cfcd69912b": {
           "_id": "66e0555fae0bd7cfcd69912b",
@@ -207,19 +174,19 @@
           "max": 67600,
           "strand": 1,
           "attributes": {
-            "gff_id": ["cds60004"],
             "gff_name": ["edenprotein.4"]
-          }
+          },
+          "featureId": "cds60004"
         }
       },
       "attributes": {
-        "gff_id": ["mRNA60003"],
         "gff_name": ["EDEN.3"]
-      }
+      },
+      "featureId": "mRNA60003"
     }
   },
   "attributes": {
-    "gff_id": ["gene60001"],
     "gff_name": ["EDEN"]
-  }
+  },
+  "featureId": "gene60001"
 }

--- a/packages/apollo-shared/test_data/one_cds.json
+++ b/packages/apollo-shared/test_data/one_cds.json
@@ -22,9 +22,9 @@
           "max": 1500,
           "strand": 1,
           "attributes": {
-            "gff_id": ["exon10001"],
             "testid": ["t007"]
-          }
+          },
+          "featureId": "exon10001"
         },
         "66d70e4ccc30b55b65e5f616": {
           "_id": "66d70e4ccc30b55b65e5f616",
@@ -34,9 +34,9 @@
           "max": 5500,
           "strand": 1,
           "attributes": {
-            "gff_id": ["exon10004"],
             "testid": ["t010"]
-          }
+          },
+          "featureId": "exon10004"
         },
         "66d70e4ccc30b55b65e5f617": {
           "_id": "66d70e4ccc30b55b65e5f617",
@@ -46,22 +46,22 @@
           "max": 5000,
           "strand": 1,
           "attributes": {
-            "gff_id": ["cds10001"],
             "gff_name": ["edenprotein.1"],
             "testid": ["t012", "t013", "t014", "t015"]
-          }
+          },
+          "featureId": "cds10001"
         }
       },
       "attributes": {
-        "gff_id": ["mRNA10001"],
         "gff_name": ["EDEN.1"],
         "testid": ["t004", "t001", "t004"]
-      }
+      },
+      "featureId": "mRNA10001"
     }
   },
   "attributes": {
-    "gff_id": ["gene10001"],
     "gff_name": ["EDEN"],
     "testid": ["t003"]
-  }
+  },
+  "featureId": "gene10001"
 }

--- a/packages/apollo-shared/test_data/onecds_without_exon_spliced_utr.json
+++ b/packages/apollo-shared/test_data/onecds_without_exon_spliced_utr.json
@@ -20,8 +20,7 @@
           "type": "CDS",
           "min": 4999,
           "max": 5500,
-          "strand": 1,
-          "attributes": { "gff_id": ["cds00001"] }
+          "strand": 1
         },
         "675af35f5758c90ab1d55834": {
           "_id": "675af35f5758c90ab1d55834",
@@ -47,9 +46,7 @@
           "max": 8000,
           "strand": 1
         }
-      },
-      "attributes": { "gff_id": ["mRNA00001"] }
+      }
     }
-  },
-  "attributes": { "gff_id": ["gene00001"] }
+  }
 }

--- a/packages/apollo-shared/test_data/two_cds.json
+++ b/packages/apollo-shared/test_data/two_cds.json
@@ -22,9 +22,9 @@
           "max": 1500,
           "strand": 1,
           "attributes": {
-            "gff_id": ["exon10001"],
             "testid": ["t007"]
-          }
+          },
+          "featureId": "exon10001"
         },
         "66d70f3b9c7a7460925687a0": {
           "_id": "66d70f3b9c7a7460925687a0",
@@ -34,9 +34,9 @@
           "max": 5500,
           "strand": 1,
           "attributes": {
-            "gff_id": ["exon10004"],
             "testid": ["t010"]
-          }
+          },
+          "featureId": "exon10004"
         },
         "66d70f3b9c7a7460925687a1": {
           "_id": "66d70f3b9c7a7460925687a1",
@@ -46,22 +46,22 @@
           "max": 5000,
           "strand": 1,
           "attributes": {
-            "gff_id": ["cds10001"],
             "gff_name": ["edenprotein.1"],
             "testid": ["t012", "t013", "t014"]
-          }
+          },
+          "featureId": "cds10001"
         }
       },
       "attributes": {
-        "gff_id": ["mRNA10001"],
         "gff_name": ["EDEN.1"],
         "testid": ["t004", "t001", "t004"]
-      }
+      },
+      "featureId": "mRNA10001"
     }
   },
   "attributes": {
-    "gff_id": ["gene10001"],
     "gff_name": ["EDEN"],
     "testid": ["t003"]
-  }
+  },
+  "featureId": "gene10001"
 }


### PR DESCRIPTION
IDs are often an important aspect of features, and there have been several requests for being able to manage the IDs. Currently Apollo doesn't treat a GFF3 feature ID attribute any differently from other attributes.

This PR introduces a change so that `featureId` is a top-level attribute of all `AnnotationFeature`s. That way it can be guaranteed to be singular (attribute values like the default ID one are technically arrays) and can be more easily tracked and edited. On export, this `featureId` is placed in the GFF3 ID attribute.

Draft for now as I still need to figure out the best way to leverage this change when doing things that potentially create/destroy IDs, like merging or splitting exons or transcripts.