### PR TITLE
fix(sequence): reject worker sequence timeout with a real Error

### DIFF
--- a/packages/jbrowse-plugin-apollo/src/ApolloSequenceAdapter/ApolloSequenceAdapter.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloSequenceAdapter/ApolloSequenceAdapter.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/prefer-promise-reject-errors */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
@@ -72,10 +71,10 @@ export class ApolloSequenceAdapter extends BaseSequenceAdapter {
     const regions = await new Promise(
       (
         resolve: (sequence: Region[]) => void,
-        reject: (reason: string) => void,
+        reject: (reason: Error) => void,
       ) => {
         const timeoutId = setTimeout(() => {
-          reject('timeout')
+          reject(new Error(`getRegions timed out for assembly "${assemblyId}"`))
         }, 20_000)
         const messageId = nanoid()
         const messageListener = (event: MessageEvent) => {
@@ -155,10 +154,12 @@ export class ApolloSequenceAdapter extends BaseSequenceAdapter {
       const seq = await new Promise(
         (
           resolve: (sequence: string) => void,
-          reject: (reason: string) => void,
+          reject: (reason: Error) => void,
         ) => {
           const timeoutId = setTimeout(() => {
-            reject('timeout')
+            reject(
+              new Error(`getSequence timed out for ${refName}:${start}-${end}`),
+            )
           }, 20_000)
           const messageId = nanoid()
           const messageListener = (event: MessageEvent) => {


### PR DESCRIPTION
## Problem

Under JBrowse's default `WebWorkerRpcDriver`, a slow Apollo reference-sequence fetch surfaces as `NonError: Non-error value: timeout`, with no indication of what actually happened. Reported at GMOD/jbrowse-components#5604.

`ApolloSequenceAdapter`'s web-worker path bridges sequence requests to the main thread with a 20s timeout, and on expiry rejected with the **bare string** `'timeout'` — which `serializeError` reports as a non-Error value, hiding both the operation and the cause.

## Change

Reject with a descriptive `Error` naming the operation and region (e.g. `getSequence timed out for chr1:1-2000000`) instead of the string `'timeout'`. One file, +6/-5.

## Not addressed here (deliberately)

This only makes the error honest — it does **not** speed anything up. The underlying issue in GMOD/jbrowse-components#5604 is that reference-sequence fetches take **>20s**, tripping the worker's timeout (the main-thread RPC path has no such cap, which is why `MainThreadRpcDriver` is a workaround). That latency is the real problem and is architectural — reference sequence served from the database rather than indexed flat-file byte-range reads — and belongs in its own discussion, not this patch.