### PR TITLE
dev: allow symlinks when serving jb2

### DIFF
--- a/packages/jbrowse-plugin-apollo/package.json
+++ b/packages/jbrowse-plugin-apollo/package.json
@@ -27,7 +27,7 @@
     "start:watch": "JB_NPM=false NODE_ENV=development rollup --config --watch",
     "start:server": "serve --no-request-logging --cors --listen 9000 --no-port-switching .",
     "build": "yarn build:shared && yarn clean && rollup --config",
-    "browse": "serve --no-request-logging --listen 3008 --no-port-switching --symlinks .jbrowse",
+    "browse": "serve --no-request-logging --listen 8999 --no-port-switching --symlinks .jbrowse",
     "test": "jest",
     "test:ci": "jest --coverage",
     "start:collab-cypress": "yarn workspace @apollo-annotation/collaboration-server run cypress:start",


### PR DESCRIPTION
not expecting this to be accepted but here it is:
wee change on the package.json to allow for symlinks 

(yeah i guess i could figure out a way i don't need it but i couldn't figure out how to have the dist/jbrowse-plugin-apollo.umd.development.js be served in .jbrowse/apollo.js and i didn't want to change my apollo jb config)