### PR TITLE
Make sure versions mentioned in docs stay up to date

### DIFF
--- a/packages/website/docs/01-try-it-out/02-local-demo/01-setting-up.md
+++ b/packages/website/docs/01-try-it-out/02-local-demo/01-setting-up.md
@@ -35,7 +35,7 @@ file:
 name: apollo-local-testing
 services:
   apollo-collaboration-server:
-    image: 'ghcr.io/gmod/apollo-collaboration-server'
+    image: 'ghcr.io/gmod/apollo-collaboration-server:latest'
     depends_on:
       db:
         condition: service_healthy
@@ -75,13 +75,19 @@ services:
         set -o errexit
         set -o nounset
         set -o pipefail
+        apk add jq
         cat /usr/local/apache2/conf/httpd.conf.append >> /usr/local/apache2/conf/httpd.conf
-        wget https://github.com/GMOD/jbrowse-components/releases/download/v2.18.0/jbrowse-web-v2.18.0.zip --output-document=jbrowse-web.zip
+        wget https://s3.amazonaws.com/jbrowse.org/code/jb2/latest/jbrowse-web-latest.zip --output-document=jbrowse-web.zip
         unzip -o jbrowse-web.zip
         rm jbrowse-web.zip
-        wget --output-document=- --quiet https://registry.npmjs.org/@apollo-annotation/jbrowse-plugin-apollo/-/jbrowse-plugin-apollo-0.3.4.tgz | \
-        tar --extract --gzip --file=- --strip=2 package/dist/jbrowse-plugin-apollo.umd.production.min.js
+        wget --output-document=- --quiet https://registry.npmjs.org/@apollo-annotation/jbrowse-plugin-apollo/ > jpa.json
+        LATEST_VERSION=$(jq --raw-output '."dist-tags".latest' jpa.json)
+        TARBALL=$(jq --raw-output ".versions.\"$${LATEST_VERSION}\".dist.tarball" jpa.json)
+        wget --output-document=- --quiet $${TARBALL} | \
+          tar --extract --gzip --file=- --strip=2 package/dist/jbrowse-plugin-apollo.umd.production.min.js package/dist/jbrowse-plugin-apollo.umd.production.min.js.map
         mv jbrowse-plugin-apollo.umd.production.min.js apollo.js
+        mv jbrowse-plugin-apollo.umd.production.min.js.map apollo.js.map
+        rm jpa.json
         wget --quiet https://github.com/The-Sequence-Ontology/SO-Ontologies/raw/refs/heads/master/Ontology_Files/so.json
         mv so.json sequence_ontology.json
         EOF

--- a/packages/website/docs/01-try-it-out/02-local-demo/02-loading-data.md
+++ b/packages/website/docs/01-try-it-out/02-local-demo/02-loading-data.md
@@ -58,6 +58,7 @@ function apollo() {
     --add-host host.docker.internal=host-gateway \
     --volume ./cli:/root/.config/apollo-cli \
     --volume ./data:/data \
+    --workdir / \
     ghcr.io/gmod/apollo-cli \
     "$@"
 }
@@ -76,7 +77,7 @@ one. Create a file called jbrowse.Dockerfile and paste the following contents
 into it:
 
 ```Dockerfile title="jbrowse.Dockerfile"
-FROM node:18-alpine
+FROM node:24-alpine
 RUN mkdir data && yarn global add @jbrowse/cli
 ENTRYPOINT ["jbrowse"]
 ```
@@ -97,6 +98,7 @@ function jbrowse() {
     --rm \
     --interactive \
     --volume ./data:/data \
+    --workdir / \
     jbrowse-cli \
     "$@"
 }

--- a/packages/website/docs/02-installation/02-examples/01-docker-compose.md
+++ b/packages/website/docs/02-installation/02-examples/01-docker-compose.md
@@ -60,7 +60,9 @@ name: my-apollo-site
 
 services:
   apollo-collaboration-server:
-    image: ghcr.io/gmod/apollo-collaboration-server
+    image:
+      ghcr.io/gmod/apollo-collaboration-server:${APOLLO_VERSION:?Please specify
+      APOLLO_VERSION}
     depends_on:
       mongo-node-1:
         condition: service_healthy
@@ -74,8 +76,8 @@ services:
   client:
     build:
       args:
-        JBROWSE_VERSION: 3.0.3
-        APOLLO_VERSION: 0.3.4
+        JBROWSE_VERSION: ${JBROWSE_VERSION:?Please specify JBROWSE_VERSION}
+        APOLLO_VERSION: ${APOLLO_VERSION:?Please specify APOLLO_VERSION}
       context: .
     depends_on:
       - apollo-collaboration-server
@@ -393,7 +395,7 @@ We're now ready to start Apollo. Inside your `~/apollo/` directory, run this
 command:
 
 ```sh
-docker compose up
+APOLLO_VERSION=1.0.0 JBROWSE_VERSION=4.3.0 docker compose up
 ```
 
 You should see logs start to print to the screen as the various pieces start up.
@@ -402,7 +404,7 @@ Once you've confirmed that everything starts without errors, go ahead and press
 similar to the one run before:
 
 ```sh
-docker compose up -d
+APOLLO_VERSION=1.0.0 JBROWSE_VERSION=4.3.0 docker compose up -d
 ```
 
 The `-d` instructs Docker to run in detached mode, so instead of seeing logs

--- a/scripts/makeGitTag.ts
+++ b/scripts/makeGitTag.ts
@@ -87,7 +87,7 @@ exec('git', ['add', '--force', 'packages/**/package.json'])
 exec('sed', [
   '--in-place',
   '--regexp-extended',
-  String.raw`"s/APOLLO_VERSION=[0-9]+\.[0-9]+\.[0-9]+/APOLLO_VERSION=${newVersion}/"`,
+  String.raw`s/APOLLO_VERSION=[0-9]+\.[0-9]+\.[0-9]+/APOLLO_VERSION=${newVersion}/`,
   'packages/website/docs/02-installation/02-examples/01-docker-compose.md',
 ])
 exec('git', [

--- a/scripts/makeGitTag.ts
+++ b/scripts/makeGitTag.ts
@@ -84,6 +84,16 @@ exec('yarn', [
   strategy,
 ])
 exec('git', ['add', '--force', 'packages/**/package.json'])
+exec('sed', [
+  '--in-place',
+  '--regexp-extended',
+  String.raw`"s/APOLLO_VERSION=[0-9]+\.[0-9]+\.[0-9]+/APOLLO_VERSION=${newVersion}/"`,
+  'packages/website/docs/02-installation/02-examples/01-docker-compose.md',
+])
+exec('git', [
+  'add',
+  'packages/website/docs/02-installation/02-examples/01-docker-compose.md',
+])
 exec('git', ['commit', '--message', m])
 exec('git', ['tag', '--annotate', `v${newVersion}`, '--message', m])
 exec('git', ['push', '--follow-tags'])


### PR DESCRIPTION
Makes sure the Apollo and JBrowse versions specified in the docs for our various tutorials stay up to date.

Fixes #745 