### PR TITLE
Refactor Linear Apollo Display glyph layout methods

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/CheckResultWarnings.tsx
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/CheckResultWarnings.tsx
@@ -52,11 +52,7 @@ export const CheckResultWarnings = observer(function CheckResultWarnings({
       if (!feature) {
         return null
       }
-      let row = 0
-      const featureLayout = display.getFeatureLayoutPosition(feature)
-      if (featureLayout) {
-        row = featureLayout.layoutRow + featureLayout.featureRow
-      }
+      const row = display.getRowForFeature(feature) ?? 0
       const top = row * apolloRowHeight
       const height = apolloRowHeight
       return (

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/LinearApolloDisplay.tsx
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/LinearApolloDisplay.tsx
@@ -79,6 +79,9 @@ export const LinearApolloDisplay = observer(function LinearApolloDisplay(
         onMouseMove={(event) => {
           setMouseCoord([event.clientX, event.clientY])
         }}
+        onMouseLeave={() => {
+          setMouseCoord(undefined)
+        }}
       >
         {session.isLocked ? (
           <div className={classes.locked} data-testid="lock-icon">

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/LinearApolloDisplay.tsx
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/LinearApolloDisplay.tsx
@@ -14,6 +14,7 @@ import { type Coord, useStyles } from '../../util/displayUtils'
 import type { LinearApolloDisplay as LinearApolloDisplayI } from '../stateModel'
 
 import { CheckResultWarnings } from './CheckResultWarnings'
+import { Tooltip as LinearApolloDisplayTooltip } from './Tooltip'
 
 interface LinearApolloDisplayProps {
   model: LinearApolloDisplayI
@@ -51,6 +52,7 @@ export const LinearApolloDisplay = observer(function LinearApolloDisplay(
   }, [theme, setTheme])
   const [contextCoord, setContextCoord] = useState<Coord>()
   const [contextMenuItems, setContextMenuItems] = useState<MenuItem[]>([])
+  const [mouseCoord, setMouseCoord] = useState<Coord>()
   const message = regionCannotBeRendered()
   if (!isShown) {
     return null
@@ -73,6 +75,9 @@ export const LinearApolloDisplay = observer(function LinearApolloDisplay(
             setContextCoord(coord)
             setContextMenuItems(getContextMenuItems(event))
           }
+        }}
+        onMouseMove={(event) => {
+          setMouseCoord([event.clientX, event.clientY])
         }}
       >
         {session.isLocked ? (
@@ -164,6 +169,10 @@ export const LinearApolloDisplay = observer(function LinearApolloDisplay(
           </>
         )}
       </div>
+      <LinearApolloDisplayTooltip
+        mouseCooordinate={mouseCoord}
+        session={session}
+      />
     </>
   )
 })

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/LinearApolloDisplay.tsx
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/LinearApolloDisplay.tsx
@@ -31,7 +31,7 @@ export const LinearApolloDisplay = observer(function LinearApolloDisplay(
     loading,
     contextMenuItems: getContextMenuItems,
     cursor,
-    featuresHeight,
+    featuresHeight: getFeaturesHeight,
     isShown,
     onMouseDown,
     onMouseLeave,
@@ -57,6 +57,7 @@ export const LinearApolloDisplay = observer(function LinearApolloDisplay(
   if (!isShown) {
     return null
   }
+  const featuresHeight = getFeaturesHeight(lgv.assemblyNames[0])
   return (
     <>
       <div

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/LinearApolloDisplay.tsx
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/LinearApolloDisplay.tsx
@@ -14,7 +14,7 @@ import { type Coord, useStyles } from '../../util/displayUtils'
 import type { LinearApolloDisplay as LinearApolloDisplayI } from '../stateModel'
 
 import { CheckResultWarnings } from './CheckResultWarnings'
-import { Tooltip as LinearApolloDisplayTooltip } from './Tooltip'
+import { OverlayCanvas } from './OverlayCanvas'
 
 interface LinearApolloDisplayProps {
   model: LinearApolloDisplayI
@@ -30,18 +30,12 @@ export const LinearApolloDisplay = observer(function LinearApolloDisplay(
   const {
     loading,
     contextMenuItems: getContextMenuItems,
-    cursor,
     featuresHeight: getFeaturesHeight,
     isShown,
-    onMouseDown,
-    onMouseLeave,
-    onMouseMove,
-    onMouseUp,
     regionCannotBeRendered,
     session,
     setCanvas,
     setCollaboratorCanvas,
-    setOverlayCanvas,
     setTheme,
   } = model
   const { classes } = useStyles()
@@ -52,131 +46,104 @@ export const LinearApolloDisplay = observer(function LinearApolloDisplay(
   }, [theme, setTheme])
   const [contextCoord, setContextCoord] = useState<Coord>()
   const [contextMenuItems, setContextMenuItems] = useState<MenuItem[]>([])
-  const [mouseCoord, setMouseCoord] = useState<Coord>()
   const message = regionCannotBeRendered()
   if (!isShown) {
     return null
   }
   const featuresHeight = getFeaturesHeight(lgv.assemblyNames[0])
   return (
-    <>
-      <div
-        className={classes.canvasContainer}
-        style={{
-          width: lgv.dynamicBlocks.totalWidthPx,
-          height: featuresHeight,
-        }}
-        onContextMenu={(event) => {
-          event.preventDefault()
-          if (contextMenuItems.length > 0) {
-            // There's already a context menu open, so close it
-            setContextMenuItems([])
-          } else {
-            const coord: [number, number] = [event.clientX, event.clientY]
-            setContextCoord(coord)
-            setContextMenuItems(getContextMenuItems(event))
-          }
-        }}
-        onMouseMove={(event) => {
-          setMouseCoord([event.clientX, event.clientY])
-        }}
-        onMouseLeave={() => {
-          setMouseCoord(undefined)
-        }}
-      >
-        {session.isLocked ? (
-          <div className={classes.locked} data-testid="lock-icon">
-            <LockIcon />
-          </div>
-        ) : null}
-        {loading ? (
-          <div className={classes.loading}>
-            <CircularProgress size="18px" />
-          </div>
-        ) : null}
-        {/* This type is wrong in @jbrowse/core */}
-        {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition */}
-        {message ? (
-          <Alert
-            severity="warning"
-            classes={{ message: classes.ellipses }}
-            slotProps={{ root: { className: classes.center } }}
-          >
-            <Tooltip title={message}>
-              <div>{message}</div>
-            </Tooltip>
-          </Alert>
-        ) : (
-          // Promise.resolve() in these 3 callbacks is to avoid infinite rendering loop
-          // https://github.com/mobxjs/mobx/issues/3728#issuecomment-1715400931
-          <>
-            <canvas
-              ref={async (node: HTMLCanvasElement) => {
-                await Promise.resolve()
-                setCollaboratorCanvas(node)
-              }}
-              width={lgv.dynamicBlocks.totalWidthPx}
-              height={featuresHeight}
-              className={classes.canvas}
-              data-testid="collaboratorCanvas"
-            />
-            <canvas
-              ref={async (node: HTMLCanvasElement) => {
-                await Promise.resolve()
-                setCanvas(node)
-              }}
-              width={lgv.dynamicBlocks.totalWidthPx}
-              height={featuresHeight}
-              className={classes.canvas}
-              data-testid="canvas"
-            />
-            <canvas
-              ref={async (node: HTMLCanvasElement) => {
-                await Promise.resolve()
-                setOverlayCanvas(node)
-              }}
-              width={lgv.dynamicBlocks.totalWidthPx}
-              height={featuresHeight}
-              onMouseMove={onMouseMove}
-              onMouseLeave={onMouseLeave}
-              onMouseDown={onMouseDown}
-              onMouseUp={onMouseUp}
-              className={classes.canvas}
-              style={{ cursor: cursor ?? 'default' }}
-              data-testid="overlayCanvas"
-            />
-            <CheckResultWarnings display={model} />
-            <Menu
-              open={contextMenuItems.length > 0}
-              onMenuItemClick={(_, callback) => {
-                callback()
-                setContextMenuItems([])
-              }}
-              onClose={() => {
-                setContextMenuItems([])
-              }}
-              slotProps={{
-                transition: {
-                  onExit: () => {
-                    setContextMenuItems([])
-                  },
+    <div
+      className={classes.canvasContainer}
+      style={{
+        width: lgv.dynamicBlocks.totalWidthPx,
+        height: featuresHeight,
+      }}
+      onContextMenu={(event) => {
+        event.preventDefault()
+        if (contextMenuItems.length > 0) {
+          // There's already a context menu open, so close it
+          setContextMenuItems([])
+        } else {
+          const coord: [number, number] = [event.clientX, event.clientY]
+          setContextCoord(coord)
+          setContextMenuItems(getContextMenuItems(event))
+        }
+      }}
+    >
+      {session.isLocked ? (
+        <div className={classes.locked} data-testid="lock-icon">
+          <LockIcon />
+        </div>
+      ) : null}
+      {loading ? (
+        <div className={classes.loading}>
+          <CircularProgress size="18px" />
+        </div>
+      ) : null}
+      {/* This type is wrong in @jbrowse/core */}
+      {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition */}
+      {message ? (
+        <Alert
+          severity="warning"
+          classes={{ message: classes.ellipses }}
+          slotProps={{ root: { className: classes.center } }}
+        >
+          <Tooltip title={message}>
+            <div>{message}</div>
+          </Tooltip>
+        </Alert>
+      ) : (
+        // Promise.resolve() in these 2 callbacks is to avoid infinite rendering loop
+        // https://github.com/mobxjs/mobx/issues/3728#issuecomment-1715400931
+        <>
+          <canvas
+            ref={async (node: HTMLCanvasElement) => {
+              await Promise.resolve()
+              setCollaboratorCanvas(node)
+            }}
+            width={lgv.dynamicBlocks.totalWidthPx}
+            height={featuresHeight}
+            className={classes.canvas}
+            data-testid="collaboratorCanvas"
+          />
+          <canvas
+            ref={async (node: HTMLCanvasElement) => {
+              await Promise.resolve()
+              setCanvas(node)
+            }}
+            width={lgv.dynamicBlocks.totalWidthPx}
+            height={featuresHeight}
+            className={classes.canvas}
+            data-testid="canvas"
+          />
+          <OverlayCanvas model={model} />
+          <CheckResultWarnings display={model} />
+          <Menu
+            open={contextMenuItems.length > 0}
+            onMenuItemClick={(_, callback) => {
+              callback()
+              setContextMenuItems([])
+            }}
+            onClose={() => {
+              setContextMenuItems([])
+            }}
+            slotProps={{
+              transition: {
+                onExit: () => {
+                  setContextMenuItems([])
                 },
-              }}
-              anchorReference="anchorPosition"
-              anchorPosition={
-                contextCoord
-                  ? { top: contextCoord[1], left: contextCoord[0] }
-                  : undefined
-              }
-              menuItems={contextMenuItems}
-            />
-          </>
-        )}
-      </div>
-      <LinearApolloDisplayTooltip
-        mouseCooordinate={mouseCoord}
-        session={session}
-      />
-    </>
+              },
+            }}
+            anchorReference="anchorPosition"
+            anchorPosition={
+              contextCoord
+                ? { top: contextCoord[1], left: contextCoord[0] }
+                : undefined
+            }
+            menuItems={contextMenuItems}
+          />
+        </>
+      )}
+    </div>
   )
 })

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/OverlayCanvas.tsx
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/OverlayCanvas.tsx
@@ -1,0 +1,74 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+
+/* eslint-disable @typescript-eslint/no-misused-promises */
+
+import { getContainingView } from '@jbrowse/core/util'
+import type { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
+import { observer } from 'mobx-react'
+import React, { useState } from 'react'
+
+import { type Coord, useStyles } from '../../util/displayUtils'
+import type { LinearApolloDisplay as LinearApolloDisplayI } from '../stateModel'
+
+import { Tooltip as LinearApolloDisplayTooltip } from './Tooltip'
+
+interface LinearApolloDisplayProps {
+  model: LinearApolloDisplayI
+}
+
+export const OverlayCanvas = observer(function OverlayCanvas(
+  props: LinearApolloDisplayProps,
+) {
+  const { model } = props
+  const {
+    cursor,
+    featuresHeight: getFeaturesHeight,
+    isShown,
+    onMouseDown,
+    onMouseLeave,
+    onMouseMove,
+    onMouseUp,
+    session,
+    setOverlayCanvas,
+  } = model
+  const { classes } = useStyles()
+  const lgv = getContainingView(model) as unknown as LinearGenomeViewModel
+
+  const [mouseCoord, setMouseCoord] = useState<Coord>()
+  if (!isShown) {
+    return null
+  }
+  const featuresHeight = getFeaturesHeight(lgv.assemblyNames[0])
+  // Promise.resolve() in this callback is to avoid infinite rendering loop
+  // https://github.com/mobxjs/mobx/issues/3728#issuecomment-1715400931
+  return (
+    <>
+      <canvas
+        ref={async (node: HTMLCanvasElement) => {
+          await Promise.resolve()
+          setOverlayCanvas(node)
+        }}
+        width={lgv.dynamicBlocks.totalWidthPx}
+        height={featuresHeight}
+        onMouseMove={(...args) => {
+          const [event] = args
+          setMouseCoord([event.clientX, event.clientY])
+          onMouseMove(...args)
+        }}
+        onMouseLeave={(...args) => {
+          setMouseCoord(undefined)
+          onMouseLeave(...args)
+        }}
+        onMouseDown={onMouseDown}
+        onMouseUp={onMouseUp}
+        className={classes.canvas}
+        style={{ cursor: cursor ?? 'default' }}
+        data-testid="overlayCanvas"
+      />
+      <LinearApolloDisplayTooltip
+        mouseCooordinate={mouseCoord}
+        session={session}
+      />
+    </>
+  )
+})

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/Tooltip.tsx
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/components/Tooltip.tsx
@@ -1,0 +1,41 @@
+import { BaseTooltip } from '@jbrowse/core/ui'
+import { observer } from 'mobx-react'
+import React from 'react'
+
+import type { ApolloSessionModel } from '../../session'
+import type { Coord } from '../../util/displayUtils'
+
+interface LinearApolloDisplayProps {
+  mouseCooordinate: Coord | undefined
+  session: ApolloSessionModel
+}
+
+export const Tooltip = observer(function Tooltip(
+  props: LinearApolloDisplayProps,
+) {
+  const { mouseCooordinate, session } = props
+  const { apolloHoveredFeature } = session
+
+  if (!(mouseCooordinate && apolloHoveredFeature)) {
+    return
+  }
+  const [x, y] = mouseCooordinate
+  const { feature } = apolloHoveredFeature
+  const { attributes, min, max } = feature
+  const location = `Loc: ${min + 1}..${max}`
+  const featureType = `Type: ${feature.type}`
+  const featureName = attributes.get('gff_name')?.find((name) => name !== '')
+  return (
+    <BaseTooltip clientPoint={{ x, y }} placement="top-start">
+      {featureType}
+      <br />
+      {featureName ? (
+        <>
+          {featureName}
+          <br />
+        </>
+      ) : null}
+      {location}
+    </BaseTooltip>
+  )
+})

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
@@ -51,69 +51,6 @@ function drawHover(
   drawHighlight(display, overlayCtx, left, top, width, height)
 }
 
-function drawTooltip(
-  display: LinearApolloDisplayMouseEvents,
-  context: CanvasRenderingContext2D,
-): void {
-  const { hoveredFeature, apolloRowHeight, lgv, theme } = display
-  if (!hoveredFeature) {
-    return
-  }
-  const { feature } = hoveredFeature
-  const position = display.getFeatureLayoutPosition(feature)
-  if (!position) {
-    return
-  }
-  const { featureRow, layoutIndex, layoutRow } = position
-  const { bpPerPx, displayedRegions, offsetPx } = lgv
-  const displayedRegion = displayedRegions[layoutIndex]
-  const { refName, reversed } = displayedRegion
-
-  let location = 'Loc: '
-
-  const { length, max, min } = feature
-  location += `${min + 1}–${max}`
-
-  let startPx =
-    (lgv.bpToPx({
-      refName,
-      coord: reversed ? max : min,
-      regionNumber: layoutIndex,
-    })?.offsetPx ?? 0) - offsetPx
-  const top = (layoutRow + featureRow) * apolloRowHeight
-  const widthPx = length / bpPerPx
-
-  const featureType = `Type: ${feature.type}`
-  const { attributes } = feature
-  const featureName = attributes.get('gff_name')?.find((name) => name !== '')
-  const textWidth = [
-    context.measureText(featureType).width,
-    context.measureText(location).width,
-  ]
-  if (featureName) {
-    textWidth.push(context.measureText(`Name: ${featureName}`).width)
-  }
-  const maxWidth = Math.max(...textWidth)
-
-  startPx = startPx + widthPx + 5
-  context.fillStyle = alpha(theme.palette.text.primary, 0.7)
-  context.fillRect(startPx, top, maxWidth + 4, textWidth.length === 3 ? 45 : 35)
-  context.beginPath()
-  context.moveTo(startPx, top)
-  context.lineTo(startPx - 5, top + 5)
-  context.lineTo(startPx, top + 10)
-  context.fill()
-  context.fillStyle = theme.palette.background.default
-  let textTop = top + 12
-  context.fillText(featureType, startPx + 2, textTop)
-  if (featureName) {
-    textTop = textTop + 12
-    context.fillText(`Name: ${featureName}`, startPx + 2, textTop)
-  }
-  textTop = textTop + 12
-  context.fillText(location, startPx + 2, textTop)
-}
-
 function drawDragPreview(
   stateModel: LinearApolloDisplay,
   overlayCtx: CanvasRenderingContext2D,
@@ -232,7 +169,6 @@ export const boxGlyph: Glyph = {
   draw,
   drawDragPreview,
   drawHover,
-  drawTooltip,
   getContextMenuItemsForFeature,
   getContextMenuItems,
   getFeatureFromLayout,

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
@@ -84,19 +84,19 @@ function getRowCount() {
   return 1
 }
 
-function getFeatureFromLayout(
+function getFeaturesFromLayout(
   _display: LinearApolloDisplay,
   feature: AnnotationFeature,
   bp: number,
   row: number,
 ) {
   if (row > 0) {
-    return
+    return []
   }
   if (bp >= feature.min && bp <= feature.max) {
-    return feature
+    return [feature]
   }
-  return
+  return []
 }
 
 function getRowForFeature(
@@ -170,7 +170,7 @@ export const boxGlyph: Glyph = {
   drawHover,
   getContextMenuItemsForFeature,
   getContextMenuItems,
-  getFeatureFromLayout,
+  getFeaturesFromLayout,
   getRowCount,
   getRowForFeature,
   onMouseDown,

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
@@ -74,36 +74,6 @@ function drawHover(
   drawHighlight(display, overlayCtx, left, top, width, height)
 }
 
-function drawDragPreview(
-  stateModel: LinearApolloDisplay,
-  overlayCtx: CanvasRenderingContext2D,
-) {
-  const { apolloDragging, apolloRowHeight, lgv, theme } = stateModel
-  const { bpPerPx, displayedRegions, offsetPx } = lgv
-  if (!apolloDragging) {
-    return
-  }
-  const { current, edge, feature, start } = apolloDragging
-
-  const row = Math.floor(start.y / apolloRowHeight)
-  const region = displayedRegions[start.regionNumber]
-  const rowCount = getRowCount()
-
-  const featureEdgeBp = region.reversed
-    ? region.end - feature[edge]
-    : feature[edge] - region.start
-  const featureEdgePx = featureEdgeBp / bpPerPx - offsetPx
-  const rectX = Math.min(current.x, featureEdgePx)
-  const rectY = row * apolloRowHeight
-  const rectWidth = Math.abs(current.x - featureEdgePx)
-  const rectHeight = apolloRowHeight * rowCount
-  overlayCtx.strokeStyle = theme.palette.info.main
-  overlayCtx.setLineDash([6])
-  overlayCtx.strokeRect(rectX, rectY, rectWidth, rectHeight)
-  overlayCtx.fillStyle = alpha(theme.palette.info.main, 0.2)
-  overlayCtx.fillRect(rectX, rectY, rectWidth, rectHeight)
-}
-
 function drawTooltip(
   display: LinearApolloDisplayMouseEvents,
   context: CanvasRenderingContext2D,
@@ -167,14 +137,34 @@ function drawTooltip(
   context.fillText(location, startPx + 2, textTop)
 }
 
-function getContextMenuItems(
-  display: LinearApolloDisplayMouseEvents,
-): MenuItem[] {
-  const { hoveredFeature } = display
-  if (!hoveredFeature) {
-    return []
+function drawDragPreview(
+  stateModel: LinearApolloDisplay,
+  overlayCtx: CanvasRenderingContext2D,
+) {
+  const { apolloDragging, apolloRowHeight, lgv, theme } = stateModel
+  const { bpPerPx, displayedRegions, offsetPx } = lgv
+  if (!apolloDragging) {
+    return
   }
-  return getContextMenuItemsForFeature(display, hoveredFeature.feature)
+  const { current, edge, feature, start } = apolloDragging
+
+  const row = Math.floor(start.y / apolloRowHeight)
+  const region = displayedRegions[start.regionNumber]
+  const rowCount = getRowCount()
+
+  const featureEdgeBp = region.reversed
+    ? region.end - feature[edge]
+    : feature[edge] - region.start
+  const featureEdgePx = featureEdgeBp / bpPerPx - offsetPx
+  const rectX = Math.min(current.x, featureEdgePx)
+  const rectY = row * apolloRowHeight
+  const rectWidth = Math.abs(current.x - featureEdgePx)
+  const rectHeight = apolloRowHeight * rowCount
+  overlayCtx.strokeStyle = theme.palette.info.main
+  overlayCtx.setLineDash([6])
+  overlayCtx.strokeRect(rectX, rectY, rectWidth, rectHeight)
+  overlayCtx.fillStyle = alpha(theme.palette.info.main, 0.2)
+  overlayCtx.fillRect(rectX, rectY, rectWidth, rectHeight)
 }
 
 function getRowCount() {
@@ -205,6 +195,16 @@ function getRowForFeature(
     return 0
   }
   return
+}
+
+function getContextMenuItems(
+  display: LinearApolloDisplayMouseEvents,
+): MenuItem[] {
+  const { hoveredFeature } = display
+  if (!hoveredFeature) {
+    return []
+  }
+  return getContextMenuItemsForFeature(display, hoveredFeature.feature)
 }
 
 function onMouseDown(

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
@@ -52,33 +52,32 @@ function drawHover(
 }
 
 function drawDragPreview(
-  stateModel: LinearApolloDisplay,
+  display: LinearApolloDisplay,
   overlayCtx: CanvasRenderingContext2D,
+  feature: AnnotationFeature,
+  row: number,
+  block: ContentBlock,
 ) {
-  const { apolloDragging, apolloRowHeight, lgv, theme } = stateModel
-  const { bpPerPx, displayedRegions, offsetPx } = lgv
+  const { apolloDragging, theme } = display
   if (!apolloDragging) {
     return
   }
-  const { current, edge, feature, start } = apolloDragging
+  const { current, start } = apolloDragging
+  const min = Math.min(current.bp, start.bp)
+  const max = Math.max(current.bp, start.bp)
 
-  const row = Math.floor(start.y / apolloRowHeight)
-  const region = displayedRegions[start.regionNumber]
-  const rowCount = getRowCount()
+  const [top, left, width, height] = getFeatureBox(
+    display,
+    { min, max },
+    row,
+    block,
+  )
 
-  const featureEdgeBp = region.reversed
-    ? region.end - feature[edge]
-    : feature[edge] - region.start
-  const featureEdgePx = featureEdgeBp / bpPerPx - offsetPx
-  const rectX = Math.min(current.x, featureEdgePx)
-  const rectY = row * apolloRowHeight
-  const rectWidth = Math.abs(current.x - featureEdgePx)
-  const rectHeight = apolloRowHeight * rowCount
-  overlayCtx.strokeStyle = theme.palette.info.main
-  overlayCtx.setLineDash([6])
-  overlayCtx.strokeRect(rectX, rectY, rectWidth, rectHeight)
   overlayCtx.fillStyle = alpha(theme.palette.info.main, 0.2)
-  overlayCtx.fillRect(rectX, rectY, rectWidth, rectHeight)
+  overlayCtx.fillRect(left, top, width, height)
+
+  overlayCtx.setLineDash([6])
+  strokeRectInner(overlayCtx, left, top, width, height, theme.palette.info.main)
 }
 
 function getRowCount() {

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/BoxGlyph.ts
@@ -213,23 +213,34 @@ function getContextMenuItems(
   return getContextMenuItemsForFeature(display, hoveredFeature.feature)
 }
 
-function getFeatureFromLayout(
-  feature: AnnotationFeature,
-  _bp: number,
-  _row: number,
-): AnnotationFeature {
-  return feature
-}
-
 function getRowCount() {
   return 1
 }
 
+function getFeatureFromLayout(
+  _display: LinearApolloDisplay,
+  feature: AnnotationFeature,
+  bp: number,
+  row: number,
+) {
+  if (row > 0) {
+    return
+  }
+  if (bp >= feature.min && bp <= feature.max) {
+    return feature
+  }
+  return
+}
+
 function getRowForFeature(
-  _feature: AnnotationFeature,
-  _childFeature: AnnotationFeature,
-): number | undefined {
-  return 0
+  _display: LinearApolloDisplay,
+  feature: AnnotationFeature,
+  childFeature: AnnotationFeature,
+) {
+  if (feature._id === childFeature._id) {
+    return 0
+  }
+  return
 }
 
 function onMouseDown(

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/CDSGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/CDSGlyph.ts
@@ -104,6 +104,12 @@ function drawHover(
   drawHighlight(display, overlayCtx, left, top, width, height)
 }
 
+function drawDragPreview() {
+  // Not implemented
+}
+// display: LinearApolloDisplayMouseEvents,
+// ctx: CanvasRenderingContext2D,
+
 function getRowCount() {
   return 1
 }
@@ -134,12 +140,6 @@ function getRowForFeature(
   return
 }
 
-function drawDragPreview() {
-  // Not implemented
-}
-// display: LinearApolloDisplayMouseEvents,
-// ctx: CanvasRenderingContext2D,
-
 function onMouseDown() {
   // Not implemented
 }
@@ -168,12 +168,6 @@ function onMouseUp() {
 // currentMousePosition: MousePositionWithFeature,
 // event: CanvasMouseEvent,
 
-function drawTooltip() {
-  // Not implemented
-}
-// display: LinearApolloDisplayMouseEvents,
-// context: CanvasRenderingContext2D,
-
 function getContextMenuItemsForFeature(): MenuItem[] {
   return []
   // Not implemented
@@ -187,6 +181,11 @@ function getContextMenuItems(): MenuItem[] {
 }
 // display: LinearApolloDisplayMouseEvents,
 // currentMousePosition: MousePositionWithFeature,
+
+// False positive here, none of these functions use "this"
+/* eslint-disable @typescript-eslint/unbound-method */
+const { drawTooltip } = boxGlyph
+/* eslint-enable @typescript-eslint/unbound-method */
 
 export const cdsGlyph: Glyph = {
   draw,

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/CDSGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/CDSGlyph.ts
@@ -114,19 +114,19 @@ function getRowCount() {
   return 1
 }
 
-function getFeatureFromLayout(
+function getFeaturesFromLayout(
   _display: LinearApolloDisplay,
   feature: AnnotationFeature,
   bp: number,
   row: number,
 ) {
   if (row > 0) {
-    return
+    return []
   }
   if (bp >= feature.min && bp <= feature.max) {
-    return feature
+    return [feature]
   }
-  return
+  return []
 }
 
 function getRowForFeature(
@@ -237,7 +237,7 @@ export const cdsGlyph: Glyph = {
   drawHover,
   getContextMenuItems,
   getContextMenuItemsForFeature,
-  getFeatureFromLayout,
+  getFeaturesFromLayout,
   getRowCount,
   getRowForFeature,
   onMouseDown,

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/CDSGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/CDSGlyph.ts
@@ -85,25 +85,35 @@ function draw(
   }
 }
 
-function getRowCount(): number {
+function getRowCount() {
   return 1
 }
 
-function getFeatureFromLayout(): AnnotationFeature | undefined {
-  return undefined
-  // Not implemented
+function getFeatureFromLayout(
+  _display: LinearApolloDisplay,
+  feature: AnnotationFeature,
+  bp: number,
+  row: number,
+) {
+  if (row > 0) {
+    return
+  }
+  if (bp >= feature.min && bp <= feature.max) {
+    return feature
+  }
+  return
 }
-// feature: AnnotationFeature,
-// bp: number,
-// row: number,
-// featureTypeOntology: OntologyRecord,
-function getRowForFeature(): number | undefined {
-  // Not implemented
-  return undefined
+
+function getRowForFeature(
+  _display: LinearApolloDisplay,
+  feature: AnnotationFeature,
+  childFeature: AnnotationFeature,
+) {
+  if (feature._id === childFeature._id) {
+    return 0
+  }
+  return
 }
-// feature: AnnotationFeature,
-// childFeature: AnnotationFeature,
-// featureTypeOntology: OntologyRecord,
 
 function drawHover() {
   // Not implemented

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/CDSGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/CDSGlyph.ts
@@ -110,12 +110,6 @@ function drawHover(
   drawHighlight(display, overlayCtx, left, top, width, height)
 }
 
-function drawDragPreview() {
-  // Not implemented
-}
-// display: LinearApolloDisplayMouseEvents,
-// ctx: CanvasRenderingContext2D,
-
 function getRowCount() {
   return 1
 }
@@ -199,6 +193,7 @@ function onMouseDown(
 function onMouseMove(
   stateModel: LinearApolloDisplay,
   mousePosition: MousePositionWithFeature,
+  event: CanvasMouseEvent,
 ) {
   const { feature, bp } = mousePosition
   stateModel.setHoveredFeature({ feature, bp })
@@ -209,6 +204,7 @@ function onMouseMove(
   }
   const transcript = feature.parent
   if (!transcript) {
+    boxGlyph.onMouseMove(stateModel, mousePosition, event)
     return
   }
   const { cdsLocations } = transcript
@@ -232,7 +228,7 @@ function onMouseMove(
 
 // False positive here, none of these functions use "this"
 /* eslint-disable @typescript-eslint/unbound-method */
-const { onMouseLeave, onMouseUp } = boxGlyph
+const { drawDragPreview, onMouseLeave, onMouseUp } = boxGlyph
 /* eslint-enable @typescript-eslint/unbound-method */
 
 export const cdsGlyph: Glyph = {

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/CDSGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/CDSGlyph.ts
@@ -232,14 +232,13 @@ function onMouseMove(
 
 // False positive here, none of these functions use "this"
 /* eslint-disable @typescript-eslint/unbound-method */
-const { drawTooltip, onMouseLeave, onMouseUp } = boxGlyph
+const { onMouseLeave, onMouseUp } = boxGlyph
 /* eslint-enable @typescript-eslint/unbound-method */
 
 export const cdsGlyph: Glyph = {
   draw,
   drawDragPreview,
   drawHover,
-  drawTooltip,
   getContextMenuItems,
   getContextMenuItemsForFeature,
   getFeatureFromLayout,

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/ExonGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/ExonGlyph.ts
@@ -67,12 +67,6 @@ function drawHover(
   drawHighlight(display, overlayCtx, left, top, width, height)
 }
 
-function drawDragPreview() {
-  // Not implemented
-}
-// display: LinearApolloDisplayMouseEvents,
-// ctx: CanvasRenderingContext2D,
-
 function getRowCount() {
   return 1
 }
@@ -134,7 +128,7 @@ function onMouseDown(
 
 // False positive here, none of these functions use "this"
 /* eslint-disable @typescript-eslint/unbound-method */
-const { onMouseMove, onMouseLeave, onMouseUp } = boxGlyph
+const { drawDragPreview, onMouseMove, onMouseLeave, onMouseUp } = boxGlyph
 /* eslint-enable @typescript-eslint/unbound-method */
 
 export const exonGlyph: Glyph = {

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/ExonGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/ExonGlyph.ts
@@ -5,6 +5,7 @@ import type { ContentBlock } from '@jbrowse/core/util/blockTypes'
 import { isSelectedFeature } from '../../util'
 import type { LinearApolloDisplay } from '../stateModel'
 
+import { boxGlyph } from './BoxGlyph'
 import type { Glyph } from './Glyph'
 import { drawHighlight, getFeatureBox, strokeRectInner } from './util'
 
@@ -60,6 +61,12 @@ function drawHover(
   drawHighlight(display, overlayCtx, left, top, width, height)
 }
 
+function drawDragPreview() {
+  // Not implemented
+}
+// display: LinearApolloDisplayMouseEvents,
+// ctx: CanvasRenderingContext2D,
+
 function getRowCount() {
   return 1
 }
@@ -90,12 +97,6 @@ function getRowForFeature(
   return
 }
 
-function drawDragPreview() {
-  // Not implemented
-}
-// display: LinearApolloDisplayMouseEvents,
-// ctx: CanvasRenderingContext2D,
-
 function onMouseDown() {
   // Not implemented
 }
@@ -124,12 +125,6 @@ function onMouseUp() {
 // currentMousePosition: MousePositionWithFeature,
 // event: CanvasMouseEvent,
 
-function drawTooltip() {
-  // Not implemented
-}
-// display: LinearApolloDisplayMouseEvents,
-// context: CanvasRenderingContext2D,
-
 function getContextMenuItemsForFeature(): MenuItem[] {
   return []
   // Not implemented
@@ -143,6 +138,11 @@ function getContextMenuItems(): MenuItem[] {
 }
 // display: LinearApolloDisplayMouseEvents,
 // currentMousePosition: MousePositionWithFeature,
+
+// False positive here, none of these functions use "this"
+/* eslint-disable @typescript-eslint/unbound-method */
+const { drawTooltip } = boxGlyph
+/* eslint-enable @typescript-eslint/unbound-method */
 
 export const exonGlyph: Glyph = {
   draw,

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/ExonGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/ExonGlyph.ts
@@ -43,25 +43,35 @@ function draw(
   strokeRectInner(ctx, left, top, width, height, theme.palette.text.primary)
 }
 
-function getRowCount(): number {
+function getRowCount() {
   return 1
 }
 
-function getFeatureFromLayout(): AnnotationFeature | undefined {
-  return undefined
-  // Not implemented
+function getFeatureFromLayout(
+  _display: LinearApolloDisplay,
+  feature: AnnotationFeature,
+  bp: number,
+  row: number,
+) {
+  if (row > 0) {
+    return
+  }
+  if (bp >= feature.min && bp <= feature.max) {
+    return feature
+  }
+  return
 }
-// feature: AnnotationFeature,
-// bp: number,
-// row: number,
-// featureTypeOntology: OntologyRecord,
-function getRowForFeature(): number | undefined {
-  // Not implemented
-  return undefined
+
+function getRowForFeature(
+  _display: LinearApolloDisplay,
+  feature: AnnotationFeature,
+  childFeature: AnnotationFeature,
+) {
+  if (feature._id === childFeature._id) {
+    return 0
+  }
+  return
 }
-// feature: AnnotationFeature,
-// childFeature: AnnotationFeature,
-// featureTypeOntology: OntologyRecord,
 
 function drawHover() {
   // Not implemented

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/ExonGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/ExonGlyph.ts
@@ -71,19 +71,19 @@ function getRowCount() {
   return 1
 }
 
-function getFeatureFromLayout(
+function getFeaturesFromLayout(
   _display: LinearApolloDisplay,
   feature: AnnotationFeature,
   bp: number,
   row: number,
 ) {
   if (row > 0) {
-    return
+    return []
   }
   if (bp >= feature.min && bp <= feature.max) {
-    return feature
+    return [feature]
   }
-  return
+  return []
 }
 
 function getRowForFeature(
@@ -137,7 +137,7 @@ export const exonGlyph: Glyph = {
   drawHover,
   getContextMenuItems,
   getContextMenuItemsForFeature,
-  getFeatureFromLayout,
+  getFeaturesFromLayout,
   getRowCount,
   getRowForFeature,
   onMouseDown,

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/ExonGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/ExonGlyph.ts
@@ -2,12 +2,18 @@ import type { AnnotationFeature } from '@apollo-annotation/mst'
 import type { MenuItem } from '@jbrowse/core/ui'
 import type { ContentBlock } from '@jbrowse/core/util/blockTypes'
 
-import { isSelectedFeature } from '../../util'
+import { type MousePositionWithFeature, isSelectedFeature } from '../../util'
 import type { LinearApolloDisplay } from '../stateModel'
+import type { CanvasMouseEvent } from '../types'
 
 import { boxGlyph } from './BoxGlyph'
 import type { Glyph } from './Glyph'
-import { drawHighlight, getFeatureBox, strokeRectInner } from './util'
+import {
+  drawHighlight,
+  getFeatureBox,
+  isMouseOnFeatureEdge,
+  strokeRectInner,
+} from './util'
 
 function draw(
   display: LinearApolloDisplay,
@@ -97,34 +103,6 @@ function getRowForFeature(
   return
 }
 
-function onMouseDown() {
-  // Not implemented
-}
-// display: LinearApolloDisplayMouseEvents,
-// currentMousePosition: MousePositionWithFeature,
-// event: CanvasMouseEvent,
-
-function onMouseMove() {
-  // Not implemented
-}
-// display: LinearApolloDisplayMouseEvents,
-// currentMousePosition: MousePositionWithFeature,
-// event: CanvasMouseEvent,
-
-function onMouseLeave() {
-  // Not implemented
-}
-// display: LinearApolloDisplayMouseEvents,
-// currentMousePosition: MousePositionWithFeature,
-// event: CanvasMouseEvent,
-
-function onMouseUp() {
-  // Not implemented
-}
-// display: LinearApolloDisplayMouseEvents,
-// currentMousePosition: MousePositionWithFeature,
-// event: CanvasMouseEvent,
-
 function getContextMenuItemsForFeature(): MenuItem[] {
   return []
   // Not implemented
@@ -139,9 +117,24 @@ function getContextMenuItems(): MenuItem[] {
 // display: LinearApolloDisplayMouseEvents,
 // currentMousePosition: MousePositionWithFeature,
 
+function onMouseDown(
+  stateModel: LinearApolloDisplay,
+  mousePosition: MousePositionWithFeature,
+  event: CanvasMouseEvent,
+) {
+  const { feature } = mousePosition
+  // swallow the mouseDown if we are on the edge of the feature so that we
+  // don't start dragging the view if we try to drag the feature edge
+  const edge = isMouseOnFeatureEdge(mousePosition, feature, stateModel)
+  if (edge) {
+    event.stopPropagation()
+    stateModel.startDrag(mousePosition, feature, edge, true)
+  }
+}
+
 // False positive here, none of these functions use "this"
 /* eslint-disable @typescript-eslint/unbound-method */
-const { drawTooltip } = boxGlyph
+const { drawTooltip, onMouseMove, onMouseLeave, onMouseUp } = boxGlyph
 /* eslint-enable @typescript-eslint/unbound-method */
 
 export const exonGlyph: Glyph = {

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/ExonGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/ExonGlyph.ts
@@ -134,14 +134,13 @@ function onMouseDown(
 
 // False positive here, none of these functions use "this"
 /* eslint-disable @typescript-eslint/unbound-method */
-const { drawTooltip, onMouseMove, onMouseLeave, onMouseUp } = boxGlyph
+const { onMouseMove, onMouseLeave, onMouseUp } = boxGlyph
 /* eslint-enable @typescript-eslint/unbound-method */
 
 export const exonGlyph: Glyph = {
   draw,
   drawDragPreview,
   drawHover,
-  drawTooltip,
   getContextMenuItems,
   getContextMenuItemsForFeature,
   getFeatureFromLayout,

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/ExonGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/ExonGlyph.ts
@@ -2,10 +2,11 @@ import type { AnnotationFeature } from '@apollo-annotation/mst'
 import type { MenuItem } from '@jbrowse/core/ui'
 import type { ContentBlock } from '@jbrowse/core/util/blockTypes'
 
+import { isSelectedFeature } from '../../util'
 import type { LinearApolloDisplay } from '../stateModel'
 
 import type { Glyph } from './Glyph'
-import { getLeftPx, strokeRectInner } from './util'
+import { drawHighlight, getFeatureBox, strokeRectInner } from './util'
 
 function draw(
   display: LinearApolloDisplay,
@@ -14,10 +15,8 @@ function draw(
   row: number,
   block: ContentBlock,
 ) {
-  const { apolloRowHeight, canvasPatterns, lgv, theme } = display
-  const { bpPerPx } = lgv
-  const left = Math.round(getLeftPx(display, exon, block))
-  const width = Math.round(exon.length / bpPerPx)
+  const { apolloRowHeight, canvasPatterns, selectedFeature, theme } = display
+  const [, left, width] = getFeatureBox(display, exon, row, block)
   const height = Math.round(0.6 * apolloRowHeight)
   const halfHeight = Math.round(height / 2)
   const top = Math.round(halfHeight / 2) + row * apolloRowHeight
@@ -41,6 +40,24 @@ function draw(
     }
   }
   strokeRectInner(ctx, left, top, width, height, theme.palette.text.primary)
+  if (isSelectedFeature(exon, selectedFeature)) {
+    drawHighlight(display, ctx, left, top, width, height, true)
+  }
+}
+
+function drawHover(
+  display: LinearApolloDisplay,
+  overlayCtx: CanvasRenderingContext2D,
+  exon: AnnotationFeature,
+  row: number,
+  block: ContentBlock,
+) {
+  const { apolloRowHeight } = display
+  const [, left, width] = getFeatureBox(display, exon, row, block)
+  const height = Math.round(0.6 * apolloRowHeight)
+  const halfHeight = Math.round(height / 2)
+  const top = Math.round(halfHeight / 2) + row * apolloRowHeight
+  drawHighlight(display, overlayCtx, left, top, width, height)
 }
 
 function getRowCount() {
@@ -72,12 +89,6 @@ function getRowForFeature(
   }
   return
 }
-
-function drawHover() {
-  // Not implemented
-}
-// display: LinearApolloDisplayMouseEvents,
-// overlayCtx: CanvasRenderingContext2D,
 
 function drawDragPreview() {
   // Not implemented

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
@@ -1,65 +1,18 @@
 import type { AnnotationFeature } from '@apollo-annotation/mst'
 import { readConfObject } from '@jbrowse/core/configuration'
-import type { BaseDisplayModel } from '@jbrowse/core/pluggableElementTypes'
 import type { MenuItem } from '@jbrowse/core/ui'
-import {
-  type AbstractSessionModel,
-  getContainingView,
-  isSessionModelWithWidgets,
-} from '@jbrowse/core/util'
 import type { ContentBlock } from '@jbrowse/core/util/blockTypes'
-import type { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
 import { alpha } from '@mui/material'
 
-import { MergeExons, MergeTranscripts, SplitExon } from '../../components'
-import { DuplicateTranscript } from '../../components/DuplicateTranscript'
-import {
-  type MousePositionWithFeature,
-  getAdjacentExons,
-  getStreamIcon,
-  isCDSFeature,
-  isExonFeature,
-  isMousePositionWithFeature,
-  isSelectedFeature,
-  isTranscriptFeature,
-  navToFeatureCenter,
-  selectFeatureAndOpenWidget,
-} from '../../util'
-import { getRelatedFeatures } from '../../util/annotationFeatureUtils'
+import { isSelectedFeature } from '../../util'
 import type { LinearApolloDisplay } from '../stateModel'
-import type { LinearApolloDisplayMouseEvents } from '../stateModel/mouseEvents'
 
 import { boxGlyph } from './BoxGlyph'
 import type { Glyph } from './Glyph'
-import { transcriptGlyph } from './TranscriptGlyph'
 import { drawHighlight, getFeatureBox, strokeRectInner } from './util'
 
-interface LayoutRow {
-  feature: AnnotationFeature
-  glyph: Glyph
-  rowInFeature: number
-}
-
-function getLayoutRows(
-  display: LinearApolloDisplay,
-  feature: AnnotationFeature,
-): LayoutRow[] {
-  const { children } = feature
-  if (!children) {
-    return []
-  }
-  const rows: LayoutRow[] = []
-  const { session } = display
-  for (const [, child] of children) {
-    const isTranscript = isTranscriptFeature(child, session)
-    const glyph = isTranscript ? transcriptGlyph : boxGlyph
-    const newRowCount = glyph.getRowCount(display, child)
-    for (let i = 0; i < newRowCount; i++) {
-      rows.push({ feature: child, glyph, rowInFeature: i })
-    }
-  }
-
-  return rows
+function getRowCount(display: LinearApolloDisplay, feature: AnnotationFeature) {
+  return getLayout(display, feature).byRow.length
 }
 
 function draw(
@@ -67,8 +20,12 @@ function draw(
   ctx: CanvasRenderingContext2D,
   gene: AnnotationFeature,
   row: number,
+  rowInFeature: number,
   block: ContentBlock,
 ): void {
+  if (rowInFeature > 0) {
+    return
+  }
   const { apolloRowHeight, theme, selectedFeature, session } = display
   const [top, left, width] = getFeatureBox(display, gene, row, block)
   const height = getRowCount(display, gene) * apolloRowHeight
@@ -83,20 +40,6 @@ function draw(
     ctx.fillRect(left, top, width, height)
   }
   strokeRectInner(ctx, left, top, width, height, theme.palette.text.primary)
-  const { children } = gene
-  if (!children) {
-    return
-  }
-
-  // Draw children of gene on their own rows
-  const rows = getLayoutRows(display, gene)
-  for (const [idx, layoutRow] of rows.entries()) {
-    const { feature: rowFeature, glyph, rowInFeature } = layoutRow
-    if (rowInFeature > 1) {
-      continue
-    }
-    glyph.draw(display, ctx, rowFeature, row + idx, block)
-  }
 
   if (isSelectedFeature(gene, selectedFeature)) {
     drawHighlight(display, ctx, left, top, width, height, true)
@@ -116,284 +59,45 @@ function drawHover(
   drawHighlight(display, ctx, left, top, width, height)
 }
 
-function getRowCount(
-  display: LinearApolloDisplay,
-  feature: AnnotationFeature,
-): number {
-  const layoutRows = getLayoutRows(display, feature)
-  if (layoutRows.length === 0) {
-    return 1
+function getLayout(display: LinearApolloDisplay, feature: AnnotationFeature) {
+  const layout = {
+    byFeature: new Map([[feature._id, 0]]),
+    byRow: [[{ feature, rowInFeature: 0 }]],
+    min: feature.min,
+    max: feature.max,
   }
-  return layoutRows.length
-}
-
-function getFeaturesFromLayout(
-  display: LinearApolloDisplay,
-  feature: AnnotationFeature,
-  bp: number,
-  row: number,
-) {
-  const layoutRow = getLayoutRows(display, feature).at(row)
-  if (!layoutRow) {
-    return []
+  const { children } = feature
+  if (!children) {
+    return layout
   }
-  const { feature: rowFeature, glyph, rowInFeature } = layoutRow
-  const layoutFeatures = glyph.getFeaturesFromLayout(
-    display,
-    rowFeature,
-    bp,
-    rowInFeature,
-  )
-  if (bp >= feature.min && bp <= feature.max) {
-    layoutFeatures.push(feature)
-  }
-  return layoutFeatures
-}
-
-function getRowForFeature(
-  display: LinearApolloDisplay,
-  feature: AnnotationFeature,
-  childFeature: AnnotationFeature,
-) {
-  const rows = getLayoutRows(display, feature)
-  for (const [idx, row] of rows.entries()) {
-    if (row.feature._id === childFeature._id) {
-      return idx
+  layout.byRow = []
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const { getGlyph } = display
+  for (const [, child] of children) {
+    const glyph = getGlyph(child)
+    const childLayout = glyph.getLayout(display, child)
+    const startingRowIndex = layout.byRow.length
+    for (const [idx, row] of childLayout.byRow.entries()) {
+      layout.byRow.push([
+        { feature, rowInFeature: startingRowIndex + idx },
+        ...row,
+      ])
     }
-    const subFeatureRow = row.glyph.getRowForFeature(
-      display,
-      row.feature,
-      childFeature,
-    )
-    if (subFeatureRow !== undefined) {
-      return subFeatureRow + idx
+    for (const entry of childLayout.byFeature.entries()) {
+      const [featureId, rowNumber] = entry
+      layout.byFeature.set(featureId, rowNumber + startingRowIndex)
     }
   }
-  return
+  return layout
 }
 
-function getContextMenuItems(
-  display: LinearApolloDisplayMouseEvents,
-  mousePosition: MousePositionWithFeature,
-): MenuItem[] {
-  const {
-    apolloInternetAccount: internetAccount,
-    hoveredFeature,
-    changeManager,
-    regions,
-    selectedFeature,
-    session,
-  } = display
-  const [region] = regions
-  const currentAssemblyId = display.getAssemblyId(region.assemblyName)
-  const menuItems: MenuItem[] = []
-  const role = internetAccount ? internetAccount.role : 'admin'
-  const readOnly = !(role && ['admin', 'user'].includes(role))
-  if (!hoveredFeature) {
-    return menuItems
-  }
-
-  if (isMousePositionWithFeature(mousePosition)) {
-    const { bp, feature } = mousePosition
-    let featuresUnderClick = getRelatedFeatures(feature, bp)
-    if (isCDSFeature(feature, session)) {
-      featuresUnderClick = getRelatedFeatures(feature, bp, true)
-    }
-
-    for (const feature of featuresUnderClick) {
-      const contextMenuItemsForFeature = boxGlyph.getContextMenuItemsForFeature(
-        display,
-        feature,
-      )
-      if (isExonFeature(feature, session)) {
-        const adjacentExons = getAdjacentExons(
-          feature,
-          display,
-          mousePosition,
-          session,
-        )
-        const lgv = getContainingView(
-          display as BaseDisplayModel,
-        ) as unknown as LinearGenomeViewModel
-        if (adjacentExons.upstream) {
-          const exon = adjacentExons.upstream
-          contextMenuItemsForFeature.push({
-            label: 'Go to upstream exon',
-            icon: getStreamIcon(
-              feature.strand,
-              true,
-              lgv.displayedRegions.at(0)?.reversed,
-            ),
-            onClick: () => {
-              lgv.navTo(navToFeatureCenter(exon, 0.1, lgv.totalBp))
-              selectFeatureAndOpenWidget(display, exon)
-            },
-          })
-        }
-        if (adjacentExons.downstream) {
-          const exon = adjacentExons.downstream
-          contextMenuItemsForFeature.push({
-            label: 'Go to downstream exon',
-            icon: getStreamIcon(
-              feature.strand,
-              false,
-              lgv.displayedRegions.at(0)?.reversed,
-            ),
-            onClick: () => {
-              lgv.navTo(navToFeatureCenter(exon, 0.1, lgv.totalBp))
-              selectFeatureAndOpenWidget(display, exon)
-            },
-          })
-        }
-        contextMenuItemsForFeature.push(
-          {
-            label: 'Merge exons',
-            disabled: readOnly,
-            onClick: () => {
-              ;(session as unknown as AbstractSessionModel).queueDialog(
-                (doneCallback) => [
-                  MergeExons,
-                  {
-                    session,
-                    handleClose: () => {
-                      doneCallback()
-                    },
-                    changeManager,
-                    sourceFeature: feature,
-                    sourceAssemblyId: currentAssemblyId,
-                    selectedFeature,
-                    setSelectedFeature: (feature?: AnnotationFeature) => {
-                      display.setSelectedFeature(feature)
-                    },
-                  },
-                ],
-              )
-            },
-          },
-          {
-            label: 'Split exon',
-            disabled: readOnly,
-            onClick: () => {
-              ;(session as unknown as AbstractSessionModel).queueDialog(
-                (doneCallback) => [
-                  SplitExon,
-                  {
-                    session,
-                    handleClose: () => {
-                      doneCallback()
-                    },
-                    changeManager,
-                    sourceFeature: feature,
-                    sourceAssemblyId: currentAssemblyId,
-                    selectedFeature,
-                    setSelectedFeature: (feature?: AnnotationFeature) => {
-                      display.setSelectedFeature(feature)
-                    },
-                  },
-                ],
-              )
-            },
-          },
-        )
-      }
-      if (isTranscriptFeature(feature, session)) {
-        contextMenuItemsForFeature.push(
-          {
-            label: 'Merge transcript',
-            onClick: () => {
-              ;(session as unknown as AbstractSessionModel).queueDialog(
-                (doneCallback) => [
-                  MergeTranscripts,
-                  {
-                    session,
-                    handleClose: () => {
-                      doneCallback()
-                    },
-                    changeManager,
-                    sourceFeature: feature,
-                    sourceAssemblyId: currentAssemblyId,
-                    selectedFeature,
-                    setSelectedFeature: (feature?: AnnotationFeature) => {
-                      display.setSelectedFeature(feature)
-                    },
-                  },
-                ],
-              )
-            },
-          },
-          {
-            label: 'Duplicate feature',
-            onClick: () => {
-              ;(session as unknown as AbstractSessionModel).queueDialog(
-                (doneCallback) => [
-                  DuplicateTranscript,
-                  {
-                    session,
-                    handleClose: () => {
-                      doneCallback()
-                    },
-                    changeManager,
-                    sourceFeature: feature,
-                    sourceAssemblyId: currentAssemblyId,
-                    selectedFeature,
-                    setSelectedFeature: (feature?: AnnotationFeature) => {
-                      display.setSelectedFeature(feature)
-                    },
-                  },
-                ],
-              )
-            },
-          },
-        )
-        if (isSessionModelWithWidgets(session)) {
-          contextMenuItemsForFeature.splice(1, 0, {
-            label: 'Open transcript editor',
-            onClick: () => {
-              const apolloTranscriptWidget = session.addWidget(
-                'ApolloTranscriptDetails',
-                'apolloTranscriptDetails',
-                {
-                  feature,
-                  assembly: currentAssemblyId,
-                  changeManager,
-                  refName: region.refName,
-                },
-              )
-              session.showWidget(apolloTranscriptWidget)
-            },
-          })
-        }
-      }
-      menuItems.push({
-        label: feature.type,
-        subMenu: contextMenuItemsForFeature,
-      })
-    }
-  }
-  return menuItems
-}
-
-// Genes are not draggable, only the underlying exons and CDS are
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-function onMouseDown() {}
-
-function onMouseMove(
-  stateModel: LinearApolloDisplay,
-  mousePosition: MousePositionWithFeature,
-) {
-  const { feature, bp } = mousePosition
-  stateModel.setHoveredFeature({ feature, bp })
-  stateModel.setCursor()
+function getContextMenuItems(): MenuItem[] {
+  return []
 }
 
 // False positive here, none of these functions use "this"
 /* eslint-disable @typescript-eslint/unbound-method */
-const {
-  drawDragPreview,
-  getContextMenuItemsForFeature,
-  onMouseLeave,
-  onMouseUp,
-} = boxGlyph
+const { drawDragPreview } = boxGlyph
 /* eslint-enable @typescript-eslint/unbound-method */
 
 export const geneGlyph: Glyph = {
@@ -401,12 +105,6 @@ export const geneGlyph: Glyph = {
   drawDragPreview,
   drawHover,
   getContextMenuItems,
-  getContextMenuItemsForFeature,
-  getFeaturesFromLayout,
-  getRowCount,
-  getRowForFeature,
-  onMouseDown,
-  onMouseLeave,
-  onMouseMove,
-  onMouseUp,
+  getLayout,
+  isDraggable: false,
 }

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
@@ -5,7 +5,6 @@ import type { MenuItem } from '@jbrowse/core/ui'
 import {
   type AbstractSessionModel,
   getContainingView,
-  intersection2,
   isSessionModelWithWidgets,
 } from '@jbrowse/core/util'
 import type { ContentBlock } from '@jbrowse/core/util/blockTypes'
@@ -15,11 +14,8 @@ import { alpha } from '@mui/material'
 import { MergeExons, MergeTranscripts, SplitExon } from '../../components'
 import { DuplicateTranscript } from '../../components/DuplicateTranscript'
 import {
-  type MousePosition,
   type MousePositionWithFeature,
   getAdjacentExons,
-  getMinAndMaxPx,
-  getOverlappingEdge,
   getStreamIcon,
   isCDSFeature,
   isExonFeature,
@@ -32,78 +28,11 @@ import {
 import { getRelatedFeatures } from '../../util/annotationFeatureUtils'
 import type { LinearApolloDisplay } from '../stateModel'
 import type { LinearApolloDisplayMouseEvents } from '../stateModel/mouseEvents'
-import type { CanvasMouseEvent } from '../types'
 
 import { boxGlyph } from './BoxGlyph'
 import type { Glyph } from './Glyph'
 import { transcriptGlyph } from './TranscriptGlyph'
 import { drawHighlight, getFeatureBox, strokeRectInner } from './util'
-
-function getDraggableFeatureInfo(
-  mousePosition: MousePosition,
-  feature: AnnotationFeature,
-  stateModel: LinearApolloDisplay,
-): { feature: AnnotationFeature; edge: 'min' | 'max' } | undefined {
-  const { session } = stateModel
-  const { apolloDataStore } = session
-  const { featureTypeOntology } = apolloDataStore.ontologyManager
-  if (!featureTypeOntology) {
-    throw new Error('featureTypeOntology is undefined')
-  }
-  const isGene =
-    featureTypeOntology.isTypeOf(feature.type, 'gene') ||
-    featureTypeOntology.isTypeOf(feature.type, 'pseudogene')
-  const isTranscript =
-    featureTypeOntology.isTypeOf(feature.type, 'transcript') ||
-    featureTypeOntology.isTypeOf(feature.type, 'pseudogenic_transcript')
-  const isCDS = featureTypeOntology.isTypeOf(feature.type, 'CDS')
-  if (isGene || isTranscript) {
-    // For gene glyphs, the sizes of genes and transcripts are determined by
-    // their child exons, so we don't make them draggable
-    return
-  }
-  // So now the type of feature is either CDS or exon. If an exon and CDS edge
-  // are in the same place, we want to prioritize dragging the exon. If the
-  // feature we're on is a CDS, let's find any exon it may overlap.
-  const { bp, refName, regionNumber, x } = mousePosition
-  const { lgv } = stateModel
-  if (isCDS) {
-    const transcript = feature.parent
-    if (!transcript?.children) {
-      return
-    }
-    const exonChildren: AnnotationFeature[] = []
-    for (const child of transcript.children.values()) {
-      const childIsExon = featureTypeOntology.isTypeOf(child.type, 'exon')
-      if (childIsExon) {
-        exonChildren.push(child)
-      }
-    }
-    const overlappingExon = exonChildren.find((child) => {
-      const [start, end] = intersection2(bp - 1, bp, child.min, child.max)
-      return start !== undefined && end !== undefined
-    })
-    if (overlappingExon) {
-      // We are on an exon, are we on the edge of it?
-      const minMax = getMinAndMaxPx(overlappingExon, refName, regionNumber, lgv)
-      if (minMax) {
-        const overlappingEdge = getOverlappingEdge(overlappingExon, x, minMax)
-        if (overlappingEdge) {
-          return overlappingEdge
-        }
-      }
-    }
-  }
-  // End of special cases, let's see if we're on the edge of this CDS or exon
-  const minMax = getMinAndMaxPx(feature, refName, regionNumber, lgv)
-  if (minMax) {
-    const overlappingEdge = getOverlappingEdge(feature, x, minMax)
-    if (overlappingEdge) {
-      return overlappingEdge
-    }
-  }
-  return
-}
 
 interface LayoutRow {
   feature: AnnotationFeature
@@ -273,64 +202,6 @@ function getRowForFeature(
     }
   }
   return
-}
-
-function onMouseDown(
-  stateModel: LinearApolloDisplay,
-  currentMousePosition: MousePositionWithFeature,
-  event: CanvasMouseEvent,
-) {
-  const { feature } = currentMousePosition
-  // swallow the mouseDown if we are on the edge of the feature so that we
-  // don't start dragging the view if we try to drag the feature edge
-  const draggableFeature = getDraggableFeatureInfo(
-    currentMousePosition,
-    feature,
-    stateModel,
-  )
-  if (draggableFeature) {
-    event.stopPropagation()
-    stateModel.startDrag(
-      currentMousePosition,
-      draggableFeature.feature,
-      draggableFeature.edge,
-      true,
-    )
-  }
-}
-
-function onMouseMove(
-  stateModel: LinearApolloDisplay,
-  mousePosition: MousePosition,
-) {
-  if (isMousePositionWithFeature(mousePosition)) {
-    const { feature, bp } = mousePosition
-    stateModel.setHoveredFeature({ feature, bp })
-    const draggableFeature = getDraggableFeatureInfo(
-      mousePosition,
-      feature,
-      stateModel,
-    )
-    if (draggableFeature) {
-      stateModel.setCursor('col-resize')
-      return
-    }
-  }
-  stateModel.setCursor()
-}
-
-function onMouseUp(
-  stateModel: LinearApolloDisplay,
-  mousePosition: MousePosition,
-) {
-  if (stateModel.apolloDragging) {
-    return
-  }
-  const { feature } = mousePosition
-  if (!feature) {
-    return
-  }
-  selectFeatureAndOpenWidget(stateModel, feature)
 }
 
 function getContextMenuItems(
@@ -534,9 +405,23 @@ function getContextMenuItems(
   return menuItems
 }
 
+// Genes are not draggable, only the underlying exons and CDS are
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+function onMouseDown() {}
+
+function onMouseMove(
+  stateModel: LinearApolloDisplay,
+  mousePosition: MousePositionWithFeature,
+) {
+  const { feature, bp } = mousePosition
+  stateModel.setHoveredFeature({ feature, bp })
+  stateModel.setCursor()
+}
+
 // False positive here, none of these functions use "this"
 /* eslint-disable @typescript-eslint/unbound-method */
-const { drawTooltip, getContextMenuItemsForFeature, onMouseLeave } = boxGlyph
+const { drawTooltip, getContextMenuItemsForFeature, onMouseLeave, onMouseUp } =
+  boxGlyph
 /* eslint-enable @typescript-eslint/unbound-method */
 
 export const geneGlyph: Glyph = {

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
@@ -127,7 +127,7 @@ function getRowCount(
   return layoutRows.length
 }
 
-function getFeatureFromLayout(
+function getFeaturesFromLayout(
   display: LinearApolloDisplay,
   feature: AnnotationFeature,
   bp: number,
@@ -135,22 +135,19 @@ function getFeatureFromLayout(
 ) {
   const layoutRow = getLayoutRows(display, feature).at(row)
   if (!layoutRow) {
-    return
+    return []
   }
   const { feature: rowFeature, glyph, rowInFeature } = layoutRow
-  const subFeature = glyph.getFeatureFromLayout(
+  const layoutFeatures = glyph.getFeaturesFromLayout(
     display,
     rowFeature,
     bp,
     rowInFeature,
   )
-  if (subFeature) {
-    return subFeature
-  }
   if (bp >= feature.min && bp <= feature.max) {
-    return feature
+    layoutFeatures.push(feature)
   }
-  return
+  return layoutFeatures
 }
 
 function getRowForFeature(
@@ -405,7 +402,7 @@ export const geneGlyph: Glyph = {
   drawHover,
   getContextMenuItems,
   getContextMenuItemsForFeature,
-  getFeatureFromLayout,
+  getFeaturesFromLayout,
   getRowCount,
   getRowForFeature,
   onMouseDown,

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
@@ -420,15 +420,13 @@ function onMouseMove(
 
 // False positive here, none of these functions use "this"
 /* eslint-disable @typescript-eslint/unbound-method */
-const { drawTooltip, getContextMenuItemsForFeature, onMouseLeave, onMouseUp } =
-  boxGlyph
+const { getContextMenuItemsForFeature, onMouseLeave, onMouseUp } = boxGlyph
 /* eslint-enable @typescript-eslint/unbound-method */
 
 export const geneGlyph: Glyph = {
   draw,
   drawDragPreview,
   drawHover,
-  drawTooltip,
   getContextMenuItems,
   getContextMenuItemsForFeature,
   getFeatureFromLayout,

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
@@ -12,7 +12,6 @@ import type { ContentBlock } from '@jbrowse/core/util/blockTypes'
 import type { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
 import { alpha } from '@mui/material'
 
-import type { OntologyRecord } from '../../OntologyManager'
 import { MergeExons, MergeTranscripts, SplitExon } from '../../components'
 import { DuplicateTranscript } from '../../components/DuplicateTranscript'
 import {
@@ -106,57 +105,32 @@ function getDraggableFeatureInfo(
   return
 }
 
-/**
- * A list of all the subfeatures for each row for a given feature, as well as
- * the feature itself.
- * If the row contains a transcript, the order is CDS -\> exon -\> transcript -\> gene
- * If the row does not contain an transcript, the order is subfeature -\> gene
- */
-function featuresForRow(
+interface LayoutRow {
+  feature: AnnotationFeature
+  glyph: Glyph
+  rowInFeature: number
+}
+
+function getLayoutRows(
+  display: LinearApolloDisplay,
   feature: AnnotationFeature,
-  featureTypeOntology: OntologyRecord,
-): AnnotationFeature[][] {
-  const isGene =
-    featureTypeOntology.isTypeOf(feature.type, 'gene') ||
-    featureTypeOntology.isTypeOf(feature.type, 'pseudogene')
-  if (!isGene) {
-    throw new Error('Top level feature for GeneGlyph must have type "gene"')
-  }
+): LayoutRow[] {
   const { children } = feature
   if (!children) {
-    return [[feature]]
+    return []
   }
-  const features: AnnotationFeature[][] = []
+  const rows: LayoutRow[] = []
+  const { session } = display
   for (const [, child] of children) {
-    if (
-      !(
-        featureTypeOntology.isTypeOf(child.type, 'transcript') ||
-        featureTypeOntology.isTypeOf(child.type, 'pseudogenic_transcript')
-      )
-    ) {
-      features.push([child, feature])
-      continue
-    }
-    if (!child.children) {
-      continue
-    }
-    const cdss: AnnotationFeature[] = []
-    const exons: AnnotationFeature[] = []
-    for (const [, grandchild] of child.children) {
-      if (featureTypeOntology.isTypeOf(grandchild.type, 'CDS')) {
-        cdss.push(grandchild)
-      } else if (featureTypeOntology.isTypeOf(grandchild.type, 'exon')) {
-        exons.push(grandchild)
-      }
-    }
-    for (const cds of cdss) {
-      features.push([cds, ...exons, child, feature])
-    }
-    if (cdss.length === 0) {
-      features.push([...exons, child, feature])
+    const isTranscript = isTranscriptFeature(child, session)
+    const glyph = isTranscript ? transcriptGlyph : boxGlyph
+    const newRowCount = glyph.getRowCount(display, child)
+    for (let i = 0; i < newRowCount; i++) {
+      rows.push({ feature: child, glyph, rowInFeature: i })
     }
   }
-  return features
+
+  return rows
 }
 
 function drawHighlight(
@@ -165,8 +139,7 @@ function drawHighlight(
   feature: AnnotationFeature,
   selected = false,
 ) {
-  const { apolloRowHeight, lgv, session, theme } = stateModel
-  const { featureTypeOntology } = session.apolloDataStore.ontologyManager
+  const { apolloRowHeight, lgv, theme } = stateModel
 
   const position = stateModel.getFeatureLayoutPosition(feature)
   if (!position) {
@@ -190,9 +163,6 @@ function drawHighlight(
     ? theme.palette.action.disabled
     : theme.palette.action.focus
 
-  if (!featureTypeOntology) {
-    throw new Error('featureTypeOntology is undefined')
-  }
   ctx.fillRect(
     startPx,
     top,
@@ -231,13 +201,13 @@ function draw(
   }
 
   // Draw lines on different rows for each transcript
-  let currentRow = 0
-  for (const [, child] of children) {
-    const isTranscript = isTranscriptFeature(child, session)
-    const glyph = isTranscript ? transcriptGlyph : boxGlyph
-    const rowCount = glyph.getRowCount(display, child)
-    glyph.draw(display, ctx, child, row + currentRow, block)
-    currentRow += rowCount
+  const rows = getLayoutRows(display, gene)
+  for (const [idx, layoutRow] of rows.entries()) {
+    const { feature: rowFeature, glyph, rowInFeature } = layoutRow
+    if (rowInFeature > 1) {
+      continue
+    }
+    glyph.draw(display, ctx, rowFeature, row + idx, block)
   }
 
   if (selectedFeature && containsSelectedFeature(gene, selectedFeature)) {
@@ -286,76 +256,60 @@ function drawHover(
   drawHighlight(stateModel, ctx, hoveredFeature.feature)
 }
 
-function getFeatureFromLayout(
-  feature: AnnotationFeature,
-  bp: number,
-  row: number,
-  featureTypeOntology: OntologyRecord,
-): AnnotationFeature | undefined {
-  const featureInThisRow: AnnotationFeature[] =
-    featuresForRow(feature, featureTypeOntology)[row] || []
-  for (const f of featureInThisRow) {
-    let featureObj
-    if (bp >= f.min && bp <= f.max && f.parent) {
-      featureObj = f
-    }
-    if (!featureObj) {
-      continue
-    }
-    if (
-      featureTypeOntology.isTypeOf(featureObj.type, 'CDS') &&
-      featureObj.parent &&
-      (featureTypeOntology.isTypeOf(featureObj.parent.type, 'transcript') ||
-        featureTypeOntology.isTypeOf(
-          featureObj.parent.type,
-          'pseudogenic_transcript',
-        ))
-    ) {
-      const { cdsLocations } = featureObj.parent
-      for (const cdsLoc of cdsLocations) {
-        for (const loc of cdsLoc) {
-          if (bp >= loc.min && bp <= loc.max) {
-            return featureObj
-          }
-        }
-      }
-
-      // If mouse position is in the intron region, return the transcript
-      return featureObj.parent
-    }
-    // If mouse position is in a feature that is not a CDS, return the feature
-    return featureObj
-  }
-  return feature
-}
-
 function getRowCount(
   display: LinearApolloDisplay,
   feature: AnnotationFeature,
 ): number {
-  const { children } = feature
-  if (!children) {
+  const layoutRows = getLayoutRows(display, feature)
+  if (layoutRows.length === 0) {
     return 1
   }
-  const { session } = display
-  let rowCount = 0
-  for (const [, child] of children) {
-    const isTranscript = isTranscriptFeature(child, session)
-    const glyph = isTranscript ? transcriptGlyph : boxGlyph
-    rowCount += glyph.getRowCount(display, child)
+  return layoutRows.length
+}
+
+function getFeatureFromLayout(
+  display: LinearApolloDisplay,
+  feature: AnnotationFeature,
+  bp: number,
+  row: number,
+) {
+  const layoutRow = getLayoutRows(display, feature).at(row)
+  if (!layoutRow) {
+    return
   }
-  return rowCount
+  const { feature: rowFeature, glyph, rowInFeature } = layoutRow
+  const subFeature = glyph.getFeatureFromLayout(
+    display,
+    rowFeature,
+    bp,
+    rowInFeature,
+  )
+  if (subFeature) {
+    return subFeature
+  }
+  if (bp >= feature.min && bp <= feature.max) {
+    return feature
+  }
+  return
 }
 
 function getRowForFeature(
+  display: LinearApolloDisplay,
   feature: AnnotationFeature,
   childFeature: AnnotationFeature,
-  featureTypeOntology: OntologyRecord,
 ) {
-  const rows = featuresForRow(feature, featureTypeOntology)
+  const rows = getLayoutRows(display, feature)
   for (const [idx, row] of rows.entries()) {
-    if (row.some((feature) => feature._id === childFeature._id)) {
+    if (row.feature._id === childFeature._id) {
       return idx
+    }
+    const subFeatureRow = row.glyph.getRowForFeature(
+      display,
+      row.feature,
+      childFeature,
+    )
+    if (subFeatureRow !== undefined) {
+      return subFeatureRow + idx
     }
   }
   return

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
@@ -17,7 +17,6 @@ import { DuplicateTranscript } from '../../components/DuplicateTranscript'
 import {
   type MousePosition,
   type MousePositionWithFeature,
-  containsSelectedFeature,
   getAdjacentExons,
   getMinAndMaxPx,
   getOverlappingEdge,
@@ -25,6 +24,7 @@ import {
   isCDSFeature,
   isExonFeature,
   isMousePositionWithFeature,
+  isSelectedFeature,
   isTranscriptFeature,
   navToFeatureCenter,
   selectFeatureAndOpenWidget,
@@ -37,7 +37,7 @@ import type { CanvasMouseEvent } from '../types'
 import { boxGlyph } from './BoxGlyph'
 import type { Glyph } from './Glyph'
 import { transcriptGlyph } from './TranscriptGlyph'
-import { getLeftPx, strokeRectInner } from './util'
+import { drawHighlight, getFeatureBox, strokeRectInner } from './util'
 
 function getDraggableFeatureInfo(
   mousePosition: MousePosition,
@@ -133,44 +133,6 @@ function getLayoutRows(
   return rows
 }
 
-function drawHighlight(
-  stateModel: LinearApolloDisplay,
-  ctx: CanvasRenderingContext2D,
-  feature: AnnotationFeature,
-  selected = false,
-) {
-  const { apolloRowHeight, lgv, theme } = stateModel
-
-  const position = stateModel.getFeatureLayoutPosition(feature)
-  if (!position) {
-    return
-  }
-  const { bpPerPx, displayedRegions, offsetPx } = lgv
-  const { featureRow, layoutIndex, layoutRow } = position
-  const displayedRegion = displayedRegions[layoutIndex]
-  const { refName, reversed } = displayedRegion
-  const { length, max, min } = feature
-  const startPx =
-    (lgv.bpToPx({
-      refName,
-      coord: reversed ? max : min,
-      regionNumber: layoutIndex,
-    })?.offsetPx ?? 0) - offsetPx
-  const row = layoutRow + featureRow
-  const top = row * apolloRowHeight
-  const widthPx = length / bpPerPx
-  ctx.fillStyle = selected
-    ? theme.palette.action.disabled
-    : theme.palette.action.focus
-
-  ctx.fillRect(
-    startPx,
-    top,
-    widthPx,
-    apolloRowHeight * getRowCount(stateModel, feature),
-  )
-}
-
 function draw(
   display: LinearApolloDisplay,
   ctx: CanvasRenderingContext2D,
@@ -178,11 +140,8 @@ function draw(
   row: number,
   block: ContentBlock,
 ): void {
-  const { apolloRowHeight, lgv, theme, selectedFeature, session } = display
-  const { bpPerPx } = lgv
-  const left = Math.round(getLeftPx(display, gene, block))
-  const width = Math.round(gene.length / bpPerPx)
-  const top = row * apolloRowHeight
+  const { apolloRowHeight, theme, selectedFeature, session } = display
+  const [top, left, width] = getFeatureBox(display, gene, row, block)
   const height = getRowCount(display, gene) * apolloRowHeight
   if (width > 2) {
     let selectedColor = readConfObject(
@@ -200,7 +159,7 @@ function draw(
     return
   }
 
-  // Draw lines on different rows for each transcript
+  // Draw children of gene on their own rows
   const rows = getLayoutRows(display, gene)
   for (const [idx, layoutRow] of rows.entries()) {
     const { feature: rowFeature, glyph, rowInFeature } = layoutRow
@@ -210,9 +169,22 @@ function draw(
     glyph.draw(display, ctx, rowFeature, row + idx, block)
   }
 
-  if (selectedFeature && containsSelectedFeature(gene, selectedFeature)) {
-    drawHighlight(display, ctx, selectedFeature, true)
+  if (isSelectedFeature(gene, selectedFeature)) {
+    drawHighlight(display, ctx, left, top, width, height, true)
   }
+}
+
+function drawHover(
+  display: LinearApolloDisplay,
+  ctx: CanvasRenderingContext2D,
+  gene: AnnotationFeature,
+  row: number,
+  block: ContentBlock,
+) {
+  const { apolloRowHeight } = display
+  const [top, left, width] = getFeatureBox(display, gene, row, block)
+  const height = getRowCount(display, gene) * apolloRowHeight
+  drawHighlight(display, ctx, left, top, width, height)
 }
 
 function drawDragPreview(
@@ -242,18 +214,6 @@ function drawDragPreview(
   overlayCtx.strokeRect(rectX, rectY, rectWidth, rectHeight)
   overlayCtx.fillStyle = alpha(theme.palette.info.main, 0.2)
   overlayCtx.fillRect(rectX, rectY, rectWidth, rectHeight)
-}
-
-function drawHover(
-  stateModel: LinearApolloDisplay,
-  ctx: CanvasRenderingContext2D,
-) {
-  const { hoveredFeature } = stateModel
-
-  if (!hoveredFeature) {
-    return
-  }
-  drawHighlight(stateModel, ctx, hoveredFeature.feature)
 }
 
 function getRowCount(

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
@@ -116,35 +116,6 @@ function drawHover(
   drawHighlight(display, ctx, left, top, width, height)
 }
 
-function drawDragPreview(
-  stateModel: LinearApolloDisplay,
-  overlayCtx: CanvasRenderingContext2D,
-) {
-  const { apolloDragging, apolloRowHeight, lgv, theme } = stateModel
-  const { bpPerPx, displayedRegions, offsetPx } = lgv
-  if (!apolloDragging) {
-    return
-  }
-  const { current, edge, feature, start } = apolloDragging
-
-  const row = Math.floor(start.y / apolloRowHeight)
-  const region = displayedRegions[start.regionNumber]
-  const rowCount = 1
-  const featureEdgeBp = region.reversed
-    ? region.end - feature[edge]
-    : feature[edge] - region.start
-  const featureEdgePx = featureEdgeBp / bpPerPx - offsetPx
-  const rectX = Math.min(current.x, featureEdgePx)
-  const rectY = row * apolloRowHeight
-  const rectWidth = Math.abs(current.x - featureEdgePx)
-  const rectHeight = apolloRowHeight * rowCount
-  overlayCtx.strokeStyle = theme.palette.info.main
-  overlayCtx.setLineDash([6])
-  overlayCtx.strokeRect(rectX, rectY, rectWidth, rectHeight)
-  overlayCtx.fillStyle = alpha(theme.palette.info.main, 0.2)
-  overlayCtx.fillRect(rectX, rectY, rectWidth, rectHeight)
-}
-
 function getRowCount(
   display: LinearApolloDisplay,
   feature: AnnotationFeature,
@@ -420,7 +391,12 @@ function onMouseMove(
 
 // False positive here, none of these functions use "this"
 /* eslint-disable @typescript-eslint/unbound-method */
-const { getContextMenuItemsForFeature, onMouseLeave, onMouseUp } = boxGlyph
+const {
+  drawDragPreview,
+  getContextMenuItemsForFeature,
+  onMouseLeave,
+  onMouseUp,
+} = boxGlyph
 /* eslint-enable @typescript-eslint/unbound-method */
 
 export const geneGlyph: Glyph = {

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GenericChildGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GenericChildGlyph.ts
@@ -100,7 +100,7 @@ function getRowCount(display: LinearApolloDisplay, feature: AnnotationFeature) {
   return rows.length
 }
 
-function getFeatureFromLayout(
+function getFeaturesFromLayout(
   display: LinearApolloDisplay,
   feature: AnnotationFeature,
   bp: number,
@@ -109,16 +109,16 @@ function getFeatureFromLayout(
   const layoutRows = getLayoutRows(display, feature)
   const layoutRow = layoutRows.at(row)
   if (!layoutRow) {
-    return
+    return []
   }
   const { feature: rowFeature, glyph, rowInFeature } = layoutRow
   if (rowInFeature === 0) {
     if (bp >= rowFeature.min && bp <= rowFeature.max) {
-      return rowFeature
+      return [rowFeature]
     }
-    return
+    return []
   }
-  return glyph.getFeatureFromLayout(display, rowFeature, bp, rowInFeature)
+  return glyph.getFeaturesFromLayout(display, rowFeature, bp, rowInFeature)
 }
 
 function getRowForFeature(
@@ -194,7 +194,7 @@ export const genericChildGlyph: Glyph = {
   drawHover,
   getContextMenuItemsForFeature,
   getContextMenuItems,
-  getFeatureFromLayout,
+  getFeaturesFromLayout,
   getRowCount,
   getRowForFeature,
   onMouseDown,

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GenericChildGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GenericChildGlyph.ts
@@ -180,7 +180,6 @@ function getContextMenuItems(
 /* eslint-disable @typescript-eslint/unbound-method */
 const {
   drawDragPreview,
-  drawTooltip,
   getContextMenuItemsForFeature,
   onMouseDown,
   onMouseLeave,
@@ -193,7 +192,6 @@ export const genericChildGlyph: Glyph = {
   draw,
   drawDragPreview,
   drawHover,
-  drawTooltip,
   getContextMenuItemsForFeature,
   getContextMenuItems,
   getFeatureFromLayout,

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GenericChildGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GenericChildGlyph.ts
@@ -3,46 +3,15 @@ import type { MenuItem } from '@jbrowse/core/ui'
 import type { ContentBlock } from '@jbrowse/core/util/blockTypes'
 import { alpha } from '@mui/material'
 
-import {
-  type MousePositionWithFeature,
-  isMousePositionWithFeature,
-  isSelectedFeature,
-} from '../../util'
-import { getRelatedFeatures } from '../../util/annotationFeatureUtils'
+import { isSelectedFeature } from '../../util'
 import type { LinearApolloDisplay } from '../stateModel'
-import type { LinearApolloDisplayMouseEvents } from '../stateModel/mouseEvents'
 
 import { boxGlyph } from './BoxGlyph'
 import type { Glyph } from './Glyph'
 import { drawHighlight, getFeatureBox, strokeRectInner } from './util'
 
-interface LayoutRow {
-  feature: AnnotationFeature
-  glyph: Glyph
-  rowInFeature: number
-}
-
-function getLayoutRows(
-  display: LinearApolloDisplay,
-  feature: AnnotationFeature,
-): LayoutRow[] {
-  const rows: LayoutRow[] = [
-    { feature, glyph: genericChildGlyph, rowInFeature: 0 },
-  ]
-  const { children } = feature
-  if (!children) {
-    return rows
-  }
-  // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { getGlyph } = display
-  for (const [, child] of children) {
-    const glyph = getGlyph(child)
-    const newRowCount = glyph.getRowCount(display, child)
-    for (let i = 0; i < newRowCount; i++) {
-      rows.push({ feature: child, glyph, rowInFeature: i })
-    }
-  }
-  return rows
+function getRowCount(display: LinearApolloDisplay, feature: AnnotationFeature) {
+  return getLayout(display, feature).byRow.length
 }
 
 function draw(
@@ -50,8 +19,12 @@ function draw(
   ctx: CanvasRenderingContext2D,
   feature: AnnotationFeature,
   row: number,
+  rowInFeature: number,
   block: ContentBlock,
 ) {
+  if (rowInFeature > 0) {
+    return
+  }
   const { apolloRowHeight, selectedFeature, theme } = display
   const [top, left, width] = getFeatureBox(display, feature, row, block)
   const height = getRowCount(display, feature) * apolloRowHeight
@@ -60,22 +33,7 @@ function draw(
     ctx.fillRect(left, top, width, height)
   }
   strokeRectInner(ctx, left, top, width, height, theme.palette.text.primary)
-  boxGlyph.draw(display, ctx, feature, row, block)
-  const { children } = feature
-  if (!children) {
-    return
-  }
-  const childRows = getLayoutRows(display, feature).slice(1)
-  let rowOffset = 1
-  for (const childRow of childRows) {
-    const { feature: childFeature, glyph, rowInFeature } = childRow
-    if (rowInFeature > 0) {
-      rowOffset += 1
-      continue
-    }
-    glyph.draw(display, ctx, childFeature, row + rowOffset, block)
-    rowOffset += 1
-  }
+  boxGlyph.draw(display, ctx, feature, row, 0, block)
 
   if (isSelectedFeature(feature, selectedFeature)) {
     drawHighlight(display, ctx, left, top, width, height, true)
@@ -95,110 +53,51 @@ function drawHover(
   drawHighlight(display, overlayCtx, left, top, width, height)
 }
 
-function getRowCount(display: LinearApolloDisplay, feature: AnnotationFeature) {
-  const rows = getLayoutRows(display, feature)
-  return rows.length
-}
-
-function getFeaturesFromLayout(
-  display: LinearApolloDisplay,
-  feature: AnnotationFeature,
-  bp: number,
-  row: number,
-) {
-  const layoutRows = getLayoutRows(display, feature)
-  const layoutRow = layoutRows.at(row)
-  if (!layoutRow) {
-    return []
+function getLayout(display: LinearApolloDisplay, feature: AnnotationFeature) {
+  const layout = {
+    byFeature: new Map([[feature._id, 0]]),
+    byRow: [[{ feature, rowInFeature: 0 }]],
+    min: feature.min,
+    max: feature.max,
   }
-  const { feature: rowFeature, glyph, rowInFeature } = layoutRow
-  if (rowInFeature === 0) {
-    if (bp >= rowFeature.min && bp <= rowFeature.max) {
-      return [rowFeature]
+  const { children } = feature
+  if (!children) {
+    return layout
+  }
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const { getGlyph } = display
+  for (const [, child] of children) {
+    const glyph = getGlyph(child)
+    const childLayout = glyph.getLayout(display, child)
+    const startingRowIndex = layout.byRow.length
+    for (const [idx, row] of childLayout.byRow.entries()) {
+      layout.byRow.push([
+        { feature, rowInFeature: startingRowIndex + idx },
+        ...row,
+      ])
     }
-    return []
-  }
-  return glyph.getFeaturesFromLayout(display, rowFeature, bp, rowInFeature)
-}
-
-function getRowForFeature(
-  display: LinearApolloDisplay,
-  feature: AnnotationFeature,
-  childFeature: AnnotationFeature,
-) {
-  const rows = getLayoutRows(display, feature)
-  for (const [idx, row] of rows.entries()) {
-    const { feature: rowFeature } = row
-    if (rowFeature._id === childFeature._id) {
-      return idx
+    for (const entry of childLayout.byFeature.entries()) {
+      const [featureId, rowNumber] = entry
+      layout.byFeature.set(featureId, rowNumber + startingRowIndex)
     }
   }
-  return
+  return layout
 }
 
-function getContextMenuItems(
-  display: LinearApolloDisplayMouseEvents,
-  mousePosition: MousePositionWithFeature,
-): MenuItem[] {
-  const { hoveredFeature, session } = display
-  const menuItems: MenuItem[] = []
-  if (!hoveredFeature) {
-    return menuItems
-  }
-  const { featureTypeOntology } = session.apolloDataStore.ontologyManager
-  if (!featureTypeOntology) {
-    throw new Error('featureTypeOntology is undefined')
-  }
-  const sourceFeatureMenuItems = boxGlyph.getContextMenuItems(
-    display,
-    mousePosition,
-  )
-  menuItems.push({
-    label: hoveredFeature.feature.type,
-    subMenu: sourceFeatureMenuItems,
-  })
-  if (isMousePositionWithFeature(mousePosition)) {
-    const { bp, feature } = mousePosition
-    for (const relative of getRelatedFeatures(feature, bp)) {
-      if (relative._id === hoveredFeature.feature._id) {
-        continue
-      }
-      const contextMenuItemsForFeature = boxGlyph.getContextMenuItemsForFeature(
-        display,
-        relative,
-      )
-      menuItems.push({
-        label: relative.type,
-        subMenu: contextMenuItemsForFeature,
-      })
-    }
-  }
-  return menuItems
+function getContextMenuItems(): MenuItem[] {
+  return []
 }
 
 // False positive here, none of these functions use "this"
 /* eslint-disable @typescript-eslint/unbound-method */
-const {
-  drawDragPreview,
-  getContextMenuItemsForFeature,
-  onMouseDown,
-  onMouseLeave,
-  onMouseMove,
-  onMouseUp,
-} = boxGlyph
+const { drawDragPreview } = boxGlyph
 /* eslint-enable @typescript-eslint/unbound-method */
 
 export const genericChildGlyph: Glyph = {
   draw,
   drawDragPreview,
   drawHover,
-  getContextMenuItemsForFeature,
   getContextMenuItems,
-  getFeaturesFromLayout,
-  getRowCount,
-  getRowForFeature,
-  onMouseDown,
-  onMouseLeave,
-  onMouseMove,
-  onMouseUp,
+  getLayout,
+  isDraggable: true,
 }

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
@@ -24,11 +24,6 @@ export interface Glyph {
     row: number,
     block: ContentBlock,
   ): void
-  /** draw the feature's tooltip on the overlay canvas */
-  drawTooltip(
-    display: LinearApolloDisplay,
-    context: CanvasRenderingContext2D,
-  ): void
   /** draw a preview of the result of a dragging action on the overlay canvas */
   drawDragPreview(
     display: LinearApolloDisplay,

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
@@ -16,19 +16,24 @@ export interface Glyph {
     row: number,
     block: ContentBlock,
   ): void
-
+  /** draw the feature's hover highlight on the overlay canvas */
   drawHover(
-    display: LinearApolloDisplayMouseEvents,
+    display: LinearApolloDisplay,
     overlayCtx: CanvasRenderingContext2D,
+    feature: AnnotationFeature,
+    row: number,
+    block: ContentBlock,
   ): void
-
   drawDragPreview(
     display: LinearApolloDisplayMouseEvents,
     ctx: CanvasRenderingContext2D,
   ): void
 
   /** @returns number of layout rows used by this glyph with this feature and zoom level */
-  getRowCount(display: LinearApolloDisplay, feature: AnnotationFeature): number
+  getRowCount(
+    display: LinearApolloDisplayMouseEvents,
+    feature: AnnotationFeature,
+  ): number
   /**
    * @returns the feature or subfeature at the given bp and row number in this
    * glyph's layout, or undefined if one does not exist

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
@@ -36,15 +36,15 @@ export interface Glyph {
   /** @returns number of layout rows used by this glyph with this feature and zoom level */
   getRowCount(display: LinearApolloDisplay, feature: AnnotationFeature): number
   /**
-   * @returns the feature or subfeature at the given bp and row number in this
-   * glyph's layout, or undefined if one does not exist
+   * @returns the features at the given bp and row number in this glyph's
+   * layout, starting with the one that is considered "on top"
    */
-  getFeatureFromLayout(
+  getFeaturesFromLayout(
     display: LinearApolloDisplay,
     feature: AnnotationFeature,
     bp: number,
     row: number,
-  ): AnnotationFeature | undefined
+  ): AnnotationFeature[]
   /**
    * @returns the row in this glyph where a child feature appears, or undefined
    * if the feature does not appear

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
@@ -57,30 +57,6 @@ export interface Glyph {
     childFeature: AnnotationFeature,
   ): number | undefined
 
-  onMouseDown(
-    display: LinearApolloDisplayMouseEvents,
-    currentMousePosition: MousePositionWithFeature,
-    event: CanvasMouseEvent,
-  ): void
-
-  onMouseMove(
-    display: LinearApolloDisplayMouseEvents,
-    currentMousePosition: MousePositionWithFeature,
-    event: CanvasMouseEvent,
-  ): void
-
-  onMouseLeave(
-    display: LinearApolloDisplayMouseEvents,
-    currentMousePosition: MousePositionWithFeature,
-    event: CanvasMouseEvent,
-  ): void
-
-  onMouseUp(
-    display: LinearApolloDisplayMouseEvents,
-    currentMousePosition: MousePositionWithFeature,
-    event: CanvasMouseEvent,
-  ): void
-
   getContextMenuItemsForFeature(
     display: LinearApolloDisplayMouseEvents,
     sourceFeature: AnnotationFeature,
@@ -90,4 +66,29 @@ export interface Glyph {
     display: LinearApolloDisplayMouseEvents,
     currentMousePosition: MousePositionWithFeature,
   ): MenuItem[]
+
+  /** take any actions needed when the canvas's onMouseDown event fires */
+  onMouseDown(
+    display: LinearApolloDisplay,
+    mousePosition: MousePositionWithFeature,
+    event: CanvasMouseEvent,
+  ): void
+  /** take any actions needed when the canvas's onMouseMove event fires */
+  onMouseMove(
+    display: LinearApolloDisplay,
+    mousePosition: MousePositionWithFeature,
+    event: CanvasMouseEvent,
+  ): void
+  /** take any actions needed when the canvas's onMouseLeave event fires */
+  onMouseLeave(
+    display: LinearApolloDisplay,
+    mousePosition: MousePositionWithFeature,
+    event: CanvasMouseEvent,
+  ): void
+  /** take any actions needed when the canvas's onMouseUp event fires */
+  onMouseUp(
+    display: LinearApolloDisplay,
+    mousePosition: MousePositionWithFeature,
+    event: CanvasMouseEvent,
+  ): void
 }

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
@@ -24,16 +24,19 @@ export interface Glyph {
     row: number,
     block: ContentBlock,
   ): void
+  /** draw the feature's tooltip on the overlay canvas */
+  drawTooltip(
+    display: LinearApolloDisplay,
+    context: CanvasRenderingContext2D,
+  ): void
+  /** draw a preview of the result of a dragging action on the overlay canvas */
   drawDragPreview(
-    display: LinearApolloDisplayMouseEvents,
+    display: LinearApolloDisplay,
     ctx: CanvasRenderingContext2D,
   ): void
 
   /** @returns number of layout rows used by this glyph with this feature and zoom level */
-  getRowCount(
-    display: LinearApolloDisplayMouseEvents,
-    feature: AnnotationFeature,
-  ): number
+  getRowCount(display: LinearApolloDisplay, feature: AnnotationFeature): number
   /**
    * @returns the feature or subfeature at the given bp and row number in this
    * glyph's layout, or undefined if one does not exist
@@ -76,11 +79,6 @@ export interface Glyph {
     display: LinearApolloDisplayMouseEvents,
     currentMousePosition: MousePositionWithFeature,
     event: CanvasMouseEvent,
-  ): void
-
-  drawTooltip(
-    display: LinearApolloDisplayMouseEvents,
-    context: CanvasRenderingContext2D,
   ): void
 
   getContextMenuItemsForFeature(

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
@@ -2,10 +2,20 @@ import type { AnnotationFeature } from '@apollo-annotation/mst'
 import type { MenuItem } from '@jbrowse/core/ui'
 import type { ContentBlock } from '@jbrowse/core/util/blockTypes'
 
-import type { MousePositionWithFeature } from '../../util'
 import type { LinearApolloDisplay } from '../stateModel'
-import type { LinearApolloDisplayMouseEvents } from '../stateModel/mouseEvents'
-import type { CanvasMouseEvent } from '../types'
+
+interface LayoutFeature {
+  feature: AnnotationFeature
+  rowInFeature: number
+}
+export type LayoutRow = LayoutFeature[]
+
+export interface Layout {
+  byFeature: Map<string, number>
+  byRow: LayoutRow[]
+  min: number
+  max: number
+}
 
 export interface Glyph {
   /** draw the feature's primary rendering on the canvas */
@@ -14,6 +24,7 @@ export interface Glyph {
     ctx: CanvasRenderingContext2D,
     feature: AnnotationFeature,
     row: number,
+    rowInFeature: number,
     block: ContentBlock,
   ): void
   /** draw the feature's hover highlight on the overlay canvas */
@@ -33,60 +44,12 @@ export interface Glyph {
     block: ContentBlock,
   ): void
 
-  /** @returns number of layout rows used by this glyph with this feature and zoom level */
-  getRowCount(display: LinearApolloDisplay, feature: AnnotationFeature): number
-  /**
-   * @returns the features at the given bp and row number in this glyph's
-   * layout, starting with the one that is considered "on top"
-   */
-  getFeaturesFromLayout(
-    display: LinearApolloDisplay,
-    feature: AnnotationFeature,
-    bp: number,
-    row: number,
-  ): AnnotationFeature[]
-  /**
-   * @returns the row in this glyph where a child feature appears, or undefined
-   * if the feature does not appear
-   */
-  getRowForFeature(
-    display: LinearApolloDisplay,
-    feature: AnnotationFeature,
-    childFeature: AnnotationFeature,
-  ): number | undefined
-
-  getContextMenuItemsForFeature(
-    display: LinearApolloDisplayMouseEvents,
-    sourceFeature: AnnotationFeature,
-  ): MenuItem[]
+  getLayout(display: LinearApolloDisplay, feature: AnnotationFeature): Layout
 
   getContextMenuItems(
-    display: LinearApolloDisplayMouseEvents,
-    currentMousePosition: MousePositionWithFeature,
+    display: LinearApolloDisplay,
+    feature: AnnotationFeature,
   ): MenuItem[]
 
-  /** take any actions needed when the canvas's onMouseDown event fires */
-  onMouseDown(
-    display: LinearApolloDisplay,
-    mousePosition: MousePositionWithFeature,
-    event: CanvasMouseEvent,
-  ): void
-  /** take any actions needed when the canvas's onMouseMove event fires */
-  onMouseMove(
-    display: LinearApolloDisplay,
-    mousePosition: MousePositionWithFeature,
-    event: CanvasMouseEvent,
-  ): void
-  /** take any actions needed when the canvas's onMouseLeave event fires */
-  onMouseLeave(
-    display: LinearApolloDisplay,
-    mousePosition: MousePositionWithFeature,
-    event: CanvasMouseEvent,
-  ): void
-  /** take any actions needed when the canvas's onMouseUp event fires */
-  onMouseUp(
-    display: LinearApolloDisplay,
-    mousePosition: MousePositionWithFeature,
-    event: CanvasMouseEvent,
-  ): void
+  isDraggable: boolean
 }

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
@@ -27,7 +27,10 @@ export interface Glyph {
   /** draw a preview of the result of a dragging action on the overlay canvas */
   drawDragPreview(
     display: LinearApolloDisplay,
-    ctx: CanvasRenderingContext2D,
+    overlayCtx: CanvasRenderingContext2D,
+    feature: AnnotationFeature,
+    row: number,
+    block: ContentBlock,
   ): void
 
   /** @returns number of layout rows used by this glyph with this feature and zoom level */

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/Glyph.ts
@@ -2,7 +2,6 @@ import type { AnnotationFeature } from '@apollo-annotation/mst'
 import type { MenuItem } from '@jbrowse/core/ui'
 import type { ContentBlock } from '@jbrowse/core/util/blockTypes'
 
-import type { OntologyRecord } from '../../OntologyManager'
 import type { MousePositionWithFeature } from '../../util'
 import type { LinearApolloDisplay } from '../stateModel'
 import type { LinearApolloDisplayMouseEvents } from '../stateModel/mouseEvents'
@@ -17,18 +16,6 @@ export interface Glyph {
     row: number,
     block: ContentBlock,
   ): void
-  /** @returns the feature or subfeature at the given bp and row number in this glyph's layout */
-  getFeatureFromLayout(
-    feature: AnnotationFeature,
-    bp: number,
-    row: number,
-    featureTypeOntology: OntologyRecord,
-  ): AnnotationFeature | undefined
-  getRowForFeature(
-    feature: AnnotationFeature,
-    childFeature: AnnotationFeature,
-    featureTypeOntology: OntologyRecord,
-  ): number | undefined
 
   drawHover(
     display: LinearApolloDisplayMouseEvents,
@@ -42,6 +29,25 @@ export interface Glyph {
 
   /** @returns number of layout rows used by this glyph with this feature and zoom level */
   getRowCount(display: LinearApolloDisplay, feature: AnnotationFeature): number
+  /**
+   * @returns the feature or subfeature at the given bp and row number in this
+   * glyph's layout, or undefined if one does not exist
+   */
+  getFeatureFromLayout(
+    display: LinearApolloDisplay,
+    feature: AnnotationFeature,
+    bp: number,
+    row: number,
+  ): AnnotationFeature | undefined
+  /**
+   * @returns the row in this glyph where a child feature appears, or undefined
+   * if the feature does not appear
+   */
+  getRowForFeature(
+    display: LinearApolloDisplay,
+    feature: AnnotationFeature,
+    childFeature: AnnotationFeature,
+  ): number | undefined
 
   onMouseDown(
     display: LinearApolloDisplayMouseEvents,

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/TranscriptGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/TranscriptGlyph.ts
@@ -2,15 +2,18 @@ import type { AnnotationFeature } from '@apollo-annotation/mst'
 import type { MenuItem } from '@jbrowse/core/ui'
 import type { ContentBlock } from '@jbrowse/core/util/blockTypes'
 
-import { type MousePositionWithFeature } from '../../util'
-import { isCDSFeature, isExonFeature } from '../../util/glyphUtils'
+import type { MousePositionWithFeature } from '../../util'
+import {
+  isCDSFeature,
+  isExonFeature,
+  isSelectedFeature,
+} from '../../util/glyphUtils'
 import type { LinearApolloDisplay } from '../stateModel'
-
 
 import { cdsGlyph } from './CDSGlyph'
 import { exonGlyph } from './ExonGlyph'
 import type { Glyph } from './Glyph'
-import { getLeftPx } from './util'
+import { drawHighlight, getFeatureBox, getLeftPx } from './util'
 
 function* range(start: number, stop: number, step = 1): Generator<number> {
   if (start === stop) {
@@ -175,6 +178,25 @@ function draw(
       glyph.draw(display, ctx, feature, row + rowInFeature, block)
     }
   }
+  const { apolloRowHeight, selectedFeature } = display
+  if (isSelectedFeature(transcript, selectedFeature)) {
+    const [top, left, width] = getFeatureBox(display, transcript, row, block)
+    const height = apolloRowHeight * getRowCount(display, transcript)
+    drawHighlight(display, ctx, left, top, width, height, true)
+  }
+}
+
+function drawHover(
+  display: LinearApolloDisplay,
+  overlayCtx: CanvasRenderingContext2D,
+  transcript: AnnotationFeature,
+  row: number,
+  block: ContentBlock,
+) {
+  const { apolloRowHeight } = display
+  const [top, left, width] = getFeatureBox(display, transcript, row, block)
+  const height = apolloRowHeight * getRowCount(display, transcript)
+  drawHighlight(display, overlayCtx, left, top, width, height)
 }
 
 function getRowCount(display: LinearApolloDisplay, feature: AnnotationFeature) {
@@ -243,12 +265,6 @@ function getRowForFeature(
   }
   return
 }
-
-function drawHover() {
-  // Not implemented
-}
-// display: LinearApolloDisplayMouseEvents,
-// overlayCtx: CanvasRenderingContext2D,
 
 function drawDragPreview() {
   // Not implemented

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/TranscriptGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/TranscriptGlyph.ts
@@ -302,14 +302,13 @@ function onMouseMove(
 
 // False positive here, none of these functions use "this"
 /* eslint-disable @typescript-eslint/unbound-method */
-const { drawTooltip, onMouseLeave, onMouseUp } = boxGlyph
+const { onMouseLeave, onMouseUp } = boxGlyph
 /* eslint-enable @typescript-eslint/unbound-method */
 
 export const transcriptGlyph: Glyph = {
   draw,
   drawDragPreview,
   drawHover,
-  drawTooltip,
   getContextMenuItems,
   getContextMenuItemsForFeature,
   getFeatureFromLayout,

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/TranscriptGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/TranscriptGlyph.ts
@@ -200,12 +200,6 @@ function drawHover(
   drawHighlight(display, overlayCtx, left, top, width, height)
 }
 
-function drawDragPreview() {
-  // Not implemented
-}
-// display: LinearApolloDisplayMouseEvents,
-// ctx: CanvasRenderingContext2D,
-
 function getRowCount(display: LinearApolloDisplay, feature: AnnotationFeature) {
   const rows = getLayoutRows(display, feature)
   if (rows.length === 0) {
@@ -302,7 +296,7 @@ function onMouseMove(
 
 // False positive here, none of these functions use "this"
 /* eslint-disable @typescript-eslint/unbound-method */
-const { onMouseLeave, onMouseUp } = boxGlyph
+const { drawDragPreview, onMouseLeave, onMouseUp } = boxGlyph
 /* eslint-enable @typescript-eslint/unbound-method */
 
 export const transcriptGlyph: Glyph = {

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/TranscriptGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/TranscriptGlyph.ts
@@ -10,6 +10,7 @@ import {
 } from '../../util/glyphUtils'
 import type { LinearApolloDisplay } from '../stateModel'
 
+import { boxGlyph } from './BoxGlyph'
 import { cdsGlyph } from './CDSGlyph'
 import { exonGlyph } from './ExonGlyph'
 import type { Glyph } from './Glyph'
@@ -199,6 +200,12 @@ function drawHover(
   drawHighlight(display, overlayCtx, left, top, width, height)
 }
 
+function drawDragPreview() {
+  // Not implemented
+}
+// display: LinearApolloDisplayMouseEvents,
+// ctx: CanvasRenderingContext2D,
+
 function getRowCount(display: LinearApolloDisplay, feature: AnnotationFeature) {
   const rows = getLayoutRows(display, feature)
   if (rows.length === 0) {
@@ -266,12 +273,6 @@ function getRowForFeature(
   return
 }
 
-function drawDragPreview() {
-  // Not implemented
-}
-// display: LinearApolloDisplayMouseEvents,
-// ctx: CanvasRenderingContext2D,
-
 function onMouseDown() {
   // Not implemented
 }
@@ -301,12 +302,6 @@ function onMouseUp() {
 // currentMousePosition: MousePositionWithFeature,
 // event: CanvasMouseEvent,
 
-function drawTooltip() {
-  // Not implemented
-}
-// display: LinearApolloDisplayMouseEvents,
-// context: CanvasRenderingContext2D,
-
 function getContextMenuItemsForFeature(): MenuItem[] {
   return []
   // Not implemented
@@ -320,6 +315,11 @@ function getContextMenuItems(): MenuItem[] {
 }
 // display: LinearApolloDisplayMouseEvents,
 // currentMousePosition: MousePositionWithFeature,
+
+// False positive here, none of these functions use "this"
+/* eslint-disable @typescript-eslint/unbound-method */
+const { drawTooltip } = boxGlyph
+/* eslint-enable @typescript-eslint/unbound-method */
 
 export const transcriptGlyph: Glyph = {
   draw,

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/TranscriptGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/TranscriptGlyph.ts
@@ -273,35 +273,6 @@ function getRowForFeature(
   return
 }
 
-function onMouseDown() {
-  // Not implemented
-}
-// display: LinearApolloDisplayMouseEvents,
-// currentMousePosition: MousePositionWithFeature,
-// event: CanvasMouseEvent,
-
-function onMouseMove(
-  display: LinearApolloDisplay,
-  mousePosition: MousePositionWithFeature,
-) {
-  const { feature, bp } = mousePosition
-  display.setHoveredFeature({ feature, bp })
-}
-
-function onMouseLeave() {
-  // Not implemented
-}
-// display: LinearApolloDisplayMouseEvents,
-// currentMousePosition: MousePositionWithFeature,
-// event: CanvasMouseEvent,
-
-function onMouseUp() {
-  // Not implemented
-}
-// display: LinearApolloDisplayMouseEvents,
-// currentMousePosition: MousePositionWithFeature,
-// event: CanvasMouseEvent,
-
 function getContextMenuItemsForFeature(): MenuItem[] {
   return []
   // Not implemented
@@ -316,9 +287,22 @@ function getContextMenuItems(): MenuItem[] {
 // display: LinearApolloDisplayMouseEvents,
 // currentMousePosition: MousePositionWithFeature,
 
+// Genes are not draggable, only the underlying exons and CDS are
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+function onMouseDown() {}
+
+function onMouseMove(
+  stateModel: LinearApolloDisplay,
+  mousePosition: MousePositionWithFeature,
+) {
+  const { feature, bp } = mousePosition
+  stateModel.setHoveredFeature({ feature, bp })
+  stateModel.setCursor()
+}
+
 // False positive here, none of these functions use "this"
 /* eslint-disable @typescript-eslint/unbound-method */
-const { drawTooltip } = boxGlyph
+const { drawTooltip, onMouseLeave, onMouseUp } = boxGlyph
 /* eslint-enable @typescript-eslint/unbound-method */
 
 export const transcriptGlyph: Glyph = {

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/TranscriptGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/TranscriptGlyph.ts
@@ -52,8 +52,12 @@ function drawTranscriptLine(
   // If view is reversed, draw forward as reverse and vice versa
   const effectiveStrand = strand * (reversed ? -1 : 1)
   // Draw the transcript line, and extend it out a bit on the 3` end
-  const lineStart = left - (effectiveStrand === -1 ? 5 : 0)
-  const lineEnd = left + width + (effectiveStrand === -1 ? 0 : 5)
+  let lineStart = left - (effectiveStrand === -1 ? 5 : 0)
+  let lineEnd = left + width + (effectiveStrand === -1 ? 0 : 5)
+  // Limit the transcript line to the width of the screen to avoid drawing
+  // too many arrows
+  lineStart = Math.max(lineStart, 0)
+  lineEnd = Math.min(lineEnd, globalThis.innerWidth)
   ctx.moveTo(lineStart, top)
   ctx.lineTo(lineEnd, top)
   // Now to draw arrows every 20 pixels along the line

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/index.ts
@@ -1,4 +1,0 @@
-export * from './BoxGlyph'
-export * from './GeneGlyph'
-export * from './GenericChildGlyph'
-export * from './TranscriptGlyph'

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/util.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/util.ts
@@ -1,5 +1,6 @@
 import type { ContentBlock } from '@jbrowse/core/util/blockTypes'
 
+import type { MousePositionWithFeature } from '../../util'
 import type { LinearApolloDisplay } from '../stateModel'
 
 export function getLeftPx(
@@ -64,4 +65,31 @@ export function strokeRectInner(
   ctx.strokeStyle = color
   ctx.lineWidth = 1
   ctx.strokeRect(left + 0.5, top + 0.5, width - 1, height - 1)
+}
+
+/** @returns undefined if mouse not on the edge of this feature, otherwise 'start' or 'end' depending on which edge */
+export function isMouseOnFeatureEdge(
+  mousePosition: MousePositionWithFeature,
+  feature: { min: number; max: number },
+  stateModel: LinearApolloDisplay,
+) {
+  const { refName, regionNumber, x } = mousePosition
+  const { lgv } = stateModel
+  const { offsetPx } = lgv
+  const minPxInfo = lgv.bpToPx({ refName, coord: feature.min, regionNumber })
+  const maxPxInfo = lgv.bpToPx({ refName, coord: feature.max, regionNumber })
+  if (minPxInfo !== undefined && maxPxInfo !== undefined) {
+    const minPx = minPxInfo.offsetPx - offsetPx
+    const maxPx = maxPxInfo.offsetPx - offsetPx
+    if (Math.abs(maxPx - minPx) < 8) {
+      return
+    }
+    if (Math.abs(minPx - x) < 4) {
+      return 'min'
+    }
+    if (Math.abs(maxPx - x) < 4) {
+      return 'max'
+    }
+  }
+  return
 }

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/util.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/util.ts
@@ -18,6 +18,37 @@ export function getLeftPx(
   return blockLeftPx + featureLeftPxDistanceFromBlockLeftPx
 }
 
+export function getFeatureBox(
+  display: LinearApolloDisplay,
+  feature: { max: number; min: number },
+  row: number,
+  block: ContentBlock,
+): [number, number, number, number] {
+  const { apolloRowHeight, lgv } = display
+  const { bpPerPx } = lgv
+  const left = Math.round(getLeftPx(display, feature, block))
+  const top = row * apolloRowHeight
+  const width = Math.round((feature.max - feature.min) / bpPerPx)
+  const height = apolloRowHeight
+  return [top, left, width, height]
+}
+
+export function drawHighlight(
+  display: LinearApolloDisplay,
+  ctx: CanvasRenderingContext2D,
+  left: number,
+  top: number,
+  width: number,
+  height: number,
+  selected = false,
+) {
+  const { theme } = display
+  ctx.fillStyle = selected
+    ? theme.palette.action.disabled
+    : theme.palette.action.focus
+  ctx.fillRect(left, top, width, height)
+}
+
 /**
  * Perform a canvas strokeRect, but have the stroke be contained within the
  * given rect instead of centered on it.

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/util.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/util.ts
@@ -1,7 +1,8 @@
 import type { ContentBlock } from '@jbrowse/core/util/blockTypes'
 
-import type { MousePositionWithFeature } from '../../util'
+import type {} from '../../util'
 import type { LinearApolloDisplay } from '../stateModel'
+import type { MousePosition } from '../stateModel/mouseEvents'
 
 export function getLeftPx(
   display: LinearApolloDisplay,
@@ -69,7 +70,7 @@ export function strokeRectInner(
 
 /** @returns undefined if mouse not on the edge of this feature, otherwise 'start' or 'end' depending on which edge */
 export function isMouseOnFeatureEdge(
-  mousePosition: MousePositionWithFeature,
+  mousePosition: MousePosition,
   feature: { min: number; max: number },
   stateModel: LinearApolloDisplay,
 ) {

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/layouts.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/layouts.ts
@@ -19,42 +19,10 @@ import { cdsGlyph } from '../glyphs/CDSGlyph'
 import { exonGlyph } from '../glyphs/ExonGlyph'
 import { geneGlyph } from '../glyphs/GeneGlyph'
 import { genericChildGlyph } from '../glyphs/GenericChildGlyph'
+import type { Layout } from '../glyphs/Glyph'
 import { transcriptGlyph } from '../glyphs/TranscriptGlyph'
 
 import { baseModelFactory } from './base'
-
-function getRowsForFeature(
-  startingRow: number,
-  rowCount: number,
-  filledRowLocations: Map<number, [number, number][]>,
-) {
-  const rowsForFeature = []
-  for (let i = startingRow; i < startingRow + rowCount; i++) {
-    const row = filledRowLocations.get(i)
-    if (row) {
-      rowsForFeature.push(row)
-    }
-  }
-  return rowsForFeature
-}
-
-function canPlaceFeatureInRows(
-  rowsForFeature: [number, number][][],
-  feature: AnnotationFeature,
-) {
-  for (const rowForFeature of rowsForFeature) {
-    for (const [rowStart, rowEnd] of rowForFeature) {
-      if (
-        doesIntersect2(feature.min, feature.max, rowStart, rowEnd) ||
-        doesIntersect2(rowStart, rowEnd, feature.min, feature.max)
-      ) {
-        return false
-      }
-    }
-  }
-
-  return true
-}
 
 export function layoutsModelFactory(
   pluginManager: PluginManager,
@@ -101,122 +69,198 @@ export function layoutsModelFactory(
       },
     }))
     .views((self) => ({
-      get featureLayouts() {
+      getCanonicalRefName(assemblyName: string, refSeq: string) {
         const { assemblyManager } =
           self.session as unknown as AbstractSessionModel
-        return self.lgv.displayedRegions.map((region) => {
-          const assembly = assemblyManager.get(region.assemblyName)
-          const featureLayout = new Map<number, [number, string][]>()
-          // Track the occupied coordinates in each row
-          const filledRowLocations = new Map<number, [number, number][]>()
-          const { end, refName, start } = region
-          for (const [id, feature] of self.seenFeatures.entries()) {
-            if (!isAlive(feature)) {
-              self.deleteSeenFeature(id)
-              continue
-            }
-            if (
-              refName !== assembly?.getCanonicalRefName(feature.refSeq) ||
-              !doesIntersect2(start, end, feature.min, feature.max) ||
-              (self.filteredFeatureTypes.length > 0 &&
-                !self.filteredFeatureTypes.includes(feature.type))
-            ) {
-              continue
-            }
-            const { featureTypeOntology } =
-              self.session.apolloDataStore.ontologyManager
-            if (!featureTypeOntology) {
-              throw new Error('featureTypeOntology is undefined')
-            }
-            const rowCount = self
-              .getGlyph(feature)
-              // @ts-expect-error ts doesn't understand mst extension
-              .getRowCount(self, feature)
-            let startingRow = 0
-            let placed = false
-            while (!placed) {
-              let rowsForFeature = getRowsForFeature(
-                startingRow,
-                rowCount,
-                filledRowLocations,
-              )
-              if (rowsForFeature.length < rowCount) {
-                for (let i = 0; i < rowCount - rowsForFeature.length; i++) {
-                  const newRowNumber = filledRowLocations.size
-                  filledRowLocations.set(newRowNumber, [])
-                  featureLayout.set(newRowNumber, [])
-                }
-                rowsForFeature = getRowsForFeature(
-                  startingRow,
-                  rowCount,
-                  filledRowLocations,
-                )
-              }
-              if (!canPlaceFeatureInRows(rowsForFeature, feature)) {
-                startingRow += 1
-                continue
-              }
-              for (
-                let rowNum = startingRow;
-                rowNum < startingRow + rowCount;
-                rowNum++
-              ) {
-                filledRowLocations.get(rowNum)?.push([feature.min, feature.max])
-                const layoutRow = featureLayout.get(rowNum)
-                layoutRow?.push([rowNum - startingRow, feature._id])
-              }
-              placed = true
-            }
-          }
-          return featureLayout
-        })
-      },
-      getFeatureLayoutPosition(feature: AnnotationFeature) {
-        const { featureLayouts } = this
-        for (const [idx, layout] of featureLayouts.entries()) {
-          for (const [layoutRowNum, layoutRow] of layout) {
-            for (const [featureRowNum, layoutFeatureId] of layoutRow) {
-              if (featureRowNum !== 0) {
-                // Same top-level feature in all feature rows, so only need to
-                // check the first one
-                continue
-              }
-              const layoutFeature =
-                self.getAnnotationFeatureById(layoutFeatureId)
-              if (!layoutFeature) {
-                continue
-              }
-              if (feature._id === layoutFeature._id) {
-                return {
-                  layoutIndex: idx,
-                  layoutRow: layoutRowNum,
-                  featureRow: featureRowNum,
-                }
-              }
-              if (layoutFeature.hasDescendant(feature._id)) {
-                const row = self
-                  .getGlyph(layoutFeature)
-                  // @ts-expect-error ts doesn't understand mst extension
-                  .getRowForFeature(self, layoutFeature, feature)
-                if (row !== undefined) {
-                  return {
-                    layoutIndex: idx,
-                    layoutRow: layoutRowNum,
-                    featureRow: row,
-                  }
-                }
-              }
-            }
-          }
+        const assembly = assemblyManager.get(assemblyName)
+        if (!assembly) {
+          throw new Error('no assembly in layout')
         }
-        return
+        const canonicalRefName = assembly.getCanonicalRefName(refSeq)
+        if (!canonicalRefName) {
+          throw new Error('no canonical refName in layout')
+        }
+        return canonicalRefName
       },
     }))
     .views((self) => ({
-      get highestRow() {
+      /**
+       * Is a feature in one of the currently displayed regions and also is not
+       * currently filtered out by the display.
+       */
+      isFeatureDisplayed(feature: AnnotationFeature) {
+        const canonicalRefName = self.getCanonicalRefName(
+          feature.assemblyId,
+          feature.refSeq,
+        )
+        return self.lgv.displayedRegions.some((region) => {
+          const { end, refName, start } = region
+          const hasDisplayedFeatureTypes = self.filteredFeatureTypes.length > 0
+          if (
+            (!hasDisplayedFeatureTypes ||
+              self.filteredFeatureTypes.includes(feature.type)) &&
+            canonicalRefName === refName &&
+            doesIntersect2(start, end, feature.min, feature.max)
+          ) {
+            return true
+          }
+          return false
+        })
+      },
+    }))
+    .views((self) => ({
+      get layouts(): Map<string, Map<string, Layout>> {
+        // Each refName in an assembly gets its own layout so that if a feature
+        // is drawn in multiple displayed regions, it has the same layout for
+        // each of them
+        const layoutByAssemblyAndRefName = new Map<
+          string,
+          Map<string, Layout>
+        >()
+        // Go through all the features we know about and add them to th
+        for (const [id, feature] of self.seenFeatures.entries()) {
+          if (!isAlive(feature)) {
+            self.deleteSeenFeature(id)
+            continue
+          }
+          const isDisplayed = self.isFeatureDisplayed(feature)
+          if (!isDisplayed) {
+            continue
+          }
+          // This contains layout information for all the feature's sub-features
+          // as well
+          const featureLayout = self
+            .getGlyph(feature)
+            // @ts-expect-error ts doesn't understand mst extension
+            .getLayout(self, feature)
+          const canonicalRefName = self.getCanonicalRefName(
+            feature.assemblyId,
+            feature.refSeq,
+          )
+          let layoutForAssembly = layoutByAssemblyAndRefName.get(
+            feature.assemblyId,
+          )
+          if (!layoutForAssembly) {
+            layoutForAssembly = new Map<string, Layout>()
+            layoutByAssemblyAndRefName.set(
+              feature.assemblyId,
+              layoutForAssembly,
+            )
+          }
+          const layout = layoutForAssembly.get(canonicalRefName)
+          if (!layout) {
+            // If this refSeq doesn't have a layout yet, use this feature's
+            // layout as a starting layout and move on to the next feature
+            layoutForAssembly.set(canonicalRefName, featureLayout)
+            continue
+          }
+          // Check this feature for collisions in the layout, and increase the
+          // starting row if needed until there are no collisions. Then place
+          // the feature in the layout.
+          let startingRowIndex = 0
+          placeFeature: while (true) {
+            let layoutRow = layout.byRow.at(startingRowIndex)
+            if (!layoutRow) {
+              // We've increased startingRowIndex to a row that doesn't exist in
+              // layout yet. Create new row(s), place the feature in them, and
+              // move on to the next feature
+              layout.byRow.push(...featureLayout.byRow)
+              for (const entry of featureLayout.byFeature.entries()) {
+                const [featureId, rowNumber] = entry
+                layout.byFeature.set(featureId, rowNumber + startingRowIndex)
+              }
+              layout.min = Math.min(layout.min, featureLayout.min)
+              layout.max = Math.max(layout.max, featureLayout.max)
+              break placeFeature
+            }
+            // Check this row for collisions. Also check higher rows for
+            // collisions if the feature layout takes up more than one row.
+            // If there is a collision, set the startingRowIndex to the next
+            // row.
+            const highestRow = startingRowIndex + featureLayout.byRow.length - 1
+            let currentRow = startingRowIndex
+            while (layoutRow && startingRowIndex <= highestRow) {
+              for (const layoutFeature of layoutRow.values()) {
+                if (
+                  doesIntersect2(
+                    featureLayout.min,
+                    featureLayout.max,
+                    layoutFeature.feature.min,
+                    layoutFeature.feature.max,
+                  )
+                ) {
+                  startingRowIndex += 1
+                  continue placeFeature
+                }
+              }
+              currentRow += 1
+              layoutRow = layout.byRow.at(currentRow)
+            }
+            // Now we have our startingRowIndex. Place feature in the layout,
+            // adding new rows if necessary.
+            for (let i = 0; i < featureLayout.byRow.length; i++) {
+              const layoutRow = layout.byRow.at(startingRowIndex + i)
+              if (layoutRow) {
+                layoutRow.push(...featureLayout.byRow[i])
+              } else {
+                layout.byRow.push(featureLayout.byRow[i])
+              }
+            }
+            for (const entry of featureLayout.byFeature.entries()) {
+              const [featureId, rowNumber] = entry
+              layout.byFeature.set(featureId, rowNumber + startingRowIndex)
+            }
+            layout.min = Math.min(layout.min, featureLayout.min)
+            layout.max = Math.max(layout.max, featureLayout.max)
+            break placeFeature
+          }
+        }
+        return layoutByAssemblyAndRefName
+      },
+      getRowForFeature(feature: AnnotationFeature) {
+        const canonicalRefName = self.getCanonicalRefName(
+          feature.assemblyId,
+          feature.refSeq,
+        )
+        return this.layouts
+          .get(feature.assemblyId)
+          ?.get(canonicalRefName)
+          ?.byFeature.get(feature._id)
+      },
+      getFeaturesAtPosition(
+        assemblyName: string,
+        refName: string,
+        row: number,
+        bp: number,
+      ): AnnotationFeature[] {
+        const assemblyLayouts = this.layouts.get(assemblyName)
+        if (!assemblyLayouts) {
+          return []
+        }
+        const layout = assemblyLayouts.get(refName)
+        if (!layout) {
+          return []
+        }
+        const layoutRow = layout.byRow.at(row)
+        if (!layoutRow) {
+          return []
+        }
+        return layoutRow
+          .filter(({ feature }) => {
+            return bp >= feature.min && bp <= feature.max
+          })
+          .map((row) => row.feature)
+      },
+    }))
+    .views((self) => ({
+      highestRow(assemblyName: string) {
+        const assemblyLayouts = self.layouts.get(assemblyName)
+        if (!assemblyLayouts) {
+          return 0
+        }
         return Math.max(
           0,
-          ...self.featureLayouts.map((layout) => Math.max(...layout.keys())),
+          ...[...assemblyLayouts.values()].map((layout) => layout.byRow.length),
         )
       },
     }))

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/layouts.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/layouts.ts
@@ -14,14 +14,12 @@ import {
   isGeneFeature,
   isTranscriptFeature,
 } from '../../util/glyphUtils'
-import {
-  boxGlyph,
-  geneGlyph,
-  genericChildGlyph,
-  transcriptGlyph,
-} from '../glyphs'
+import { boxGlyph } from '../glyphs/BoxGlyph'
 import { cdsGlyph } from '../glyphs/CDSGlyph'
 import { exonGlyph } from '../glyphs/ExonGlyph'
+import { geneGlyph } from '../glyphs/GeneGlyph'
+import { genericChildGlyph } from '../glyphs/GenericChildGlyph'
+import { transcriptGlyph } from '../glyphs/TranscriptGlyph'
 
 import { baseModelFactory } from './base'
 
@@ -76,20 +74,19 @@ export function layoutsModelFactory(
         return self.seenFeatures.get(id)
       },
       getGlyph(feature: AnnotationFeature) {
-        const { topLevelFeature } = feature
-        if (isGeneFeature(topLevelFeature, self.session)) {
+        if (isGeneFeature(feature, self.session)) {
           return geneGlyph
         }
-        if (isTranscriptFeature(topLevelFeature, self.session)) {
+        if (isTranscriptFeature(feature, self.session)) {
           return transcriptGlyph
         }
-        if (isExonFeature(topLevelFeature, self.session)) {
+        if (isExonFeature(feature, self.session)) {
           return exonGlyph
         }
-        if (isCDSFeature(topLevelFeature, self.session)) {
+        if (isCDSFeature(feature, self.session)) {
           return cdsGlyph
         }
-        if (topLevelFeature.children?.size) {
+        if (feature.children?.size) {
           return genericChildGlyph
         }
         return boxGlyph

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/mouseEvents.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/mouseEvents.ts
@@ -71,10 +71,11 @@ export function mouseEventsModelIntermediateFactory(
           throw new Error('featureTypeOntology is undefined')
         }
         const feature = glyph.getFeatureFromLayout(
+          // @ts-expect-error ts doesn't understand mst extension
+          self,
           topLevelFeature,
           bp,
           featureRow,
-          featureTypeOntology,
         )
         if (!feature) {
           return mousePosition

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/mouseEvents.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/mouseEvents.ts
@@ -6,6 +6,7 @@ import {
 import type PluginManager from '@jbrowse/core/PluginManager'
 import type { AnyConfigurationSchemaType } from '@jbrowse/core/configuration'
 import type { MenuItem } from '@jbrowse/core/ui'
+import { doesIntersect2 } from '@jbrowse/core/util'
 import { type Instance, addDisposer } from '@jbrowse/mobx-state-tree'
 import { autorun } from 'mobx'
 import type { CSSProperties } from 'react'
@@ -262,31 +263,28 @@ export function mouseEventsModelFactory(
           self,
           autorun(
             () => {
-              // This type is wrong in @jbrowse/core
-              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-              if (!self.lgv.initialized || self.regionCannotBeRendered()) {
+              const { lgv, overlayCanvas } = self
+              if (
+                !lgv.initialized ||
+                // This type is wrong in @jbrowse/core
+                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                self.regionCannotBeRendered() ||
+                !overlayCanvas
+              ) {
                 return
               }
-              const ctx = self.overlayCanvas?.getContext('2d')
+              const { dynamicBlocks, offsetPx } = lgv
+              const ctx = overlayCanvas.getContext('2d')
               if (!ctx) {
                 return
               }
-              ctx.clearRect(
-                0,
-                0,
-                self.lgv.dynamicBlocks.totalWidthPx,
-                self.featuresHeight,
-              )
-
+              ctx.clearRect(0, 0, overlayCanvas.width, overlayCanvas.height)
               const { apolloDragging, hoveredFeature } = self
               if (!hoveredFeature) {
                 return
               }
-              const glyph = self.getGlyph(hoveredFeature.feature)
-
-              // draw mouseover hovers
-              glyph.drawHover(self, ctx)
-
+              const { feature } = hoveredFeature
+              const glyph = self.getGlyph(feature)
               // draw tooltip on hover
               glyph.drawTooltip(self, ctx)
 
@@ -298,6 +296,41 @@ export function mouseEventsModelFactory(
                   apolloDragging.feature.topLevelFeature,
                 )
                 glyph.drawDragPreview(self, ctx)
+              }
+              const position = self.getFeatureLayoutPosition(feature)
+              if (!position) {
+                return
+              }
+              const { featureRow, layoutRow } = position
+
+              for (const block of dynamicBlocks.contentBlocks) {
+                if (
+                  !doesIntersect2(
+                    block.start,
+                    block.end,
+                    feature.min,
+                    feature.max,
+                  )
+                ) {
+                  continue
+                }
+                const blockLeftPx = block.offsetPx - offsetPx
+                ctx.save()
+                ctx.beginPath()
+                ctx.rect(blockLeftPx, 0, block.widthPx, overlayCanvas.height)
+                ctx.clip()
+
+                // draw mouseover hovers
+                glyph.drawHover(
+                  // @ts-expect-error ts doesn't understand mst extension
+                  self,
+                  ctx,
+                  feature,
+                  featureRow + layoutRow,
+                  block,
+                )
+
+                ctx.restore()
               }
             },
             { name: 'LinearApolloDisplayRenderMouseoverAndDrag' },

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/mouseEvents.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/mouseEvents.ts
@@ -286,6 +286,7 @@ export function mouseEventsModelFactory(
               const { feature } = hoveredFeature
               const glyph = self.getGlyph(feature)
               // draw tooltip on hover
+              // @ts-expect-error ts doesn't understand mst extension
               glyph.drawTooltip(self, ctx)
 
               // dragging previews
@@ -295,6 +296,7 @@ export function mouseEventsModelFactory(
                 const glyph = self.getGlyph(
                   apolloDragging.feature.topLevelFeature,
                 )
+                // @ts-expect-error ts doesn't understand mst extension
                 glyph.drawDragPreview(self, ctx)
               }
               const position = self.getFeatureLayoutPosition(feature)

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/mouseEvents.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/mouseEvents.ts
@@ -71,19 +71,20 @@ export function mouseEventsModelIntermediateFactory(
         if (!featureTypeOntology) {
           throw new Error('featureTypeOntology is undefined')
         }
-        const feature = glyph.getFeatureFromLayout(
+        const features = glyph.getFeaturesFromLayout(
           // @ts-expect-error ts doesn't understand mst extension
           self,
           topLevelFeature,
           bp,
           featureRow,
         )
-        if (!feature) {
+        const topFeature = features.at(0)
+        if (!topFeature) {
           return mousePosition
         }
         return {
           ...mousePosition,
-          feature,
+          feature: topFeature,
         }
       },
     }))

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/mouseEvents.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/mouseEvents.ts
@@ -298,9 +298,6 @@ export function mouseEventsModelFactory(
               }
               const { feature } = hoveredFeature
               const glyph = self.getGlyph(feature)
-              // draw tooltip on hover
-              // @ts-expect-error ts doesn't understand mst extension
-              glyph.drawTooltip(self, ctx)
 
               // dragging previews
               if (apolloDragging) {

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/mouseEvents.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/mouseEvents.ts
@@ -236,7 +236,7 @@ export function mouseEventsModelFactory(
             const edge = isMouseOnFeatureEdge(mousePosition, feature, self)
             if (edge) {
               event.stopPropagation()
-              self.startDrag(mousePosition, feature, edge)
+              self.startDrag(mousePosition, feature, edge, true)
               return
             }
           }
@@ -260,6 +260,8 @@ export function mouseEventsModelFactory(
         }
         if (topFeature) {
           self.setHoveredFeature({ feature: topFeature, bp: mousePosition.bp })
+        } else {
+          self.setHoveredFeature()
         }
         for (const feature of features.toReversed()) {
           const glyph = self.getGlyph(feature)

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/mouseEvents.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/mouseEvents.ts
@@ -276,7 +276,7 @@ export function mouseEventsModelFactory(
         }
         self.setCursor()
       },
-      onMouseLeave() {
+      onMouseLeave(_event: CanvasMouseEvent) {
         self.setDragging()
         self.setHoveredFeature()
       },

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/rendering.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/rendering.ts
@@ -24,7 +24,6 @@ export function renderingModelFactory(
       apolloRowHeight: 20,
       detailsMinHeight: 200,
       detailsHeight: 200,
-      lastRowTooltipBufferHeight: 40,
       isShown: true,
       filteredTranscripts: types.array(types.string),
     })
@@ -36,10 +35,7 @@ export function renderingModelFactory(
     }))
     .views((self) => ({
       get featuresHeight() {
-        return (
-          (self.highestRow + 1) * self.apolloRowHeight +
-          self.lastRowTooltipBufferHeight
-        )
+        return (self.highestRow + 1) * self.apolloRowHeight
       },
       get canvasPatterns(): Record<
         'forward' | 'backward',

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/rendering.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/rendering.ts
@@ -34,8 +34,8 @@ export function renderingModelFactory(
       theme: createTheme(),
     }))
     .views((self) => ({
-      get featuresHeight() {
-        return (self.highestRow + 1) * self.apolloRowHeight
+      featuresHeight(assemblyName: string) {
+        return (self.highestRow(assemblyName) + 1) * self.apolloRowHeight
       },
       get canvasPatterns(): Record<
         'forward' | 'backward',
@@ -123,7 +123,7 @@ export function renderingModelFactory(
                 0,
                 0,
                 self.lgv.dynamicBlocks.totalWidthPx,
-                self.featuresHeight,
+                self.featuresHeight(self.lgv.assemblyNames[0]),
               )
               for (const collaborator of (
                 self.session as unknown as ApolloSessionModel
@@ -171,7 +171,7 @@ export function renderingModelFactory(
           self,
           autorun(
             () => {
-              const { canvas, featureLayouts, lgv } = self
+              const { canvas, layouts, lgv } = self
               if (
                 !lgv.initialized ||
                 self.regionCannotBeRendered() ||
@@ -185,19 +185,25 @@ export function renderingModelFactory(
               if (!ctx) {
                 return
               }
+              const featureLayouts = layouts.get(lgv.assemblyNames[0])
+              if (!featureLayouts) {
+                return
+              }
               ctx.clearRect(0, 0, canvas.width, canvas.height)
-              for (const [idx, featureLayout] of featureLayouts.entries()) {
-                const block = dynamicBlocks.contentBlocks.at(idx)
-                if (!block) {
-                  continue
-                }
+              for (const block of dynamicBlocks.contentBlocks) {
                 const blockLeftPx = block.offsetPx - offsetPx
-                for (const [row, featureLayoutRow] of featureLayout.entries()) {
-                  for (const [featureRow, featureId] of featureLayoutRow) {
-                    const feature = self.getAnnotationFeatureById(featureId)
-                    if (featureRow > 0 || !feature) {
-                      continue
-                    }
+                ctx.save()
+                ctx.beginPath()
+                ctx.rect(blockLeftPx, 0, block.widthPx, canvas.height)
+                ctx.clip()
+                const layout = featureLayouts.get(block.refName)
+                if (!layout) {
+                  return
+                }
+                const { byRow } = layout
+                for (const [row, layoutRow] of byRow.entries()) {
+                  for (const layoutFeature of layoutRow) {
+                    const { feature, rowInFeature } = layoutFeature
                     if (
                       !doesIntersect2(
                         block.start,
@@ -208,15 +214,13 @@ export function renderingModelFactory(
                     ) {
                       continue
                     }
-                    ctx.save()
-                    ctx.beginPath()
-                    ctx.rect(blockLeftPx, 0, block.widthPx, canvas.height)
-                    ctx.clip()
-                    // @ts-expect-error ts doesn't understand mst extension
-                    self.getGlyph(feature).draw(self, ctx, feature, row, block)
-                    ctx.restore()
+                    self
+                      .getGlyph(feature)
+                      // @ts-expect-error ts doesn't understand mst extension
+                      .draw(self, ctx, feature, row, rowInFeature, block)
                   }
                 }
+                ctx.restore()
               }
             },
             { name: 'LinearApolloDisplayRenderFeatures' },

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloReferenceSequenceDisplay/drawSequenceOverlay.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloReferenceSequenceDisplay/drawSequenceOverlay.ts
@@ -78,7 +78,7 @@ function drawHighlight(
   selected = false,
 ) {
   const row = getSeqRow(feature.strand, bpPerPx, block.reversed)
-  if (!row) {
+  if (row === undefined) {
     return
   }
   const left = getLeftPx(feature, bpPerPx, offsetPx, block)

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/components/LinearApolloSixFrameDisplay.tsx
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/components/LinearApolloSixFrameDisplay.tsx
@@ -207,7 +207,7 @@ export const LinearApolloSixFrameDisplay = observer(
                           ? [0, 5, 3, 1, 15, 13, 11]
                           : [0, 2, 1, 0, 8, 7, 6]
                         const rowNum = frameOffsets.at(frame)
-                        if (!rowNum) {
+                        if (rowNum === undefined) {
                           continue
                         }
                         if (

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/glyphs/GeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/glyphs/GeneGlyph.ts
@@ -886,12 +886,7 @@ function getContextMenuItems(
         feature,
       )
       if (isExonFeature(feature, session)) {
-        const adjacentExons = getAdjacentExons(
-          feature,
-          display,
-          mousePosition,
-          session,
-        )
+        const adjacentExons = getAdjacentExons(feature, display)
         const lgv = getContainingView(
           display as BaseDisplayModel,
         ) as unknown as LinearGenomeViewModel

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/glyphs/GeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/glyphs/GeneGlyph.ts
@@ -330,7 +330,7 @@ function draw(
       let prevCDSTop = 0
       let prevCDSEndPx = 0
       let counter = 1
-      for (const cds of cdsRow.sort((a, b) => a.max - b.max)) {
+      for (const cds of cdsRow.toSorted((a, b) => a.max - b.max)) {
         if (
           (selectedFeature &&
             isSelected &&
@@ -520,7 +520,7 @@ function drawHover(
     let prevCDSTop = 0
     let prevCDSEndPx = 0
     let counter = 1
-    for (const cds of cdsRow.sort((a, b) => a.max - b.max)) {
+    for (const cds of cdsRow.toSorted((a, b) => a.max - b.max)) {
       const cdsWidthPx = (cds.max - cds.min) / bpPerPx
       const minX =
         (lgv.bpToPx({

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/stateModel/layouts.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/stateModel/layouts.ts
@@ -170,7 +170,7 @@ export function layoutsModelFactory(
                         ? [0, 5, 3, 1, 15, 13, 11]
                         : [0, 2, 1, 0, 8, 7, 6]
                       const rowNum = frameOffsets.at(frame)
-                      if (!rowNum) {
+                      if (rowNum === undefined) {
                         continue
                       }
                       if (!featureLayout.get(rowNum)) {

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/stateModel/layouts.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/stateModel/layouts.ts
@@ -13,7 +13,7 @@ import { autorun, observable } from 'mobx'
 
 import type { ApolloSessionModel } from '../../session'
 import { looksLikeGene } from '../../util/glyphUtils'
-import { geneGlyph } from '../glyphs'
+import { geneGlyph } from '../glyphs/GeneGlyph'
 
 import { baseModelFactory } from './base'
 

--- a/packages/jbrowse-plugin-apollo/src/makeDisplayComponent.tsx
+++ b/packages/jbrowse-plugin-apollo/src/makeDisplayComponent.tsx
@@ -65,9 +65,16 @@ function scrollSelectedFeatureIntoView(
 ) {
   const { apolloRowHeight, selectedFeature } = model
   if (scrollContainerRef.current && selectedFeature) {
-    const position = model.getFeatureLayoutPosition(selectedFeature)
-    if (position) {
-      const row = position.layoutRow + position.featureRow
+    let row: number | undefined
+    if ('getFeatureLayoutPosition' in model) {
+      const position = model.getFeatureLayoutPosition(selectedFeature)
+      if (position) {
+        row = position.layoutRow + position.featureRow
+      }
+    } else {
+      row = model.getRowForFeature(selectedFeature)
+    }
+    if (row !== undefined) {
       const top = row * apolloRowHeight
       scrollContainerRef.current.scroll({ top, behavior: 'smooth' })
     }

--- a/packages/jbrowse-plugin-apollo/src/util/glyphUtils.ts
+++ b/packages/jbrowse-plugin-apollo/src/util/glyphUtils.ts
@@ -3,11 +3,9 @@ import type {
   Children,
   TranscriptPartCoding,
 } from '@apollo-annotation/mst'
-import type { BaseDisplayModel } from '@jbrowse/core/pluggableElementTypes'
 import type { MenuItem } from '@jbrowse/core/ui'
 import {
   type AbstractSessionModel,
-  getContainingView,
   isSessionModelWithWidgets,
 } from '@jbrowse/core/util'
 import type { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
@@ -20,8 +18,6 @@ import { AddChildFeature } from '../components/AddChildFeature'
 import { CopyFeature } from '../components/CopyFeature'
 import { DeleteFeature } from '../components/DeleteFeature'
 import type { ApolloSessionModel } from '../session'
-
-import type { MousePositionWithFeature } from '.'
 
 type NavLocation = Parameters<LinearGenomeViewModel['navTo']>[0]
 
@@ -156,16 +152,8 @@ export function getAdjacentExons(
   display:
     | LinearApolloDisplayMouseEvents
     | LinearApolloSixFrameDisplayMouseEvents,
-  mousePosition: MousePositionWithFeature,
-  session: ApolloSessionModel,
 ): AdjacentExons {
-  const lgv = getContainingView(
-    display as BaseDisplayModel,
-  ) as unknown as LinearGenomeViewModel
-
   // Genomic coords of current view
-  const viewGenomicLeft = mousePosition.bp - lgv.bpPerPx * mousePosition.x
-  const viewGenomicRight = viewGenomicLeft + lgv.coarseTotalBp
   if (!currentExon.parent) {
     return { upstream: undefined, downstream: undefined }
   }
@@ -173,7 +161,8 @@ export function getAdjacentExons(
   if (!transcript.children) {
     throw new Error(`Error getting children of ${transcript._id}`)
   }
-  const { featureTypeOntology } = session.apolloDataStore.ontologyManager
+  const { featureTypeOntology } =
+    display.session.apolloDataStore.ontologyManager
   if (!featureTypeOntology) {
     throw new Error('featureTypeOntology is undefined')
   }
@@ -190,14 +179,14 @@ export function getAdjacentExons(
   }
   exons = exons.sort((a, b) => (a.min < b.min ? -1 : 1))
   for (const exon of exons) {
-    if (exon.min > viewGenomicRight) {
+    if (exon.min > currentExon.max) {
       adjacentExons.downstream = exon
       break
     }
   }
   exons = exons.sort((a, b) => (a.min > b.min ? -1 : 1))
   for (const exon of exons) {
-    if (exon.max < viewGenomicLeft) {
+    if (exon.max < currentExon.min) {
       adjacentExons.upstream = exon
       break
     }

--- a/packages/jbrowse-plugin-apollo/src/util/glyphUtils.ts
+++ b/packages/jbrowse-plugin-apollo/src/util/glyphUtils.ts
@@ -288,19 +288,6 @@ export function isSelectedFeature(
   return Boolean(selectedFeature && feature._id === selectedFeature._id)
 }
 
-export function containsSelectedFeature(
-  feature: AnnotationFeature,
-  selectedFeature: AnnotationFeature | undefined,
-): boolean {
-  if (!selectedFeature) {
-    return false
-  }
-  if (feature._id === selectedFeature._id) {
-    return true
-  }
-  return feature.hasDescendant(selectedFeature._id)
-}
-
 function makeFeatureLabel(feature: AnnotationFeature) {
   let name: string | undefined
   if (feature.attributes.get('gff_name')) {


### PR DESCRIPTION
Continues the work in #725 by distributing the layout logic that was entirely in GeneGlyph among GeneGlyph, TranscriptGlyph, ExonGlyph, and CDSGlyph.