### PR TITLE
Add server-side sort, filter, and pagination to changelog

### DIFF
--- a/packages/apollo-cli/src/commands/change/get.ts
+++ b/packages/apollo-cli/src/commands/change/get.ts
@@ -26,14 +26,14 @@ In such cases you need to use the assembly ID.'
 
     const access = await this.getAccess()
 
-    const changes: Response = await queryApollo(
+    const response: Response = await queryApollo(
       access.address,
       access.accessToken,
       'changes',
     )
-    const json = (await changes.json()) as object[]
+    const { changes } = (await response.json()) as { changes: object[] }
 
-    let keep = json
+    let keep = changes
     if (flags.assembly !== undefined) {
       keep = []
       const assembly = await idReader(flags.assembly)
@@ -42,7 +42,7 @@ In such cases you need to use the assembly ID.'
         access.accessToken,
         assembly,
       )
-      for (const x of json) {
+      for (const x of changes) {
         if (assemblyIds.includes(x['assembly' as keyof typeof x])) {
           keep.push(x)
         }

--- a/packages/apollo-collaboration-server/src/changes/changes.service.ts
+++ b/packages/apollo-collaboration-server/src/changes/changes.service.ts
@@ -265,39 +265,96 @@ export class ChangesService {
   }
 
   async findAll(changeFilter: FindChangeDto) {
-    // eslint-disable-next-line @typescript-eslint/no-misused-spread
-    const queryCond: FilterQuery<ChangeDocument> = { ...changeFilter }
-    if (changeFilter.user) {
-      queryCond.user = { $regex: changeFilter.user, $options: 'i' }
+    const {
+      assembly,
+      changedIds,
+      reverts,
+      user,
+      typeName,
+      since,
+      sort,
+      limit,
+      page,
+      pageSize,
+      sortField,
+      sortOrder,
+      startTime,
+      endTime,
+    } = changeFilter
+
+    const queryCond: FilterQuery<ChangeDocument> = {}
+    if (assembly) {
+      queryCond.assembly = assembly
     }
-    if (changeFilter.since) {
-      queryCond.sequence = { $gt: Number(changeFilter.since) }
-      delete queryCond.since
+    if (changedIds) {
+      queryCond.changedIds = changedIds
+    }
+    if (reverts) {
+      queryCond.reverts = reverts
+    }
+    if (typeName) {
+      queryCond.typeName = typeName
+    }
+    if (user) {
+      queryCond.user = { $regex: user, $options: 'i' }
+    }
+    if (since) {
+      queryCond.sequence = { $gt: Number(since) }
+    }
+    if (startTime || endTime) {
+      const createdAt: { $gte?: Date; $lte?: Date } = {}
+      if (startTime) {
+        createdAt.$gte = new Date(startTime)
+      }
+      if (endTime) {
+        createdAt.$lte = new Date(endTime)
+      }
+      queryCond.createdAt = createdAt
     }
     this.logger.debug(`Search criteria: "${JSON.stringify(queryCond)}"`)
 
-    let sortOrder: 1 | -1 = -1
-    if (changeFilter.sort && changeFilter.sort === '1') {
-      sortOrder = 1
+    const sortableFields = new Set([
+      'sequence',
+      'typeName',
+      'user',
+      'createdAt',
+    ])
+    const resolvedSortField =
+      sortField && sortableFields.has(sortField) ? sortField : 'sequence'
+    let resolvedSortOrder: 1 | -1 = -1
+    if (sortOrder === 'asc') {
+      resolvedSortOrder = 1
+    } else if (sortOrder === 'desc') {
+      resolvedSortOrder = -1
+    } else if (sort === '1') {
+      resolvedSortOrder = 1
     }
     let changeCursor = this.changeModel
       // unicorn thinks this is an Array.prototype.find, so we ignore it
       // eslint-disable-next-line unicorn/no-array-callback-reference
       .find(queryCond)
-      .sort({ sequence: sortOrder })
+      .sort({ [resolvedSortField]: resolvedSortOrder })
 
-    if (changeFilter.limit) {
-      changeCursor = changeCursor.limit(Number(changeFilter.limit))
+    if (page !== undefined && pageSize !== undefined) {
+      const pageNum = Number(page)
+      const size = Number(pageSize)
+      changeCursor = changeCursor.skip(pageNum * size).limit(size)
+    } else if (limit) {
+      changeCursor = changeCursor.limit(Number(limit))
     }
-    const change = await changeCursor.exec()
 
-    if (!change) {
+    const [changes, totalCount] = await Promise.all([
+      changeCursor.exec(),
+      this.changeModel.countDocuments(queryCond).exec(),
+    ])
+
+    if (!changes) {
       const errMsg = 'ERROR: The following change was not found in database....'
       this.logger.error(errMsg)
       throw new NotFoundException(errMsg)
     }
 
-    return change
+    return { changes, totalCount }
   }
 
   async batchUpdateMany(

--- a/packages/apollo-collaboration-server/src/changes/dto/find-change.dto.ts
+++ b/packages/apollo-collaboration-server/src/changes/dto/find-change.dto.ts
@@ -7,4 +7,10 @@ export class FindChangeDto {
   readonly since?: string
   readonly sort?: string
   readonly limit?: string
+  readonly page?: string
+  readonly pageSize?: string
+  readonly sortField?: string
+  readonly sortOrder?: string
+  readonly startTime?: string
+  readonly endTime?: string
 }

--- a/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloInternetAccount/model.ts
@@ -253,7 +253,7 @@ const stateModelFactory = (configSchema: ApolloInternetAccountConfigModel) => {
             )
             throw new Error(errorMessage)
           }
-          const changes = yield response.json()
+          const { changes } = yield response.json()
           const sequence = changes.length > 0 ? changes[0].sequence : 0
           self.setLastChangeSequenceNumber(sequence)
         },
@@ -298,7 +298,7 @@ const stateModelFactory = (configSchema: ApolloInternetAccountConfigModel) => {
           )
           return
         }
-        const serializedChanges = yield response.json()
+        const { changes: serializedChanges } = yield response.json()
         for (const serializedChange of serializedChanges) {
           const change = Change.fromJSON(serializedChange)
           void changeManager.submit(change, { submitToBackend: false })

--- a/packages/jbrowse-plugin-apollo/src/BackendDrivers/BackendDriver.ts
+++ b/packages/jbrowse-plugin-apollo/src/BackendDrivers/BackendDriver.ts
@@ -23,6 +23,24 @@ export interface ChangeDocument extends SerializedChange {
   changes?: SerializedChange[]
 }
 
+export interface GetChangesOpts {
+  page?: number
+  pageSize?: number
+  sortField?: string
+  sortOrder?: 'asc' | 'desc'
+  filters?: {
+    user?: string
+    typeName?: string
+    startTime?: string
+    endTime?: string
+  }
+}
+
+export interface GetChangesResult {
+  changes: ChangeDocument[]
+  totalCount: number
+}
+
 export abstract class BackendDriver {
   constructor(protected clientStore: ClientDataStoreModel) {}
 
@@ -48,7 +66,10 @@ export abstract class BackendDriver {
     assemblies: string[],
   ): Promise<AnnotationFeatureSnapshot[]>
 
-  abstract getChanges(assemblyName: string): Promise<ChangeDocument[]>
+  abstract getChanges(
+    assemblyName: string,
+    opts?: GetChangesOpts,
+  ): Promise<GetChangesResult>
 
   abstract getCheckResults(assemblyName: string): Promise<CheckResultSnapshot[]>
 }

--- a/packages/jbrowse-plugin-apollo/src/BackendDrivers/CollaborationServerDriver.ts
+++ b/packages/jbrowse-plugin-apollo/src/BackendDrivers/CollaborationServerDriver.ts
@@ -30,7 +30,8 @@ import { createFetchErrorMessage } from '../util'
 
 import {
   BackendDriver,
-  type ChangeDocument,
+  type GetChangesOpts,
+  type GetChangesResult,
   type RefNameAliases,
 } from './BackendDriver'
 
@@ -396,11 +397,39 @@ export class CollaborationServerDriver extends BackendDriver {
     })
   }
 
-  async getChanges(assemblyName: string): Promise<ChangeDocument[]> {
+  async getChanges(
+    assemblyName: string,
+    opts: GetChangesOpts = {},
+  ): Promise<GetChangesResult> {
     const internetAccount = this.clientStore.getInternetAccount(assemblyName)
     const { baseURL } = internetAccount
     const url = new URL('changes', baseURL)
-    url.search = new URLSearchParams({ assembly: assemblyName }).toString()
+    const params: Record<string, string> = { assembly: assemblyName }
+    if (opts.page !== undefined) {
+      params.page = String(opts.page)
+    }
+    if (opts.pageSize !== undefined) {
+      params.pageSize = String(opts.pageSize)
+    }
+    if (opts.sortField) {
+      params.sortField = opts.sortField
+    }
+    if (opts.sortOrder) {
+      params.sortOrder = opts.sortOrder
+    }
+    if (opts.filters?.user) {
+      params.user = opts.filters.user
+    }
+    if (opts.filters?.typeName) {
+      params.typeName = opts.filters.typeName
+    }
+    if (opts.filters?.startTime) {
+      params.startTime = opts.filters.startTime
+    }
+    if (opts.filters?.endTime) {
+      params.endTime = opts.filters.endTime
+    }
+    url.search = new URLSearchParams(params).toString()
     const response = await this.fetch(internetAccount, url.toString())
     if (!response.ok) {
       const errorMessage = await createFetchErrorMessage(
@@ -409,7 +438,7 @@ export class CollaborationServerDriver extends BackendDriver {
       )
       throw new Error(errorMessage)
     }
-    return response.json() as Promise<ChangeDocument[]>
+    return response.json() as Promise<GetChangesResult>
   }
 
   async getCheckResults(assemblyName: string): Promise<CheckResultSnapshot[]> {

--- a/packages/jbrowse-plugin-apollo/src/BackendDrivers/LocalDriver/LocalDriver.ts
+++ b/packages/jbrowse-plugin-apollo/src/BackendDrivers/LocalDriver/LocalDriver.ts
@@ -32,6 +32,8 @@ import type { SubmitOpts } from '../../ChangeManager'
 import {
   BackendDriver,
   type ChangeDocument,
+  type GetChangesOpts,
+  type GetChangesResult,
   type RefNameAliases,
 } from '../BackendDriver'
 
@@ -303,17 +305,63 @@ export class LocalDriver extends BackendDriver {
     return checkResults
   }
 
-  async getChanges(assemblyName: string): Promise<ChangeDocument[]> {
+  async getChanges(
+    assemblyName: string,
+    opts: GetChangesOpts = {},
+  ): Promise<GetChangesResult> {
     const regions = await this.getRegions(assemblyName)
     const refNames = regions.map((r) => r.refName)
     const db = await openDb(assemblyName, refNames)
-    const changes: ChangeDocument[] = []
+    let changes: ChangeDocument[] = []
     for await (const cursor of db.transaction('changes').store.iterate()) {
       changes.push({
         sequence: cursor.key,
         ...(cursor.value as SerializedChange & { createdAt: string }),
       })
     }
-    return changes
+
+    const { filters } = opts
+    if (filters?.user) {
+      const re = new RegExp(filters.user, 'i')
+      changes = changes.filter((c) => c.user !== undefined && re.test(c.user))
+    }
+    if (filters?.typeName) {
+      changes = changes.filter((c) => c.typeName === filters.typeName)
+    }
+    if (filters?.startTime) {
+      const start = new Date(filters.startTime).getTime()
+      changes = changes.filter((c) => new Date(c.createdAt).getTime() >= start)
+    }
+    if (filters?.endTime) {
+      const end = new Date(filters.endTime).getTime()
+      changes = changes.filter((c) => new Date(c.createdAt).getTime() <= end)
+    }
+
+    const totalCount = changes.length
+
+    const sortField = opts.sortField ?? 'sequence'
+    const sortOrder = opts.sortOrder ?? 'desc'
+    const direction = sortOrder === 'asc' ? 1 : -1
+    changes.sort((a, b) => {
+      const aVal = a[sortField as keyof ChangeDocument]
+      const bVal = b[sortField as keyof ChangeDocument]
+      if (aVal === bVal) {
+        return 0
+      }
+      if (aVal === undefined) {
+        return 1
+      }
+      if (bVal === undefined) {
+        return -1
+      }
+      return aVal < bVal ? -direction : direction
+    })
+
+    if (opts.page !== undefined && opts.pageSize !== undefined) {
+      const start = opts.page * opts.pageSize
+      changes = changes.slice(start, start + opts.pageSize)
+    }
+
+    return { changes, totalCount }
   }
 }

--- a/packages/jbrowse-plugin-apollo/src/components/ViewChangeLog.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/ViewChangeLog.tsx
@@ -4,6 +4,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 import { changeRegistry } from '@apollo-annotation/common'
+import type { AbstractSessionModel } from '@jbrowse/core/util'
 import { makeStyles } from '@jbrowse/core/util/tss-react'
 import {
   Button,
@@ -11,9 +12,17 @@ import {
   DialogContent,
   DialogContentText,
 } from '@mui/material'
-import { DataGrid, type GridColDef, type GridRowsProp } from '@mui/x-data-grid'
+import {
+  DataGrid,
+  type GridColDef,
+  type GridFilterModel,
+  type GridPaginationModel,
+  type GridRowsProp,
+  type GridSortModel,
+} from '@mui/x-data-grid'
 import React, { useEffect, useState } from 'react'
 
+import type { GetChangesOpts } from '../BackendDrivers/BackendDriver'
 import type { ApolloSessionModel } from '../session'
 
 import { Dialog } from './Dialog'
@@ -34,16 +43,67 @@ const useStyles = makeStyles()((theme) => ({
   },
 }))
 
+function buildFiltersFromModel(
+  filterModel: GridFilterModel,
+): GetChangesOpts['filters'] {
+  const filters: NonNullable<GetChangesOpts['filters']> = {}
+  for (const item of filterModel.items) {
+    if (item.value === undefined || item.value === '' || item.value === null) {
+      continue
+    }
+    switch (item.field) {
+      case 'user': {
+        filters.user = String(item.value)
+        break
+      }
+      case 'typeName': {
+        filters.typeName = String(item.value)
+        break
+      }
+      case 'createdAt': {
+        const date = new Date(
+          item.value as string | number | Date,
+        ).toISOString()
+        if (item.operator === 'after' || item.operator === 'onOrAfter') {
+          filters.startTime = date
+        } else if (
+          item.operator === 'before' ||
+          item.operator === 'onOrBefore'
+        ) {
+          filters.endTime = date
+        }
+        break
+      }
+    }
+  }
+  return filters
+}
+
 export function ViewChangeLog({
   handleClose,
   session,
-  assembly: assemblyName,
+  assembly: assemblyId,
 }: ViewChangeLogProps) {
   const { classes } = useStyles()
   const [errorMessage, setErrorMessage] = useState<string>()
   const [displayGridData, setDisplayGridData] = useState<GridRowsProp[]>([])
+  const [rowCount, setRowCount] = useState(0)
+  const [loading, setLoading] = useState(false)
+  const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({
+    page: 0,
+    pageSize: 15,
+  })
+  const [sortModel, setSortModel] = useState<GridSortModel>([
+    { field: 'sequence', sort: 'desc' },
+  ])
+  const [filterModel, setFilterModel] = useState<GridFilterModel>({
+    items: [],
+  })
 
   const { apolloDataStore } = session
+  const { assemblyManager } = session as unknown as AbstractSessionModel
+  const assembly = assemblyManager.get(assemblyId)
+  const assemblyName = assembly?.displayName ?? assemblyId
 
   const gridColumns: GridColDef[] = [
     { field: 'sequence' },
@@ -59,6 +119,8 @@ export function ViewChangeLog({
       field: 'changeData',
       headerName: 'Change JSON',
       width: 600,
+      sortable: false,
+      filterable: false,
       renderCell: ({ value }) => (
         <textarea
           className={classes.changeTextarea}
@@ -79,24 +141,53 @@ export function ViewChangeLog({
 
   useEffect(() => {
     async function getGridData() {
-      const backendDriver = apolloDataStore.getBackendDriver(assemblyName)
+      const backendDriver = apolloDataStore.getBackendDriver(assemblyId)
       if (!backendDriver) {
-        setErrorMessage(`No driver found for assembly "${assemblyName}"`)
+        setErrorMessage(`No driver found for assembly "${assemblyId}"`)
         return
       }
-      const data = await backendDriver.getChanges(assemblyName)
-      const gridData = data.map((change) => {
-        const { sequence, typeName, changes, user, createdAt, ...rest } = change
-        const changeData = changes ?? { typeName, ...rest }
+      setLoading(true)
+      const [sortEntry] = sortModel
+      const sortField = sortEntry?.field
+      const sortOrderValue = sortEntry?.sort
+      const sortOrder: 'asc' | 'desc' | undefined =
+        sortOrderValue === 'asc' || sortOrderValue === 'desc'
+          ? sortOrderValue
+          : undefined
+      const { changes, totalCount } = await backendDriver.getChanges(
+        assemblyId,
+        {
+          page: paginationModel.page,
+          pageSize: paginationModel.pageSize,
+          sortField,
+          sortOrder,
+          filters: buildFiltersFromModel(filterModel),
+        },
+      )
+      const gridData = changes.map((change) => {
+        const {
+          sequence,
+          typeName,
+          changes: nestedChanges,
+          user,
+          createdAt,
+          ...rest
+        } = change
+        const changeData = nestedChanges ?? { typeName, ...rest }
         return { sequence, typeName, changeData, user, createdAt }
       })
       // @ts-expect-error not sure how to type this
       setDisplayGridData(gridData)
+      setRowCount(totalCount)
     }
-    getGridData().catch((error) => {
-      setErrorMessage(String(error))
-    })
-  }, [apolloDataStore, assemblyName])
+    getGridData()
+      .catch((error) => {
+        setErrorMessage(String(error))
+      })
+      .finally(() => {
+        setLoading(false)
+      })
+  }, [apolloDataStore, assemblyId, paginationModel, sortModel, filterModel])
 
   return (
     <Dialog
@@ -110,12 +201,23 @@ export function ViewChangeLog({
         <DialogContentText>Changes for {assemblyName}</DialogContentText>
         <DataGrid
           pagination
+          paginationMode="server"
+          sortingMode="server"
+          filterMode="server"
+          rowCount={rowCount}
+          paginationModel={paginationModel}
+          onPaginationModelChange={setPaginationModel}
+          sortModel={sortModel}
+          onSortModelChange={setSortModel}
+          filterModel={filterModel}
+          onFilterModelChange={setFilterModel}
+          loading={loading}
           rows={displayGridData}
           columns={gridColumns}
           getRowId={(row) => row.sequence}
           showToolbar
+          pageSizeOptions={[5, 15, 25, 50, 100]}
           initialState={{
-            sorting: { sortModel: [{ field: 'sequence', sort: 'desc' }] },
             columns: { columnVisibilityModel: { sequence: false } },
           }}
         />


### PR DESCRIPTION
This adds server-side sorting, filtering, and pagination to `GET` requests to the `changes` endpoint. This is then used to power the `DataGrid` from `@mui/x-data-grid`, making the UI much more responsive when there are many changes.

The changelog also still works for local editing when the changes are stored in indexedDb.