### PR TITLE
Standardize abort errors, give better descriptions

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/components/AuthTypeSelector.tsx
+++ b/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/components/AuthTypeSelector.tsx
@@ -57,7 +57,12 @@ export const AuthTypeSelector = ({
       }
     })
     return () => {
-      controller.abort('AuthTypeSelector')
+      controller.abort(
+        new DOMException(
+          'Error retrieving valid authentication types',
+          'AbortError',
+        ),
+      )
     }
   }, [baseURL])
 

--- a/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
@@ -503,7 +503,9 @@ const stateModelFactory = (configSchema: ApolloInternetAccountConfigModel) => {
       beforeDestroy() {
         self.removeBeforeUnloadListener()
         self.removeVisibilityChangeListener()
-        self.controller.abort('internet account beforeDestroy')
+        self.controller.abort(
+          new DOMException('Cleaning up Apollo connection', 'AbortError'),
+        )
         self.socket.close()
       },
     }))

--- a/packages/jbrowse-plugin-apollo/src/ChangeManager.ts
+++ b/packages/jbrowse-plugin-apollo/src/ChangeManager.ts
@@ -66,7 +66,12 @@ export class ChangeManager {
       statusMessage: 'Pre-validating',
       progressPct: 0,
       cancelCallback: () => {
-        controller.abort('ChangeManager')
+        controller.abort(
+          new DOMException(
+            `Cancelling change "${change.typeName}"`,
+            'AbortError',
+          ),
+        )
       },
     }
 

--- a/packages/jbrowse-plugin-apollo/src/components/AddAssembly.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/AddAssembly.tsx
@@ -200,7 +200,12 @@ export function AddAssembly({
         statusMessage: 'Pre-validating',
         progressPct: 0,
         cancelCallback: () => {
-          controller.abort('AddAssembly')
+          controller.abort(
+            new DOMException(
+              `Canceling adding of assembly "${assemblyName}"`,
+              'AbortError',
+            ),
+          )
           jobsManager.abortJob(job.name)
         },
       }

--- a/packages/jbrowse-plugin-apollo/src/components/ImportFeatures.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/ImportFeatures.tsx
@@ -182,7 +182,12 @@ export function ImportFeatures({
       statusMessage: 'Uploading file, this may take awhile',
       progressPct: 0,
       cancelCallback: () => {
-        controller.abort('ImportFeatures')
+        controller.abort(
+          new DOMException(
+            `Canceling importing of features to ${selectedAssembly.displayName}`,
+            'AbortError',
+          ),
+        )
         jobsManager.abortJob(job.name)
       },
     }

--- a/packages/jbrowse-plugin-apollo/src/components/OntologyTermAutocomplete.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/OntologyTermAutocomplete.tsx
@@ -93,7 +93,12 @@ export function OntologyTermAutocomplete({
       )
     }
     return () => {
-      controller.abort('OntologyTermAutocomplete matcher')
+      controller.abort(
+        new DOMException(
+          'Cancel getting current term from ontology store',
+          'AbortError',
+        ),
+      )
     }
   }, [session, valueString, filterTerms, ontologyStore, needToLoadCurrentTerm])
 
@@ -119,7 +124,12 @@ export function OntologyTermAutocomplete({
       )
     }
     return () => {
-      controller.abort('OntologyTermAutocomplete loader')
+      controller.abort(
+        new DOMException(
+          'Canceling getting valid terms from ontology store',
+          'AbortError',
+        ),
+      )
     }
   }, [
     needToLoadTermChoices,

--- a/packages/jbrowse-plugin-apollo/src/components/OntologyTermMultiSelect.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/OntologyTermMultiSelect.tsx
@@ -89,7 +89,12 @@ function TermTagWithTooltip({
     })
 
     return () => {
-      controller.abort('TermTagWithTooltip ')
+      controller.abort(
+        new DOMException(
+          'Cancel fetching term description from ontology store',
+          'AbortError',
+        ),
+      )
     }
   }, [termId, ontology, manager])
 
@@ -211,7 +216,9 @@ export function OntologyTermMultiSelect({
     })
 
     return () => {
-      aborter.abort('OntologyTermMultiSelect')
+      aborter.abort(
+        new DOMException('Cancel getting ontology terms', 'AbortError'),
+      )
     }
   }, [getOntologyTerms, ontology, includeDeprecated, inputValue, value])
 

--- a/packages/jbrowse-plugin-apollo/src/makeDisplayComponent.tsx
+++ b/packages/jbrowse-plugin-apollo/src/makeDisplayComponent.tsx
@@ -97,7 +97,9 @@ const ResizeHandle = ({
         const controller = new AbortController()
         const { signal } = controller
         function abortDrag() {
-          controller.abort('makeDisplayComponent')
+          controller.abort(
+            new DOMException('Canceling drag event listener', 'AbortError'),
+          )
         }
         globalThis.addEventListener('mousemove', mouseMove, { signal })
         globalThis.addEventListener('mouseup', abortDrag, { signal })

--- a/packages/jbrowse-plugin-apollo/src/session/ClientDataStore.ts
+++ b/packages/jbrowse-plugin-apollo/src/session/ClientDataStore.ts
@@ -204,7 +204,12 @@ export function clientDataStoreFactory(
                   statusMessage: `Loading ontology "${name}", version "${version}", this may take a while`,
                   progressPct: 0,
                   cancelCallback: () => {
-                    controller.abort('ClientDataStore')
+                    controller.abort(
+                      new DOMException(
+                        `Canceling loading of ontology "${name}"`,
+                        'AbortError',
+                      ),
+                    )
                     jobsManager.abortJob(job.name)
                   },
                 }

--- a/packages/jbrowse-plugin-apollo/src/session/session.ts
+++ b/packages/jbrowse-plugin-apollo/src/session/session.ts
@@ -351,7 +351,9 @@ export function extendSession(
         )
       },
       beforeDestroy() {
-        self.abortController.abort('destroying session model')
+        self.abortController.abort(
+          new DOMException('Clean up Apollo session', 'AbortError'),
+        )
       },
     }))
 


### PR DESCRIPTION
Before these abort exceptions weren't caught properly by `isAbortException`. Also improved the messages for better UX and debugging.