### PR TITLE
Skip copying certain attributes (configurable) when we create/duplicate a feature

### DIFF
--- a/packages/apollo-collaboration-server/src/app.module.ts
+++ b/packages/apollo-collaboration-server/src/app.module.ts
@@ -59,6 +59,7 @@ const validationSchema = Joi.object({
   DESCRIPTION: Joi.string(),
   FEATURE_TYPE_ONTOLOGY_LOCATION: Joi.string(),
   PLUGIN_LOCATION: Joi.string(),
+  SKIPPED_ATTRIBUTES_ON_COPY: Joi.string().default(''),
   INDEXED_IDS: Joi.string().default('gff_id'),
   ALLOW_ROOT_USER: Joi.boolean().default(false),
   ROOT_USER_PASSWORD: Joi.string(),

--- a/packages/apollo-collaboration-server/src/jbrowse/jbrowse.service.ts
+++ b/packages/apollo-collaboration-server/src/jbrowse/jbrowse.service.ts
@@ -26,6 +26,7 @@ export class JBrowseService {
         DESCRIPTION?: string
         PLUGIN_LOCATION?: string
         FEATURE_TYPE_ONTOLOGY_LOCATION?: string
+        SKIPPED_ATTRIBUTES_ON_COPY?: string
       },
       true
     >,
@@ -43,6 +44,7 @@ export class JBrowseService {
       this.configService.get('FEATURE_TYPE_ONTOLOGY_LOCATION', {
         infer: true,
       }) ?? 'sequence_ontology.json'
+    const skippedAttributesOnCopy = this.getSkippedAttributesOnCopy()
     const configuration = {
       theme: {
         palette: {
@@ -69,7 +71,10 @@ export class JBrowseService {
           ],
         },
       },
-      ApolloPlugin: { hasRole: false },
+      ApolloPlugin: {
+        hasRole: false,
+        skippedAttributesOnCopy,
+      },
     }
     if (!role) {
       return configuration
@@ -79,6 +84,7 @@ export class JBrowseService {
         ...configuration,
         ApolloPlugin: {
           hasRole: true,
+          skippedAttributesOnCopy,
         },
       }
     }
@@ -86,6 +92,7 @@ export class JBrowseService {
       ...configuration,
       ApolloPlugin: {
         hasRole: true,
+        skippedAttributesOnCopy,
         ontologies: [
           {
             name: 'Sequence Ontology',
@@ -97,6 +104,19 @@ export class JBrowseService {
         ],
       },
     }
+  }
+
+  getSkippedAttributesOnCopy() {
+    const skippedAttributes = this.configService.get(
+      'SKIPPED_ATTRIBUTES_ON_COPY',
+      {
+        infer: true,
+      },
+    )
+    return (skippedAttributes ?? '')
+      .split(',')
+      .map((attribute) => attribute.trim())
+      .filter(Boolean)
   }
 
   getPlugins() {

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/TranscriptGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/TranscriptGlyph.ts
@@ -6,7 +6,7 @@ import {
 } from '@jbrowse/core/util'
 import type { ContentBlock } from '@jbrowse/core/util/blockTypes'
 
-import { MergeTranscripts } from '../../components'
+import { DuplicateTranscript, MergeTranscripts } from '../../components'
 import {
   isCDSFeature,
   isExonFeature,
@@ -217,29 +217,54 @@ function getContextMenuItems(
       },
     })
   }
-  menuItems.push({
-    label: 'Merge transcript',
-    onClick: () => {
-      ;(session as unknown as AbstractSessionModel).queueDialog(
-        (doneCallback) => [
-          MergeTranscripts,
-          {
-            session,
-            handleClose: () => {
-              doneCallback()
+  menuItems.push(
+    {
+      label: 'Merge transcript',
+      onClick: () => {
+        ;(session as unknown as AbstractSessionModel).queueDialog(
+          (doneCallback) => [
+            MergeTranscripts,
+            {
+              session,
+              handleClose: () => {
+                doneCallback()
+              },
+              changeManager,
+              sourceFeature: feature,
+              sourceAssemblyId: currentAssemblyId,
+              selectedFeature,
+              setSelectedFeature: (feature?: AnnotationFeature) => {
+                display.setSelectedFeature(feature)
+              },
             },
-            changeManager,
-            sourceFeature: feature,
-            sourceAssemblyId: currentAssemblyId,
-            selectedFeature,
-            setSelectedFeature: (feature?: AnnotationFeature) => {
-              display.setSelectedFeature(feature)
-            },
-          },
-        ],
-      )
+          ],
+        )
+      },
     },
-  })
+    {
+      label: 'Duplicate feature',
+      onClick: () => {
+        ;(session as unknown as AbstractSessionModel).queueDialog(
+          (doneCallback) => [
+            DuplicateTranscript,
+            {
+              session,
+              handleClose: () => {
+                doneCallback()
+              },
+              changeManager,
+              sourceFeature: feature,
+              sourceAssemblyId: currentAssemblyId,
+              selectedFeature,
+              setSelectedFeature: (feature?: AnnotationFeature) => {
+                display.setSelectedFeature(feature)
+              },
+            },
+          ],
+        )
+      },
+    },
+  )
   return menuItems
 }
 

--- a/packages/jbrowse-plugin-apollo/src/components/CreateApolloAnnotation.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/CreateApolloAnnotation.tsx
@@ -9,6 +9,7 @@ import {
   LocationStartChange,
 } from '@apollo-annotation/shared'
 import type { Assembly } from '@jbrowse/core/assemblyManager/assembly'
+import { readConfObject } from '@jbrowse/core/configuration'
 import type { AbstractSessionModel } from '@jbrowse/core/util'
 import { getSnapshot } from '@jbrowse/mobx-state-tree'
 import {
@@ -30,6 +31,7 @@ import ObjectID from 'bson-objectid'
 import React, { useEffect, useMemo, useState } from 'react'
 
 import type { ApolloSessionModel } from '../session'
+import { removeSkippedAttributes } from '../util'
 
 import { Dialog } from './Dialog'
 
@@ -162,6 +164,11 @@ export function CreateApolloAnnotation({
   region,
 }: CreateApolloAnnotationProps) {
   const apolloSessionModel = session as unknown as ApolloSessionModel
+  const configuredSkippedAttributes = readConfObject(
+    apolloSessionModel.getPluginConfiguration(),
+    'skippedAttributesOnCopy',
+  ) as string[] | undefined
+  const skippedAttributesOnCopy = new Set(configuredSkippedAttributes ?? [])
   const { featureTypeOntology } =
     apolloSessionModel.apolloDataStore.ontologyManager
   const childIds = useMemo(
@@ -340,23 +347,28 @@ export function CreateApolloAnnotation({
 
   // Copies gene feature along with its selected children
   const copyGeneFeature = async () => {
+    const copiedAnnotationFeature = {
+      ...annotationFeature,
+    } as AnnotationFeatureSnapshot
+    removeSkippedAttributes(copiedAnnotationFeature, skippedAttributesOnCopy)
+
     let change
     if (
-      annotationFeature.children &&
+      copiedAnnotationFeature.children &&
       checkedChildrens.length !==
-        Object.values(annotationFeature.children).length
+        Object.values(copiedAnnotationFeature.children).length
     ) {
       // IF SOME CHILDREN ARE CHECKED
       const childrens: Record<string, AnnotationFeatureSnapshot> = {}
       for (const childId of checkedChildrens) {
-        childrens[childId] = annotationFeature.children[childId]
+        childrens[childId] = copiedAnnotationFeature.children[childId]
       }
       change = new AddFeatureChange({
         changedIds: [annotationFeature._id],
         typeName: 'AddFeatureChange',
         assembly: assembly.name,
         addedFeature: {
-          ...annotationFeature,
+          ...copiedAnnotationFeature,
           children: childrens,
         },
       })
@@ -366,7 +378,7 @@ export function CreateApolloAnnotation({
         changedIds: [annotationFeature._id],
         typeName: 'AddFeatureChange',
         assembly: assembly.name,
-        addedFeature: annotationFeature,
+        addedFeature: copiedAnnotationFeature,
       })
     }
 
@@ -380,7 +392,10 @@ export function CreateApolloAnnotation({
       return
     }
     for (const transcriptId of Object.keys(transcripts)) {
-      const transcript = transcripts[transcriptId]
+      const transcript = {
+        ...transcripts[transcriptId],
+      } as AnnotationFeatureSnapshot
+      removeSkippedAttributes(transcript, skippedAttributesOnCopy)
       transcript.strand = selectedDestinationFeature.strand
 
       // update strand of transcript children if they exist
@@ -405,9 +420,20 @@ export function CreateApolloAnnotation({
   const createNewGeneFeatureWithTranscripts = async (
     childrens: Record<string, AnnotationFeatureSnapshot>,
   ) => {
+    const copiedChildrens: Record<string, AnnotationFeatureSnapshot> = {}
+    for (const [childId, child] of Object.entries(childrens)) {
+      const copiedChild = { ...child } as AnnotationFeatureSnapshot
+      removeSkippedAttributes(copiedChild, skippedAttributesOnCopy)
+      copiedChildrens[childId] = copiedChild
+    }
+
     const newGeneId = new ObjectID().toHexString()
-    const min = Math.min(...Object.values(childrens).map((child) => child.min))
-    const max = Math.max(...Object.values(childrens).map((child) => child.max))
+    const min = Math.min(
+      ...Object.values(copiedChildrens).map((child) => child.min),
+    )
+    const max = Math.max(
+      ...Object.values(copiedChildrens).map((child) => child.max),
+    )
     const change = new AddFeatureChange({
       changedIds: [newGeneId],
       typeName: 'AddFeatureChange',
@@ -419,7 +445,7 @@ export function CreateApolloAnnotation({
         max,
         strand: annotationFeature.strand,
         type: 'gene',
-        children: childrens,
+        children: copiedChildrens,
         attributes: {
           name: [getGeneNameOrId(annotationFeature)],
           gene_name: [getGeneNameOrId(annotationFeature)],

--- a/packages/jbrowse-plugin-apollo/src/components/DuplicateTranscript.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/DuplicateTranscript.tsx
@@ -4,6 +4,7 @@ import type {
   AnnotationFeatureSnapshot,
 } from '@apollo-annotation/mst'
 import { AddFeatureChange } from '@apollo-annotation/shared'
+import { readConfObject } from '@jbrowse/core/configuration'
 import type { AbstractSessionModel } from '@jbrowse/core/util/types'
 import { getSnapshot } from '@jbrowse/mobx-state-tree'
 import {
@@ -17,6 +18,7 @@ import React, { useState } from 'react'
 
 import type { ChangeManager } from '../ChangeManager'
 import type { ApolloSessionModel } from '../session'
+import { removeSkippedAttributes } from '../util'
 
 import { Dialog } from './Dialog'
 
@@ -70,6 +72,14 @@ export function DuplicateTranscript({
         }
         duplicateTranscript.children = newChildren
       }
+
+      // skip attributes that are configured (SKIPPED_ATTRIBUTES_ON_COPY env var in backend)
+      const configuredSkippedAttributes = readConfObject(
+        session.getPluginConfiguration(),
+        'skippedAttributesOnCopy',
+      ) as string[] | undefined
+      const skippedAttributesOnCopy = new Set(configuredSkippedAttributes ?? [])
+      removeSkippedAttributes(duplicateTranscript, skippedAttributesOnCopy)
 
       const change = new AddFeatureChange({
         parentFeatureId: parentGene._id,

--- a/packages/jbrowse-plugin-apollo/src/config.ts
+++ b/packages/jbrowse-plugin-apollo/src/config.ts
@@ -3,36 +3,42 @@ import { types } from '@jbrowse/mobx-state-tree'
 
 import { OntologyRecordConfiguration } from './OntologyManager'
 
-const ApolloPluginConfigurationSchema = ConfigurationSchema(
-  'ApolloPlugin',
-  {
-    ontologies: types.array(OntologyRecordConfiguration),
-    featureTypeOntologyName: {
-      description: 'Name of the feature type ontology',
-      type: 'string',
-      defaultValue: 'Sequence Ontology',
-    },
-    hasRole: {
-      description: 'Flag used internally by jbrowse-plugin-apollo',
-      type: 'boolean',
-      defaultValue: false,
-    },
-    geneBackgroundColor: {
-      description: 'Color for feature background',
-      type: 'string',
-      defaultValue: 'jexl:geneBackgroundColor(featureType)',
-      contextVariable: ['featureType'],
-    },
-  },
-  {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    actions: (self: any) => ({
-      addOntology(ontologySnapshot: { name: string }) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-        self.ontologies.push(ontologySnapshot)
+const ApolloPluginConfigurationSchema: ReturnType<typeof ConfigurationSchema> =
+  ConfigurationSchema(
+    'ApolloPlugin',
+    {
+      ontologies: types.array(OntologyRecordConfiguration),
+      featureTypeOntologyName: {
+        description: 'Name of the feature type ontology',
+        type: 'string',
+        defaultValue: 'Sequence Ontology',
       },
-    }),
-  },
-)
+      hasRole: {
+        description: 'Flag used internally by jbrowse-plugin-apollo',
+        type: 'boolean',
+        defaultValue: false,
+      },
+      skippedAttributesOnCopy: {
+        description: 'Feature attribute keys to skip when copying features',
+        type: 'stringArray',
+        defaultValue: [],
+      },
+      geneBackgroundColor: {
+        description: 'Color for feature background',
+        type: 'string',
+        defaultValue: 'jexl:geneBackgroundColor(featureType)',
+        contextVariable: ['featureType'],
+      },
+    },
+    {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      actions: (self: any) => ({
+        addOntology(ontologySnapshot: { name: string }) {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+          self.ontologies.push(ontologySnapshot)
+        },
+      }),
+    },
+  )
 
 export default ApolloPluginConfigurationSchema

--- a/packages/jbrowse-plugin-apollo/src/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/index.ts
@@ -118,7 +118,8 @@ validationRegistry.registerValidation(new ParentChildValidation())
 export default class ApolloPlugin extends Plugin {
   name = 'ApolloPlugin'
   version = version
-  configurationSchema = ApolloPluginConfigurationSchema
+  configurationSchema: ReturnType<typeof ConfigurationSchema> =
+    ApolloPluginConfigurationSchema
 
   install(pluginManager: PluginManager) {
     installApolloSequenceAdapter(pluginManager)

--- a/packages/jbrowse-plugin-apollo/src/util/annotationFeatureUtils.ts
+++ b/packages/jbrowse-plugin-apollo/src/util/annotationFeatureUtils.ts
@@ -1,4 +1,7 @@
-import type { AnnotationFeature } from '@apollo-annotation/mst'
+import type {
+  AnnotationFeature,
+  AnnotationFeatureSnapshot,
+} from '@apollo-annotation/mst'
 
 export function getFeatureName(feature: AnnotationFeature) {
   const { attributes } = feature
@@ -109,4 +112,29 @@ export function getRelatedFeatures(
     }
   }
   return relatedFeatures
+}
+
+export function removeSkippedAttributes(
+  feature: AnnotationFeatureSnapshot,
+  skippedAttributes: Set<string>,
+) {
+  if (feature.attributes) {
+    const newAttributes: Record<string, readonly string[] | undefined> = {}
+    for (const [attribute, values] of Object.entries(feature.attributes)) {
+      if (!skippedAttributes.has(attribute)) {
+        newAttributes[attribute] = values
+      }
+    }
+    feature.attributes =
+      Object.keys(newAttributes).length === 0 ? undefined : newAttributes
+  }
+  if (feature.children) {
+    const newChildren: Record<string, AnnotationFeatureSnapshot> = {}
+    for (const [childId, child] of Object.entries(feature.children)) {
+      const newChild = { ...child } as AnnotationFeatureSnapshot
+      removeSkippedAttributes(newChild, skippedAttributes)
+      newChildren[childId] = newChild
+    }
+    feature.children = newChildren
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/GMOD/Apollo3/issues/772

### Details
- Skip copying configured attributes of a transcript for duplicate transcript operation
- Skip copying configured attributes of a feature before creating a feature from jbrowse track 