### PR TITLE
Fix end location detection of transcript "trim" button (v2)

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/Translation.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/Translation.tsx
@@ -157,7 +157,15 @@ export function Translation({
 
     // Trim any sequence before first start codon and after stop codon
     const startCodonIndex = proteinSequence.indexOf('M')
+    if (startCodonIndex === -1) {
+      notify('Start codon not found', 'error')
+      return
+    }
     const stopCodonIndex = proteinSequence.indexOf('*', startCodonIndex)
+    if (stopCodonIndex === -1) {
+      notify('Stop codon not found', 'error')
+      return
+    }
 
     const startCodonPos = startCodonIndex * 3
     const stopCodonPos = stopCodonIndex * 3

--- a/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/Translation.tsx
+++ b/packages/jbrowse-plugin-apollo/src/FeatureDetailsWidget/Translation.tsx
@@ -157,7 +157,7 @@ export function Translation({
 
     // Trim any sequence before first start codon and after stop codon
     const startCodonIndex = proteinSequence.indexOf('M')
-    const stopCodonIndex = proteinSequence.lastIndexOf('*')
+    const stopCodonIndex = proteinSequence.indexOf('*', startCodonIndex)
 
     const startCodonPos = startCodonIndex * 3
     const stopCodonPos = stopCodonIndex * 3


### PR DESCRIPTION
I ran into a problem where the "trim" button didn't work if there was a stop codon before the start codon in the CDS. I tried to fix it in #810, but that solution was not correct.

Now I'm fixing it by only looking for stop codons that come after a start codon.