### PR TITLE
Fix highlighting searched feature with apollo id

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/ApolloTextSearchAdapter/ApolloTextSearchAdapter.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloTextSearchAdapter/ApolloTextSearchAdapter.ts
@@ -16,7 +16,7 @@ function getMatchedFeature(
   feature: AnnotationFeatureSnapshot,
 ): AnnotationFeatureSnapshot | undefined {
   // @ts-expect-error this actually has a bit more info that a plain snapshot
-  const { children, indexedIds, ...featureWithoutChildren } = feature
+  const { children, indexedIds, allIds, ...featureWithoutChildren } = feature
   const featureString = JSON.stringify(featureWithoutChildren)
   if (featureString.includes(query)) {
     return feature


### PR DESCRIPTION
### Details

When we search a transcript with apollo object id its highlighting the gene. This fix should highlight the searched transcript if we search with apollo id or using its external indexed id.