### PR TITLE
Add "Open feature details" to feature context menu

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/GeneGlyph.ts
@@ -974,8 +974,8 @@ function getContextMenuItems(
           },
         })
         if (isSessionModelWithWidgets(session)) {
-          contextMenuItemsForFeature.push({
-            label: 'Open transcript details',
+          contextMenuItemsForFeature.splice(1, 0, {
+            label: 'Open transcript editor',
             onClick: () => {
               const apolloTranscriptWidget = session.addWidget(
                 'ApolloTranscriptDetails',

--- a/packages/jbrowse-plugin-apollo/src/util/glyphUtils.ts
+++ b/packages/jbrowse-plugin-apollo/src/util/glyphUtils.ts
@@ -7,6 +7,7 @@ import { type MenuItem } from '@jbrowse/core/ui'
 import {
   type AbstractSessionModel,
   getContainingView,
+  isSessionModelWithWidgets,
 } from '@jbrowse/core/util'
 import { type LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
 import SkipNextRoundedIcon from '@mui/icons-material/SkipNextRounded'
@@ -363,6 +364,23 @@ export function getContextMenuItemsForFeature(
       },
     },
   )
+  if (isSessionModelWithWidgets(session)) {
+    menuItems.push({
+      label: 'Open feature details',
+      onClick: () => {
+        const apolloGeneWidget = session.addWidget(
+          'ApolloFeatureDetailsWidget',
+          'apolloFeatureDetailsWidget',
+          {
+            feature: sourceFeature,
+            assembly: currentAssemblyId,
+            refName: region.refName,
+          },
+        )
+        session.showWidget(apolloGeneWidget)
+      },
+    })
+  }
   return menuItems
 }
 


### PR DESCRIPTION
Alternative to #743. This adds "Open feature details" to all feature right-click menus. This is especially useful for genes, where there may not be any place to click to access the gene that's not overlapped by another feature, but also applies to any feature in a gene glyph that might be covered. Is of more limited utility to non-gene glyphs, but probably good to add to those as well for consistency.

<img width="514" height="292" alt="image" src="https://github.com/user-attachments/assets/5324cd31-ecd5-410e-98b5-86dbfd70c892" />
