### PR TITLE
Avoid sub-pixel rendering in sequence display

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/util.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/util.ts
@@ -17,3 +17,20 @@ export function getLeftPx(
     featureLeftBpDistanceFromBlockLeftBp / bpPerPx
   return blockLeftPx + featureLeftPxDistanceFromBlockLeftPx
 }
+
+/**
+ * Perform a canvas strokeRect, but have the stroke be contained within the
+ * given rect instead of centered on it.
+ */
+export function strokeRectInner(
+  ctx: CanvasRenderingContext2D,
+  left: number,
+  top: number,
+  width: number,
+  height: number,
+  color: string,
+) {
+  ctx.strokeStyle = color
+  ctx.lineWidth = 1
+  ctx.strokeRect(left + 0.5, top + 0.5, width - 1, height - 1)
+}


### PR DESCRIPTION
This makes sure all canvas drawing commands in the LinearApolloReferenceSequenceDisplay use integers instead of floating-point numbers. This can help performance (see this [tip on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Optimizing_canvas#avoid_floating-point_coordinates_and_use_integers_instead)), but the motivation was to get rid of some odd artifacts in the rendering. See for example the whitespace between bases of the same color and the irregularity in the border between the base sequence and translation rows in the "before" below.

Before:
<img width="209" height="141" alt="image" src="https://github.com/user-attachments/assets/de39eb5f-e353-4eda-849d-62ea6f19d01c" />

After:
<img width="221" height="142" alt="image" src="https://github.com/user-attachments/assets/924655c3-0796-4e4f-beb1-1adf56d4d29b" />
