### PR TITLE
Fix LGV block API usage after upstream rename to displayedRegionIndex

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/util.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/glyphs/util.ts
@@ -104,8 +104,16 @@ export function isMouseOnFeatureEdge(
   const { refName, regionNumber, x } = mousePosition
   const { lgv } = stateModel
   const { offsetPx } = lgv
-  const minPxInfo = lgv.bpToPx({ refName, coord: feature.min, regionNumber })
-  const maxPxInfo = lgv.bpToPx({ refName, coord: feature.max, regionNumber })
+  const minPxInfo = lgv.bpToPx({
+    refName,
+    coord: feature.min,
+    displayedRegionIndex: regionNumber,
+  })
+  const maxPxInfo = lgv.bpToPx({
+    refName,
+    coord: feature.max,
+    displayedRegionIndex: regionNumber,
+  })
   if (minPxInfo !== undefined && maxPxInfo !== undefined) {
     const minPx = minPxInfo.offsetPx - offsetPx
     const maxPx = maxPxInfo.offsetPx - offsetPx

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/rendering.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloDisplay/stateModel/rendering.ts
@@ -138,7 +138,7 @@ export function renderingModelFactory(
                     const locationStartPxInfo = self.lgv.bpToPx({
                       refName: refSeq,
                       coord: start,
-                      regionNumber: idx,
+                      displayedRegionIndex: idx,
                     })
                     if (!locationStartPxInfo) {
                       continue

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloReferenceSequenceDisplay/stateModel/base.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloReferenceSequenceDisplay/stateModel/base.ts
@@ -14,7 +14,6 @@ import {
 import { BaseDisplay } from '@jbrowse/core/pluggableElementTypes'
 import {
   type AbstractSessionModel,
-  type Region,
   getContainingView,
   getSession,
 } from '@jbrowse/core/util'
@@ -95,8 +94,9 @@ export function baseModelFactory(
     .views((self) => ({
       get expandedRegions() {
         const regions = self.lgv.dynamicBlocks.contentBlocks.map((block) => {
-          const { assemblyName, end, refName, start } = block
-          const { parentRegion } = block as unknown as { parentRegion: Region }
+          const { assemblyName, displayedRegionIndex, end, refName, start } =
+            block
+          const parentRegion = self.lgv.displayedRegions[displayedRegionIndex]
           const expandedStart = Math.round(
             Math.max(start - 5, parentRegion.start),
           )

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/components/LinearApolloSixFrameDisplay.tsx
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/components/LinearApolloSixFrameDisplay.tsx
@@ -186,7 +186,7 @@ export const LinearApolloSixFrameDisplay = observer(
                       (lgv.bpToPx({
                         refName: region.refName,
                         coord: checkResult.start,
-                        regionNumber: idx,
+                        displayedRegionIndex: idx,
                       })?.offsetPx ?? 0) - lgv.offsetPx
                     const [feature] = checkResult.featureIds
                     if (

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/glyphs/GeneGlyph.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/glyphs/GeneGlyph.ts
@@ -174,7 +174,7 @@ function draw(
     (lgv.bpToPx({
       refName,
       coord: min,
-      regionNumber: displayedRegionIndex,
+      displayedRegionIndex,
     })?.offsetPx ?? 0) - offsetPx
   const topLevelFeatureWidthPx = topLevelFeature.length / bpPerPx
   const topLevelFeatureStartPx = reversed
@@ -275,7 +275,7 @@ function draw(
         (lgv.bpToPx({
           refName,
           coord: exon.min,
-          regionNumber: displayedRegionIndex,
+          displayedRegionIndex,
         })?.offsetPx ?? 0) - offsetPx
       const widthPx = exon.length / bpPerPx
       const startPx = reversed ? minX - widthPx : minX
@@ -341,7 +341,7 @@ function draw(
             (lgv.bpToPx({
               refName,
               coord: cds.min,
-              regionNumber: displayedRegionIndex,
+              displayedRegionIndex,
             })?.offsetPx ?? 0) - offsetPx
           cdsStartPx = reversed ? minX - cdsWidthPx : minX
           ctx.fillStyle = theme.palette.text.primary
@@ -525,7 +525,7 @@ function drawOverlay(
         (lgv.bpToPx({
           refName,
           coord: cds.min,
-          regionNumber: layoutIndex,
+          displayedRegionIndex: layoutIndex,
         })?.offsetPx ?? 0) - offsetPx
       const cdsStartPx = reversed ? minX - cdsWidthPx : minX
       const frame = getFrame(cds.min, cds.max, strand ?? 1, cds.phase)
@@ -788,7 +788,7 @@ function drawTooltip(
     (lgv.bpToPx({
       refName,
       coord: reversed ? max : min,
-      regionNumber: layoutIndex,
+      displayedRegionIndex: layoutIndex,
     })?.offsetPx ?? 0) - offsetPx
   const frame = getFrame(min, max, strand ?? 1, phase)
   const frameOffsets = showFeatureLabels

--- a/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/stateModel/rendering.ts
+++ b/packages/jbrowse-plugin-apollo/src/LinearApolloSixFrameDisplay/stateModel/rendering.ts
@@ -151,7 +151,7 @@ export function renderingModelFactory(
                     const locationStartPxInfo = self.lgv.bpToPx({
                       refName: refSeq,
                       coord: start,
-                      regionNumber: idx,
+                      displayedRegionIndex: idx,
                     })
                     if (!locationStartPxInfo) {
                       continue

--- a/packages/jbrowse-plugin-apollo/src/util/glyphUtils.ts
+++ b/packages/jbrowse-plugin-apollo/src/util/glyphUtils.ts
@@ -236,12 +236,12 @@ export function getMinAndMaxPx(
   const minPxInfo = lgv.bpToPx({
     refName,
     coord: feature.min,
-    regionNumber,
+    displayedRegionIndex: regionNumber,
   })
   const maxPxInfo = lgv.bpToPx({
     refName,
     coord: feature.max,
-    regionNumber,
+    displayedRegionIndex: regionNumber,
   })
   if (minPxInfo === undefined || maxPxInfo === undefined) {
     return


### PR DESCRIPTION
This addresses some breaking changes from jbrowse-components. Upstream jbrowse-components webgl-poc refactor removed block.parentRegion and changed it to just store 'displayedRegionIndex'. This concept was then applied broadly across several APIs. Instead of storing parentRegion, users can manually lookup view.displayedRegions[displayedRegionIndex]. This was try to to simplify and optimize the block generation code: it was running getSnapshot frequently on the region objects, etc.

Sort of similarly, we renamed bpToPx's `regionNumber` attribute to `displayedRegionIndex`. 
We could potentially add backcompat for the bpToPx thing, but it may not be worth it to add backcompat for parentRegion.

If it is desirable to maintain compat with v4 and v5 of jbrowse though in apollo, we could add backcompat layer for 1 or both these issues and close this PR