### PR TITLE
Fix import when CDS lines aren't together in file

### DIFF
--- a/packages/apollo-shared/src/GFF3/gff3ToAnnotationFeature.test.ts
+++ b/packages/apollo-shared/src/GFF3/gff3ToAnnotationFeature.test.ts
@@ -137,6 +137,12 @@ describe('gff3ToAnnotationFeature examples', () => {
     assert.equal(txt.match(/intron/g), null)
     assert.equal(txt.match(/_codon/g), null)
   })
+  it('Convert noncontiguous CDS lines', () => {
+    const [gffFeature] = readFeatureFile('test_data/mixed_order.gff3')
+    const actual = gff3ToAnnotationFeature(gffFeature)
+    const expected = readAnnotationFeatureSnapshot('test_data/mixed_order.json')
+    compareFeatures(actual, expected)
+  })
 })
 
 describe('CDS without exons', () => {

--- a/packages/apollo-shared/src/GFF3/gff3ToAnnotationFeature.ts
+++ b/packages/apollo-shared/src/GFF3/gff3ToAnnotationFeature.ts
@@ -171,7 +171,12 @@ function convertChildren(
   const cdsFeatures: GFF3Feature[] = []
   const exonFeatures: GFF3Feature[] = []
   const utrFeatures: GFF3Feature[] = []
+  const seenChildFeatures = new Set<GFF3Feature>()
   for (const childFeature of childFeatures) {
+    if (seenChildFeatures.has(childFeature)) {
+      continue
+    }
+    seenChildFeatures.add(childFeature)
     const [firstChildFeatureLocation] = childFeature
     if (firstChildFeatureLocation.type === 'exon') {
       exonFeatures.push(childFeature)

--- a/packages/apollo-shared/test_data/mixed_order.gff3
+++ b/packages/apollo-shared/test_data/mixed_order.gff3
@@ -1,0 +1,13 @@
+OVOC_OM2	WormBase	CDS	23840223	23840282	.	-	0	ID=CDS:OVOC7322;Parent=Transcript:OVOC7322.1;Name=OVOC7322;prediction_status=Predicted;wormpep=OVP06434
+OVOC_OM2	WormBase	exon	23840223	23840282	.	-	.	Parent=Transcript:OVOC7322.1
+OVOC_OM2	WormBase	gene	23840223	23842130	.	-	.	ID=Gene:WBGene00244131;Name=WBGene00244131;sequence_name=OVOC7322;biotype=protein_coding;so_term_name=protein_coding_gene;curie=WB:WBGene00244131;Alias=OVOC7322
+OVOC_OM2	WormBase	mRNA	23840223	23842130	.	-	.	ID=Transcript:OVOC7322.1;Parent=Gene:WBGene00244131;Name=OVOC7322.1;wormpep=OVP06434
+OVOC_OM2	WormBase	intron	23840283	23840606	.	-	.	Parent=Transcript:OVOC7322.1
+OVOC_OM2	WormBase	CDS	23840607	23840698	.	-	2	ID=CDS:OVOC7322;Parent=Transcript:OVOC7322.1;Name=OVOC7322;prediction_status=Predicted;wormpep=OVP06434
+OVOC_OM2	WormBase	exon	23840607	23840698	.	-	.	Parent=Transcript:OVOC7322.1
+OVOC_OM2	WormBase	intron	23840699	23840940	.	-	.	Parent=Transcript:OVOC7322.1
+OVOC_OM2	WormBase	CDS	23840941	23841057	.	-	2	ID=CDS:OVOC7322;Parent=Transcript:OVOC7322.1;Name=OVOC7322;prediction_status=Predicted;wormpep=OVP06434
+OVOC_OM2	WormBase	exon	23840941	23841057	.	-	.	Parent=Transcript:OVOC7322.1
+OVOC_OM2	WormBase	intron	23841058	23842123	.	-	.	Parent=Transcript:OVOC7322.1
+OVOC_OM2	WormBase	CDS	23842124	23842130	.	-	0	ID=CDS:OVOC7322;Parent=Transcript:OVOC7322.1;Name=OVOC7322;prediction_status=Predicted;wormpep=OVP06434
+OVOC_OM2	WormBase	exon	23842124	23842130	.	-	.	Parent=Transcript:OVOC7322.1

--- a/packages/apollo-shared/test_data/mixed_order.json
+++ b/packages/apollo-shared/test_data/mixed_order.json
@@ -1,0 +1,87 @@
+{
+  "_id": "6a9b52bb29ee0a50a460744a",
+  "refSeq": "OVOC_OM2",
+  "type": "gene",
+  "min": 23840222,
+  "max": 23842130,
+  "strand": -1,
+  "children": {
+    "6a9b52bb29ee0a50a4607449": {
+      "_id": "6a9b52bb29ee0a50a4607449",
+      "refSeq": "OVOC_OM2",
+      "type": "mRNA",
+      "min": 23840222,
+      "max": 23842130,
+      "strand": -1,
+      "children": {
+        "6a9b52bb29ee0a50a4607443": {
+          "_id": "6a9b52bb29ee0a50a4607443",
+          "refSeq": "OVOC_OM2",
+          "type": "exon",
+          "min": 23840222,
+          "max": 23840282,
+          "strand": -1,
+          "attributes": { "gff_source": ["WormBase"] }
+        },
+        "6a9b52bb29ee0a50a4607444": {
+          "_id": "6a9b52bb29ee0a50a4607444",
+          "refSeq": "OVOC_OM2",
+          "type": "exon",
+          "min": 23840606,
+          "max": 23840698,
+          "strand": -1,
+          "attributes": { "gff_source": ["WormBase"] }
+        },
+        "6a9b52bb29ee0a50a4607445": {
+          "_id": "6a9b52bb29ee0a50a4607445",
+          "refSeq": "OVOC_OM2",
+          "type": "exon",
+          "min": 23840940,
+          "max": 23841057,
+          "strand": -1,
+          "attributes": { "gff_source": ["WormBase"] }
+        },
+        "6a9b52bb29ee0a50a4607446": {
+          "_id": "6a9b52bb29ee0a50a4607446",
+          "refSeq": "OVOC_OM2",
+          "type": "exon",
+          "min": 23842123,
+          "max": 23842130,
+          "strand": -1,
+          "attributes": { "gff_source": ["WormBase"] }
+        },
+        "6a9b52bb29ee0a50a4607447": {
+          "_id": "6a9b52bb29ee0a50a4607447",
+          "refSeq": "OVOC_OM2",
+          "type": "CDS",
+          "min": 23840222,
+          "max": 23842130,
+          "strand": -1,
+          "attributes": {
+            "gff_source": ["WormBase"],
+            "gff_id": ["CDS:OVOC7322"],
+            "gff_name": ["OVOC7322"],
+            "prediction_status": ["Predicted"],
+            "wormpep": ["OVP06434"]
+          }
+        }
+      },
+      "attributes": {
+        "gff_source": ["WormBase"],
+        "gff_id": ["Transcript:OVOC7322.1"],
+        "gff_name": ["OVOC7322.1"],
+        "wormpep": ["OVP06434"]
+      }
+    }
+  },
+  "attributes": {
+    "gff_source": ["WormBase"],
+    "gff_id": ["Gene:WBGene00244131"],
+    "gff_name": ["WBGene00244131"],
+    "sequence_name": ["OVOC7322"],
+    "biotype": ["protein_coding"],
+    "so_term_name": ["protein_coding_gene"],
+    "curie": ["WB:WBGene00244131"],
+    "gff_alias": ["OVOC7322"]
+  }
+}


### PR DESCRIPTION
I ran across a GFF3 that had the CDS lines not next to each other, which isn't common but is valid. Our parser added and extra CDS entry in these cases, so this fixes that and adds a regression test.