### PR TITLE
Fix collaboration server running out of memory on GFF3 import

### DIFF
--- a/packages/apollo-collaboration-server/src/files/files.service.ts
+++ b/packages/apollo-collaboration-server/src/files/files.service.ts
@@ -103,7 +103,10 @@ export class FilesService {
     }
   }
 
-  parseGFF3(stream: ReadableStream<Uint8Array>): ReadableStream<GFF3Feature> {
+  parseGFF3(
+    stream: ReadableStream<Uint8Array>,
+    options?: { bufferSize?: number },
+  ): ReadableStream<GFF3Feature> {
     return stream.pipeThrough(
       new TransformStream(
         new GFFTransformer({
@@ -111,6 +114,7 @@ export class FilesService {
           parseComments: false,
           parseDirectives: false,
           parseFeatures: true,
+          ...options,
         }),
       ),
     )

--- a/packages/apollo-common/src/Operation.ts
+++ b/packages/apollo-common/src/Operation.ts
@@ -45,7 +45,10 @@ export interface ServerDataStore {
   filesService: {
     getFileStream(file: FileDocument): ReadableStream<Uint8Array>
     getFileHandle(file: FileDocument): GenericFilehandle
-    parseGFF3(stream: ReadableStream<Uint8Array>): ReadableStream<GFF3Feature>
+    parseGFF3(
+      stream: ReadableStream<Uint8Array>,
+      parseOptions?: { bufferSize?: number },
+    ): ReadableStream<GFF3Feature>
     create(createFileDto: CreateFileDto): void
     remove(id: string): void
   }

--- a/packages/apollo-shared/src/Changes/AddAssemblyAndFeaturesFromFileChange.ts
+++ b/packages/apollo-shared/src/Changes/AddAssemblyAndFeaturesFromFileChange.ts
@@ -19,6 +19,7 @@ export interface SerializedAddAssemblyAndFeaturesFromFileChangeBase
 export interface AddAssemblyAndFeaturesFromFileChangeDetails {
   assemblyName: string
   fileIds: { fa: string }
+  parseOptions?: { bufferSize: number }
 }
 
 export interface SerializedAddAssemblyAndFeaturesFromFileChangeSingle
@@ -68,7 +69,7 @@ export class AddAssemblyAndFeaturesFromFileChange extends FromFileBaseChange {
     const { assemblyModel, checkModel, fileModel, filesService, user } = backend
     const { assembly, changes, logger } = this
     for (const change of changes) {
-      const { assemblyName, fileIds } = change
+      const { assemblyName, fileIds, parseOptions } = change
       const fileId = fileIds.fa
 
       const { FILE_UPLOAD_FOLDER } = process.env
@@ -110,12 +111,10 @@ export class AddAssemblyAndFeaturesFromFileChange extends FromFileBaseChange {
         backend,
       )
 
-      // Loop all features
-      logger.debug?.(
-        `**************** LOOPATAAN KAIKKI FEATURET SEURAAVAKSI File type: "${fileDoc.type}"`,
-      )
+      const { bufferSize = 10_000 } = parseOptions ?? {}
       const featureStream = filesService.parseGFF3(
         filesService.getFileStream(fileDoc),
+        { bufferSize },
       )
       // @ts-expect-error type is wrong here
       // eslint-disable-next-line @typescript-eslint/await-thenable

--- a/packages/apollo-shared/src/Changes/AddFeaturesFromFileChange.ts
+++ b/packages/apollo-shared/src/Changes/AddFeaturesFromFileChange.ts
@@ -18,6 +18,7 @@ export interface SerializedAddFeaturesFromFileChangeBase
 
 export interface AddFeaturesFromFileChangeDetails {
   fileId: string
+  parseOptions?: { bufferSize: number }
 }
 
 export interface SerializedAddFeaturesFromFileChangeSingle
@@ -75,7 +76,7 @@ export class AddFeaturesFromFileChange extends FromFileBaseChange {
     }
 
     for (const change of changes) {
-      const { fileId } = change
+      const { fileId, parseOptions } = change
 
       const { FILE_UPLOAD_FOLDER } = process.env
       if (!FILE_UPLOAD_FOLDER) {
@@ -89,8 +90,10 @@ export class AddFeaturesFromFileChange extends FromFileBaseChange {
       logger.debug?.(`FileId "${fileId}", checksum "${fileDoc.checksum}"`)
 
       // Read data from compressed file and parse the content
+      const { bufferSize = 10_000 } = parseOptions ?? {}
       const featureStream = filesService.parseGFF3(
         filesService.getFileStream(fileDoc),
+        { bufferSize },
       )
       let featureCount = 0
       // @ts-expect-error type is wrong here


### PR DESCRIPTION
I was doing some benchmarking and managed to crash the collaboration server with an out-of-memory error. I realized it was because I imported a GFF3 without sync marks, and the default parser introduced in #681 has `bufferSize` be `Infinity`, so it tries to hold the whole GFF3 in memory if there are no sync marks. This PR puts in a reasonable `bufferSize` of 10,000, similar to what the previous parser had, to avoid this. This means that GFF3s with related features that are very far apart could fail to import properly, but that could probably be solved by sorting the GFF3.