### PR TITLE
Make frame row order consistent in LinearApolloSixFrameDisplay

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/components/LinearApolloSixFrameDisplay.tsx
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/components/LinearApolloSixFrameDisplay.tsx
@@ -41,7 +41,6 @@ export const LinearApolloSixFrameDisplay = observer(
       contextMenuItems: getContextMenuItems,
       cursor,
       featuresHeight,
-      featureLabelSpacer,
       geneTrackRowNums,
       isShown,
       onMouseDown,
@@ -55,6 +54,7 @@ export const LinearApolloSixFrameDisplay = observer(
       setOverlayCanvas,
       setTheme,
       showCheckResults,
+      showFeatureLabels,
     } = model
     const { classes } = useStyles()
     const lgv = getContainingView(model) as unknown as LinearGenomeViewModel
@@ -188,15 +188,19 @@ export const LinearApolloSixFrameDisplay = observer(
                     let row
                     for (const loc of feature.cdsLocations) {
                       for (const cds of loc) {
-                        let rowNum: number = getFrame(
+                        const frame = getFrame(
                           cds.min,
                           cds.max,
                           feature.strand ?? 1,
                           cds.phase,
                         )
-                        rowNum = featureLabelSpacer(
-                          rowNum < 0 ? -1 * rowNum + 5 : rowNum,
-                        )
+                        const frameOffsets = showFeatureLabels
+                          ? [0, 5, 3, 1, 15, 13, 11]
+                          : [0, 2, 1, 0, 8, 7, 6]
+                        const rowNum = frameOffsets.at(frame)
+                        if (!rowNum) {
+                          continue
+                        }
                         if (
                           checkResult.start >= cds.min &&
                           checkResult.start <= cds.max

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/glyphs/GeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/glyphs/GeneGlyph.ts
@@ -347,9 +347,14 @@ function draw(
           cdsStartPx = reversed ? minX - cdsWidthPx : minX
           ctx.fillStyle = theme.palette.text.primary
           const frame = getFrame(cds.min, cds.max, child.strand ?? 1, cds.phase)
-          const frameAdjust =
-            (frame < 0 ? -1 * frame + 5 : frame) * featureLabelSpacer
-          cdsTop = (frameAdjust - featureLabelSpacer) * rowHeight
+          const frameOffsets = showFeatureLabels
+            ? [0, 4, 2, 0, 14, 12, 10]
+            : [0, 2, 1, 0, 7, 6, 5]
+          const row = frameOffsets.at(frame)
+          if (row === undefined) {
+            continue
+          }
+          cdsTop = row * rowHeight
           ctx.fillRect(cdsStartPx, cdsTop, cdsWidthPx, cdsHeight)
 
           // Draw lines to connect CDS features with shared mRNA parent
@@ -525,9 +530,14 @@ function drawHover(
         })?.offsetPx ?? 0) - offsetPx
       const cdsStartPx = reversed ? minX - cdsWidthPx : minX
       const frame = getFrame(cds.min, cds.max, strand ?? 1, cds.phase)
-      const frameAdjust =
-        (frame < 0 ? -1 * frame + 5 : frame) * featureLabelSpacer
-      const cdsTop = (frameAdjust - featureLabelSpacer) * rowHeight
+      const frameOffsets = showFeatureLabels
+        ? [0, 4, 2, 0, 14, 12, 10]
+        : [0, 2, 1, 0, 7, 6, 5]
+      const row = frameOffsets.at(frame)
+      if (row === undefined) {
+        continue
+      }
+      const cdsTop = row * rowHeight
       if (counter > 1) {
         // Mid-point for intron line "hat"
         const midPoint: [number, number] = [
@@ -759,8 +769,6 @@ function drawTooltip(
   const displayedRegion = displayedRegions[layoutIndex]
   const { refName, reversed } = displayedRegion
   const rowHeight = apolloRowHeight
-  const cdsHeight = Math.round(0.7 * rowHeight)
-  const featureLabelSpacer = showFeatureLabels ? 2 : 1
   let location = 'Loc: '
   let cds: TranscriptPartCoding | undefined = undefined
   for (const loc of feature.cdsLocations) {
@@ -784,9 +792,14 @@ function drawTooltip(
       regionNumber: layoutIndex,
     })?.offsetPx ?? 0) - offsetPx
   const frame = getFrame(min, max, strand ?? 1, phase)
-  const frameAdjust = (frame < 0 ? -1 * frame + 5 : frame) * featureLabelSpacer
-  const cdsTop =
-    (frameAdjust - featureLabelSpacer) * rowHeight + (rowHeight - cdsHeight) / 2
+  const frameOffsets = showFeatureLabels
+    ? [0, 4, 2, 0, 14, 12, 10]
+    : [0, 2, 1, 0, 7, 6, 5]
+  const row = frameOffsets.at(frame)
+  if (row === undefined) {
+    return
+  }
+  const cdsTop = row * rowHeight
   const cdsWidthPx = (max - min) / bpPerPx
 
   const featureType = `Type: ${cds.type}`

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/stateModel/layouts.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/stateModel/layouts.ts
@@ -159,15 +159,19 @@ export function layoutsModelFactory(
                   }
                   for (const cdsRow of cdsLocations) {
                     for (const cds of cdsRow) {
-                      let rowNum: number = getFrame(
+                      const frame = getFrame(
                         cds.min,
                         cds.max,
                         strand ?? 1,
                         cds.phase,
                       )
-                      rowNum = self.featureLabelSpacer(
-                        rowNum < 0 ? -1 * rowNum + 5 : rowNum,
-                      )
+                      const frameOffsets = self.showFeatureLabels
+                        ? [0, 5, 3, 1, 15, 13, 11]
+                        : [0, 2, 1, 0, 8, 7, 6]
+                      const rowNum = frameOffsets.at(frame)
+                      if (!rowNum) {
+                        continue
+                      }
                       if (!featureLayout.get(rowNum)) {
                         featureLayout.set(rowNum, [])
                       }

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/stateModel/mouseEvents.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/stateModel/mouseEvents.ts
@@ -86,15 +86,16 @@ export function mouseEventsModelIntermediateFactory(
             }
             for (const loc of feature.cdsLocations) {
               for (const cds of loc) {
-                let rowNum: number = getFrame(
+                const frame = getFrame(
                   cds.min,
                   cds.max,
                   feature.strand ?? 1,
                   cds.phase,
                 )
-                rowNum = self.featureLabelSpacer(
-                  rowNum < 0 ? -1 * rowNum + 5 : rowNum,
-                )
+                const frameOffsets = self.showFeatureLabels
+                  ? [0, 5, 3, 1, 15, 13, 11]
+                  : [0, 2, 1, 0, 8, 7, 6]
+                const rowNum = frameOffsets.at(frame)
                 if (row === rowNum && bp >= cds.min && bp <= cds.max) {
                   return (
                     featureID === undefined ||


### PR DESCRIPTION
I noticed that the row order for the CDS glyphs was not the same as the order for the stop codons in the LinearApolloSixFrameDisplay on the forward strand (reverse strand was correct).

This standardizes the CDS glyph frame row order so it's the same as the stop codon row order, as well as the same order as the ApolloSequenceDisplay.