### PR TITLE
Fix various sequence-related features not working

### DIFF
--- a/packages/jbrowse-plugin-apollo/cypress/e2e/editFeature.cy.ts
+++ b/packages/jbrowse-plugin-apollo/cypress/e2e/editFeature.cy.ts
@@ -175,22 +175,6 @@ describe('Different ways of editing features', () => {
     })
   })
 
-  it.skip('Can select region on rubber-band and zoom into it', () => {
-    const assemblyName = 'space.gff3'
-    cy.addAssemblyFromGff(assemblyName, `test_data/${assemblyName}`)
-    cy.selectAssemblyToView(assemblyName, 'ctgA:1..10000')
-    cy.get('[data-testid="rubberband_controls"]').trigger('mouseover')
-    cy.get('[data-testid="rubberband_controls"]').trigger('mousedown', 100, 5)
-    cy.get('[data-testid="rubberband_controls"]').trigger('mousemove', 200, 5)
-    cy.get('[data-testid="rubberband_controls"]').trigger('mouseup', 200, 5, {
-      force: true,
-    })
-    cy.intercept('POST', '/users/userLocation').as('done')
-    cy.contains('Zoom to region').click()
-    cy.wait('@done')
-    cy.currentLocationEquals('ctgA', 1021, 2041, 10)
-  })
-
   it.skip('Can drag and move position', () => {
     const assemblyName = 'space.gff3'
     cy.addAssemblyFromGff(assemblyName, `test_data/${assemblyName}`)

--- a/packages/jbrowse-plugin-apollo/cypress/e2e/rubberband.cy.ts
+++ b/packages/jbrowse-plugin-apollo/cypress/e2e/rubberband.cy.ts
@@ -1,0 +1,68 @@
+describe('Rubberband selection', () => {
+  before(() => {
+    cy.deleteAssemblies()
+    cy.wrap(
+      globalThis.indexedDB.databases().then((dbs) => {
+        for (const db of dbs) {
+          if (db.name) {
+            globalThis.indexedDB.deleteDatabase(db.name)
+          }
+        }
+      }),
+    )
+    cy.addOntologies()
+  })
+
+  beforeEach(() => {
+    cy.loginAsGuest()
+  })
+
+  afterEach(() => {
+    cy.deleteAssemblies()
+  })
+
+  it('Can get sequence via rubberband selection', () => {
+    const assemblyName = 'space.gff3'
+    cy.addAssemblyFromGff(assemblyName, `test_data/${assemblyName}`)
+    cy.selectAssemblyToView(assemblyName, 'ctgA:1..10000')
+
+    cy.get('[data-testid="rubberband_controls"]').trigger('mouseover')
+    cy.get('[data-testid="rubberband_controls"]').trigger('mousedown', 100, 5)
+    cy.get('[data-testid="rubberband_controls"]').trigger('mousemove', 120, 5)
+    cy.get('[data-testid="rubberband_controls"]').trigger('mouseup', 120, 5, {
+      force: true,
+    })
+    cy.contains('Get sequence').click()
+    cy.contains('tgtcacctcgggtactgcctctattacagaggtatcttaatggcgcatccag')
+  })
+
+  it.only('Can get sequence via rubberband selection', () => {
+    const assemblyName = 'space.gff3'
+    cy.addAssemblyFromGff(assemblyName, `test_data/${assemblyName}`)
+    cy.selectAssemblyToView(assemblyName, 'ctgA:1..10000')
+    cy.contains('Open track selector').click()
+    cy.contains('Annotations (').click()
+    cy.annotationTrackAppearance('Show both graphical and table display')
+
+    cy.get('[data-testid="rubberband_controls"]').trigger('mouseover')
+    cy.get('[data-testid="rubberband_controls"]').trigger('mousedown', 100, 5)
+    cy.get('[data-testid="rubberband_controls"]').trigger('mousemove', 120, 5)
+    cy.get('[data-testid="rubberband_controls"]').trigger('mouseup', 120, 5, {
+      force: true,
+    })
+    cy.contains('Add new feature').click()
+    cy.get('[data-testid="add-feature-dialog"]').should('be.visible')
+    cy.contains('Add feature with a sequence ontology type').click()
+    cy.get('[data-testid="add-feature-dialog"]')
+      .contains('Type')
+      .parent()
+      .within(() => {
+        cy.get('input').click({ timeout: 60_000 })
+      })
+    cy.contains('li', /^remark$/, { timeout: 60_000, matchCase: false }).click()
+    cy.get('button').contains('Submit').click()
+    cy.get('tbody', { timeout: 10_000 }).find(
+      'input[type="text"][value="remark"]',
+    )
+  })
+})

--- a/packages/jbrowse-plugin-apollo/src/index.ts
+++ b/packages/jbrowse-plugin-apollo/src/index.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable @typescript-eslint/no-misused-promises */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { changeRegistry, checkRegistry } from '@apollo-annotation/common'
@@ -78,8 +77,10 @@ import { addTopLevelMenus } from './menus'
 import { type ApolloSessionModel, extendSession } from './session'
 
 interface RpcHandle {
-  on(event: string, listener: (event: MessageEvent) => void): this
-  workers: Worker[]
+  client: {
+    on?(event: string, listener: (event: MessageEvent) => void): void
+  }
+  worker: Worker
 }
 
 interface ApolloMessageData {
@@ -356,10 +357,10 @@ export default class ApolloPlugin extends Plugin {
       pluginManager.addToExtensionPoint(
         'Core-extendWorker',
         (handle: RpcHandle) => {
-          if (!('on' in handle && handle.on)) {
+          if (!('on' in handle.client && handle.client.on)) {
             return handle
           }
-          handle.on('apollo', async (event: MessageEvent) => {
+          handle.client.on('apollo', async (event: MessageEvent) => {
             if (!isApolloMessageData(event)) {
               return
             }
@@ -382,7 +383,7 @@ export default class ApolloPlugin extends Plugin {
                 }
                 const { seq: sequence } =
                   await backendDriver.getSequence(region)
-                handle.workers[0].postMessage({
+                handle.worker.postMessage({
                   apollo,
                   messageId,
                   sequence,
@@ -404,7 +405,7 @@ export default class ApolloPlugin extends Plugin {
                   break
                 }
                 const regions = await backendDriver.getRegions(assembly)
-                handle.workers[0].postMessage({
+                handle.worker.postMessage({
                   apollo,
                   messageId,
                   regions,
@@ -427,7 +428,7 @@ export default class ApolloPlugin extends Plugin {
                 }
                 const refNameAliases =
                   await backendDriver.getRefNameAliases(assembly)
-                handle.workers[0].postMessage({
+                handle.worker.postMessage({
                   apollo,
                   messageId,
                   refNameAliases,


### PR DESCRIPTION
The standard reference sequence display, the "Get sequence" rubberband dialog, and the "Sequence search" dialog all weren't working. At some point the handle passed to JBrowse's `Core-extendWorker` extension point changed, which broke all those things. This fixes it and adds a test for the "Get sequence" rubberband dialog to catch it in the future.

Thanks to @shashankbrgowda for reporting.