### PR TITLE
Better attribute handling when copying JBrowse feature

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/extensions/annotationFromJBrowseFeature.test.ts
+++ b/packages/jbrowse-plugin-apollo/src/extensions/annotationFromJBrowseFeature.test.ts
@@ -110,7 +110,7 @@ describe('Convert JBrowse feature to annotation feature', () => {
       expect(xcds?.type).toStrictEqual('CDS')
       expect(xcds?.min).toStrictEqual(15)
       expect(xcds?.max).toStrictEqual(27)
-      expect(xcds?.attributes?.name?.at(0)).toStrictEqual('XYZ')
+      expect(xcds?.attributes?.gff_name?.at(0)).toStrictEqual('XYZ')
       expect(xcds?.attributes?.gff_score?.at(0)).toStrictEqual('0')
       expect(xcds?.attributes?.gff_source?.at(0)).toStrictEqual('mySource')
     } else {

--- a/packages/jbrowse-plugin-apollo/src/extensions/annotationFromJBrowseFeature.ts
+++ b/packages/jbrowse-plugin-apollo/src/extensions/annotationFromJBrowseFeature.ts
@@ -57,24 +57,52 @@ export function jbrowseFeatureToAnnotationFeature(
   return gff3ToAnnotationFeature(simpleFeatureToGFF3Feature(feature, refSeqId))
 }
 
+const fieldsToSkip = new Set([
+  'start',
+  'end',
+  'type',
+  'strand',
+  'refName',
+  'subfeatures',
+  'derived_features',
+  'phase',
+  'source',
+  'score',
+  'parent',
+  // From https://github.com/GMOD/jbrowse-components/blob/ab3126374367f43d01038d6d2e86d8db03c4d8d8/packages/core/src/BaseFeatureWidget/BaseFeatureDetail/Attributes.tsx#L12-L24
+  '__jbrowsefmt',
+  'length',
+  'position',
+  'uniqueId',
+  'exonFrames',
+  'parentId',
+  'thickStart',
+  'thickEnd',
+  '_lineHash',
+])
+
+const fieldsToRename: Record<string, string | undefined> = {
+  id: 'gff_id',
+  name: 'gff_name',
+  alias: 'gff_alias',
+  target: 'gff_target',
+  gap: 'gff_gap',
+  derives_from: 'gff_derives_from',
+  note: 'gff_note',
+  dbxref: 'gff_dbxref',
+  ontology_term: 'gff_ontology_term',
+  is_circular: 'gff_is_circular',
+}
+
 function convertFeatureAttributes(feature: Feature): Record<string, string[]> {
   const attributes: Record<string, string[]> = {}
-  const defaultFields = new Set([
-    'start',
-    'end',
-    'type',
-    'strand',
-    'refName',
-    'subfeatures',
-    'derived_features',
-    'phase',
-    'source',
-    'score',
-  ])
-  for (const [key, value] of Object.entries(feature.toJSON())) {
-    if (defaultFields.has(key)) {
+
+  for (const [originalKey, value] of Object.entries(feature.toJSON())) {
+    if (fieldsToSkip.has(originalKey)) {
       continue
     }
+    const renamedKey = fieldsToRename[originalKey]
+    const key = renamedKey ?? originalKey
     attributes[key] = Array.isArray(value) ? value.map(String) : [String(value)]
   }
   return attributes


### PR DESCRIPTION
This makes it so that when a JBrowse feature is added to Apollo, JBrowse-internal attributes like `_lineHash` get skipped when creating the Apollo feature attributes. It also does a better job of making sure that GFF3 reserved fields in the copied features are marked as such.