### PR TITLE
Stream result of getFeatures from server

### DIFF
--- a/packages/apollo-collaboration-server/src/checks/checks.service.ts
+++ b/packages/apollo-collaboration-server/src/checks/checks.service.ts
@@ -163,14 +163,27 @@ export class ChecksService {
    * @returns an array of checkResult-documents
    */
   async findByRange(searchDto: FeatureRangeSearchDto) {
-    return this.checkResultModel
-      .find({
-        refSeq: searchDto.refSeq,
-        start: { $lte: searchDto.end },
-        end: { $gte: searchDto.start },
-        status: 0,
-      })
-      .exec()
+    return this.checkResultModel.find(this.byRangeQuery(searchDto)).exec()
+  }
+
+  /**
+   * Get all possible checkResults for given range (refSeq, start, end) as a
+   * cursor, so callers can stream results instead of loading them all into
+   * memory at once.
+   * @param searchDto - range
+   * @returns a cursor over matching checkResult-documents
+   */
+  findByRangeCursor(searchDto: FeatureRangeSearchDto) {
+    return this.checkResultModel.find(this.byRangeQuery(searchDto)).cursor()
+  }
+
+  private byRangeQuery(searchDto: FeatureRangeSearchDto) {
+    return {
+      refSeq: searchDto.refSeq,
+      start: { $lte: searchDto.end },
+      end: { $gte: searchDto.start },
+      status: 0,
+    }
   }
 
   update(id: string, updatedCheckReport: CheckDocument) {

--- a/packages/apollo-collaboration-server/src/features/features.controller.ts
+++ b/packages/apollo-collaboration-server/src/features/features.controller.ts
@@ -7,7 +7,10 @@ import {
   ParseBoolPipe,
   Post,
   Query,
+  Response,
+  StreamableFile,
 } from '@nestjs/common'
+import type { Response as ExpressResponse } from 'express'
 
 import type {
   FeatureIdsSearchDto,
@@ -45,12 +48,27 @@ export class FeaturesController {
    * or if search data was not found or in case of error throw exception
    */
   @Get('getFeatures')
-  getFeaturesByRange(@Query() request: FeatureRangeSearchDto) {
+  getFeaturesByRange(
+    @Query() request: FeatureRangeSearchDto,
+    @Response({ passthrough: true }) res: ExpressResponse,
+  ) {
     this.logger.debug(
       `getFeatures endpoint: refSeq: ${request.refSeq}, start: ${request.start}, end: ${request.end}`,
     )
 
-    return this.featuresService.findByRange(request)
+    const stream = this.featuresService.findByRangeStream(request)
+    res.set({ 'Content-Type': 'application/json' })
+    return new StreamableFile(stream).setErrorHandler((error, response) => {
+      if (response.destroyed) {
+        return
+      }
+      if (response.headersSent) {
+        response.end()
+        return
+      }
+      response.statusCode = 400
+      response.send(error.message)
+    })
   }
 
   @Post('getByIds')

--- a/packages/apollo-collaboration-server/src/features/features.service.ts
+++ b/packages/apollo-collaboration-server/src/features/features.service.ts
@@ -1,4 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
+import { Readable } from 'node:stream'
+import { ReadableStream } from 'node:stream/web'
+
 import {
   Feature,
   type FeatureDocument,
@@ -8,6 +11,7 @@ import {
 import { Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { InjectModel } from '@nestjs/mongoose'
 import { Model } from 'mongoose'
+import StreamConcat from 'stream-concat'
 
 import { ChecksService } from '../checks/checks.service.js'
 import type { FeatureRangeSearchDto } from '../entity/gff3Object.dto.js'
@@ -16,6 +20,7 @@ import type {
   FeatureCountRequest,
   GetByIndexedIdRequest,
 } from './dto/feature.dto.js'
+import { CheckFeatureStream, DocToJSONArrayStream } from './transforms.js'
 
 @Injectable()
 export class FeaturesService {
@@ -223,18 +228,69 @@ export class FeaturesService {
 
   async findByRange(searchDto: FeatureRangeSearchDto) {
     const featureDocs = await this.featureModel
-      .find({
-        refSeq: searchDto.refSeq,
-        min: { $lte: searchDto.end },
-        max: { $gte: searchDto.start },
-        status: 0,
-      })
+      .find(this.byRangeQuery(searchDto))
       .exec()
     for (const featureDoc of featureDocs) {
       await this.checksService.checkFeature(featureDoc)
     }
     const checkResults = await this.checksService.findByRange(searchDto)
     return [featureDocs, checkResults]
+  }
+
+  /**
+   * Same as findByRange, but streams the response instead of resolving the
+   * full feature and checkResult arrays in memory first.
+   * @param searchDto - range
+   * @returns a stream of the JSON body `[[...features],[...checkResults]]`
+   */
+  findByRangeStream(searchDto: FeatureRangeSearchDto): Readable {
+    const featuresStream = Readable.toWeb(
+      this.featureModel.find(this.byRangeQuery(searchDto)).cursor(),
+    )
+      .pipeThrough(new CheckFeatureStream(this.checksService))
+      .pipeThrough(new DocToJSONArrayStream())
+
+    const checkResultsStream = Readable.toWeb(
+      this.checksService.findByRangeCursor(searchDto),
+    ).pipeThrough(new DocToJSONArrayStream())
+
+    const openBracket = new ReadableStream<string>({
+      start(controller) {
+        controller.enqueue('[')
+        controller.close()
+      },
+    })
+    const comma = new ReadableStream<string>({
+      start(controller) {
+        controller.enqueue(',')
+        controller.close()
+      },
+    })
+    const closeBracket = new ReadableStream<string>({
+      start(controller) {
+        controller.enqueue(']')
+        controller.close()
+      },
+    })
+
+    return new StreamConcat(
+      [
+        openBracket,
+        featuresStream,
+        comma,
+        checkResultsStream,
+        closeBracket,
+      ].map((stream) => Readable.fromWeb(stream)),
+    )
+  }
+
+  private byRangeQuery(searchDto: FeatureRangeSearchDto) {
+    return {
+      refSeq: searchDto.refSeq,
+      min: { $lte: searchDto.end },
+      max: { $gte: searchDto.start },
+      status: 0,
+    }
   }
 
   async checkFeature(featureId: string, checkTimestamps = true) {

--- a/packages/apollo-collaboration-server/src/features/transforms.ts
+++ b/packages/apollo-collaboration-server/src/features/transforms.ts
@@ -1,0 +1,43 @@
+import { TransformStream } from 'node:stream/web'
+
+import type { FeatureDocument } from '@apollo-annotation/schemas'
+
+import type { ChecksService } from '../checks/checks.service.js'
+
+export class CheckFeatureStream extends TransformStream<
+  FeatureDocument,
+  FeatureDocument
+> {
+  constructor(checksService: ChecksService) {
+    super({
+      async transform(chunk, controller) {
+        try {
+          await checksService.checkFeature(chunk)
+          controller.enqueue(chunk)
+        } catch (error) {
+          controller.error(
+            error instanceof Error ? error : new Error(String(error)),
+          )
+        }
+      },
+    })
+  }
+}
+
+export class DocToJSONArrayStream<T> extends TransformStream<T, string> {
+  constructor() {
+    let isFirst = true
+    super({
+      start(controller) {
+        controller.enqueue('[')
+      },
+      transform(chunk, controller) {
+        controller.enqueue((isFirst ? '' : ',') + JSON.stringify(chunk))
+        isFirst = false
+      },
+      flush(controller) {
+        controller.enqueue(']')
+      },
+    })
+  }
+}


### PR DESCRIPTION
There have been reports of `getFeatures` requests taking a lot of memory on the server. This helps reduce it by streaming the results as they become available from the database instead of collecting them all in an object before returning them.