### PR TITLE
Fix "Create Apollo annotation" when selecting parent gene

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/components/CreateApolloAnnotation.tsx
+++ b/packages/jbrowse-plugin-apollo/src/components/CreateApolloAnnotation.tsx
@@ -190,7 +190,10 @@ export function CreateApolloAnnotation({
     assembly.name,
   )
   const refSeq = apolloAssembly?.refSeqs.get(refSeqId)
-  const features = refSeq?.getFeatures(region.start, region.end)
+  const features = useMemo(
+    () => refSeq?.getFeatures(region.start, region.end),
+    [refSeq, region.start, region.end],
+  )
 
   useEffect(() => {
     const getDestinationFeatures = () => {


### PR DESCRIPTION
Fixes #813

`useEffect` loop was preventing the gene selector in the dialog from rendering properly.