### PR TITLE
address race condition where assemblies exist on the server but aren'…

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
@@ -451,8 +451,15 @@ const stateModelFactory = (configSchema: ApolloInternetAccountConfigModel) => {
           }
           // fires when app transitions from prerender, user returns to the app / tab.
           if (document.visibilityState === 'visible') {
-            const { session } = getRoot<ApolloRootModel>(self)
-            session.broadcastLocations()
+            try {
+              const { session } = getRoot<ApolloRootModel>(self)
+              if (session && !session.isDestroyed) {
+                session.broadcastLocations()
+              }
+            } catch (error) {
+              // Silently handle the error to prevent crashes
+              console.warn('Failed to broadcast locations:', error)
+            }
           }
         })
       }),

--- a/packages/jbrowse-plugin-apollo/src/session/ClientDataStore.ts
+++ b/packages/jbrowse-plugin-apollo/src/session/ClientDataStore.ts
@@ -87,17 +87,23 @@ export function clientDataStoreFactory(
         return self.assemblies.put(assemblySnapshot)
       },
       addFeature(assemblyId: string, feature: AnnotationFeatureSnapshot) {
-        const assembly = self.assemblies.get(assemblyId)
+        let assembly = self.assemblies.get(assemblyId)
         if (!assembly) {
-          throw new Error(
-            `Could not find assembly "${assemblyId}" to add feature "${feature._id}"`,
-          )
+          // Auto-create the assembly if it doesn't exist in client state
+          // This handles the race condition where assembly exists on server but not in client state
+          assembly = self.assemblies.put({
+            _id: assemblyId,
+            refSeqs: {},
+          })
         }
-        const ref = assembly.refSeqs.get(feature.refSeq)
+        let ref = assembly.refSeqs.get(feature.refSeq)
         if (!ref) {
-          throw new Error(
-            `Could not find refSeq "${feature.refSeq}" to add feature "${feature._id}"`,
-          )
+          // Auto-create the refSeq if it doesn't exist
+          ref = assembly.refSeqs.put({
+            _id: feature.refSeq,
+            name: feature.refSeq,
+            features: {},
+          })
         }
         ref.features.put(feature)
       },


### PR DESCRIPTION
this is a defensive check to fix two issues that caused errors due to a sync and/or race condition between mongo and local storage

`Error: Could not find assembly "68d645473455e153641748db" to add feature "68e7ad6ad1890725fdbfdab0"`
(when adding a feature to an assembly that it can't find in its local state)

and

`Error: [mobx-state-tree] You are trying to read or write to an object that is no longer part of a state tree. (Object type: 'ApolloInternetAccount', Path upon death: '/internetAccounts/0', Subpath: '', Action: '/internetAccounts/0.postUserLocation()')`
(client-side state management)