### PR TITLE
Improve creating annotation from JBrowse feature

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/extensions/annotationFromJBrowseFeature.ts
+++ b/packages/jbrowse-plugin-apollo/src/extensions/annotationFromJBrowseFeature.ts
@@ -108,6 +108,16 @@ function convertFeatureAttributes(feature: Feature): Record<string, string[]> {
   return attributes
 }
 
+function getTopLevelSimpleFeature(feature: Feature) {
+  let topLevel = feature
+  let parent = feature.get('parent')
+  while (parent) {
+    topLevel = parent
+    parent = parent.get('parent')
+  }
+  return topLevel
+}
+
 export function annotationFromJBrowseFeature(
   pluggableElement: PluggableElementType,
 ) {
@@ -146,6 +156,7 @@ export function annotationFromJBrowseFeature(
           if (!feature) {
             return superContextMenuItems()
           }
+          const topLevelFeature = getTopLevelSimpleFeature(feature)
           return [
             ...superContextMenuItems(),
             {
@@ -169,7 +180,7 @@ export function annotationFromJBrowseFeature(
                   refSeqId = backendRefSeqId
                 }
                 const annotationFeature = jbrowseFeatureToAnnotationFeature(
-                  feature,
+                  topLevelFeature,
                   refSeqId,
                 )
                 session.queueDialog((doneCallback) => [

--- a/packages/jbrowse-plugin-apollo/src/extensions/annotationFromJBrowseFeature.ts
+++ b/packages/jbrowse-plugin-apollo/src/extensions/annotationFromJBrowseFeature.ts
@@ -11,10 +11,10 @@ import type DisplayType from '@jbrowse/core/pluggableElementTypes/DisplayType'
 import { getContainingView, getSession } from '@jbrowse/core/util'
 import type { Feature } from '@jbrowse/core/util/simpleFeature'
 import type { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
-import AddIcon from '@mui/icons-material/Add'
 
 import { CollaborationServerDriver } from '../BackendDrivers'
 import { CreateApolloAnnotation } from '../components/CreateApolloAnnotation'
+import { Apollo as ApolloIcon } from '../menus/Icons'
 import type { ApolloSessionModel } from '../session'
 
 function simpleFeatureToGFF3Feature(
@@ -161,7 +161,7 @@ export function annotationFromJBrowseFeature(
             ...superContextMenuItems(),
             {
               label: 'Create Apollo annotation',
-              icon: AddIcon,
+              icon: ApolloIcon,
               onClick: async () => {
                 const backendDriver = (
                   session as unknown as ApolloSessionModel

--- a/packages/jbrowse-plugin-apollo/src/extensions/annotationFromPileup.ts
+++ b/packages/jbrowse-plugin-apollo/src/extensions/annotationFromPileup.ts
@@ -15,11 +15,11 @@ import {
 } from '@jbrowse/core/util'
 import type { Feature } from '@jbrowse/core/util/simpleFeature'
 import type { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
-import AddIcon from '@mui/icons-material/Add'
 import ObjectID from 'bson-objectid'
 
 import { CollaborationServerDriver } from '../BackendDrivers'
 import { CreateApolloAnnotation } from '../components/CreateApolloAnnotation'
+import { Apollo as ApolloIcon } from '../menus/Icons'
 import type { ApolloSessionModel } from '../session'
 
 function parseCigar(cigar: string): [string, number][] {
@@ -172,7 +172,7 @@ export function annotationFromPileup(pluggableElement: PluggableElementType) {
             ...superContextMenuItems(),
             {
               label: 'Create Apollo annotation',
-              icon: AddIcon,
+              icon: ApolloIcon,
               onClick: async () => {
                 const backendDriver = (
                   session as unknown as ApolloSessionModel

--- a/packages/jbrowse-plugin-apollo/src/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/index.ts
@@ -91,6 +91,12 @@ interface ApolloMessageData {
   assembly: string
 }
 
+interface JBrowseTrackConfig {
+  trackId: string
+  type: string
+  displays?: { type: string; displayId: string }[]
+}
+
 function isApolloMessageData(data?: unknown): data is ApolloMessageData {
   return (
     typeof data === 'object' &&
@@ -287,6 +293,43 @@ export default class ApolloPlugin extends Plugin {
     pluginManager.addToExtensionPoint(
       'Core-extendPluggableElement',
       annotationFromJBrowseFeature,
+    )
+
+    pluginManager.addToExtensionPoint(
+      'Core-preProcessTrackConfig',
+      (snap: JBrowseTrackConfig): JBrowseTrackConfig => {
+        if (snap.type !== 'ReferenceSequenceTrack') {
+          return snap
+        }
+        const displays = snap.displays ?? []
+        const apolloDisplayIdx = displays.findIndex(
+          (d) => d.type === 'LinearApolloReferenceSequenceDisplay',
+        )
+        if (apolloDisplayIdx === 0) {
+          return snap
+        }
+        if (apolloDisplayIdx === -1) {
+          return {
+            ...snap,
+            displays: [
+              {
+                type: 'LinearApolloReferenceSequenceDisplay',
+                displayId: `${snap.trackId}-LinearApolloReferenceSequenceDisplay`,
+              },
+              ...displays,
+            ],
+          }
+        }
+        const reorderedDisplays = displays.toSpliced(apolloDisplayIdx, 1)
+        reorderedDisplays.unshift({
+          type: 'LinearApolloReferenceSequenceDisplay',
+          displayId: `${snap.trackId}-LinearApolloReferenceSequenceDisplay`,
+        })
+        return {
+          ...snap,
+          displays: reorderedDisplays,
+        }
+      },
     )
 
     pluginManager.addToExtensionPoint(

--- a/packages/jbrowse-plugin-apollo/src/menus/Icons.tsx
+++ b/packages/jbrowse-plugin-apollo/src/menus/Icons.tsx
@@ -1,0 +1,49 @@
+import { SvgIcon, type SvgIconProps } from '@mui/material'
+import React from 'react'
+
+// Icon source: https://developers.google.com/identity/branding-guidelines
+export function Apollo(props: SvgIconProps) {
+  return (
+    <SvgIcon
+      viewBox="0 0 856 855"
+      style={{ fontSize: 18, marginRight: 4 }}
+      {...props}
+    >
+      <g>
+        <path
+          style={{ opacity: 0.68, fill: '#AEAEAE' }}
+          d="M276.7,656.9l85-148h102.9c23.1,0,16.1-16,11.1-25l-134-238.5l85-148l185,315.6c0,0-15-26.3,0,0
+			c53,92.9-24,243.9-132,243.9c-6,0-4,0-6.4,0H276.7z"
+        />
+        <polygon
+          style={{ opacity: 0.85, fill: '#717171' }}
+          points="49.7,756.9 219.1,756.9 513.7,246.9 425.7,99.9 		"
+        />
+        <polygon
+          style={{ opacity: 0.85, fill: '#717171' }}
+          points="630,756.9 806.4,756.9 513.7,246.9 425.1,400.2 		"
+        />
+        <polygon
+          style={{ fill: '#C6C6C6' }}
+          points="175.7,657.3 195.6,657.3 277.9,508.9 254.1,508.9 170.6,657.3 		"
+        />
+        <polygon
+          style={{ fill: '#C6C6C6' }}
+          points="369.7,657.3 389.6,657.3 471.9,508.9 448.1,508.9 364.6,657.3 		"
+        />
+        <polygon
+          style={{ fill: '#C6C6C6' }}
+          points="321.7,657.3 341.6,657.3 423.9,508.9 400.1,508.9 316.6,657.3 		"
+        />
+        <polygon
+          style={{ fill: '#C6C6C6' }}
+          points="224.7,657.3 244.6,657.3 326.9,508.9 303.1,508.9 219.6,657.3 		"
+        />
+        <polygon
+          style={{ fill: '#C6C6C6' }}
+          points="273.7,657.3 293.6,657.3 375.9,508.9 352.1,508.9 268.6,657.3 		"
+        />
+      </g>
+    </SvgIcon>
+  )
+}


### PR DESCRIPTION
It's sometimes hard to tell if you've right-clicked a transcript or a gene in a JBrowse gene model. This makes it so that whether the user right-clicked the transcript or the gene, it still uses the gene to populate the annotation creation dialog box. The user can then select just the transcript from the dialog box if that's what they want.

This also changes the icon in the menu item from a simple `+` to a grayscale version of the Apollo `A` logo.

<img width="240" height="196" alt="image" src="https://github.com/user-attachments/assets/0f2e73f2-9d2f-4b7a-a367-a581f6e8e147" />
