### PR TITLE
Fix display of auth type selection in CLI

### DIFF
--- a/packages/apollo-cli/README.md
+++ b/packages/apollo-cli/README.md
@@ -16,7 +16,7 @@ $ npm install -g @apollo-annotation/cli
 $ apollo COMMAND
 running command...
 $ apollo (--version)
-@apollo-annotation/cli/1.1.1 linux-x64 node-v24.14.1
+@apollo-annotation/cli/1.1.1 linux-x64 node-v24.19.0
 $ apollo --help [COMMAND]
 USAGE
   $ apollo COMMAND

--- a/packages/apollo-cli/src/commands/config.ts
+++ b/packages/apollo-cli/src/commands/config.ts
@@ -129,16 +129,11 @@ export default class ApolloConfig extends BaseCommand<typeof ApolloConfig> {
   private async askProfileName(currentProfiles: string[]): Promise<string> {
     const newProfile = '<New profile>'
     currentProfiles.push(newProfile)
-    const xchoices = []
-    for (const profileName of currentProfiles) {
-      xchoices.push({ name: profileName, value: profileName })
-    }
+    const choices = currentProfiles.map((p) => ({ name: p, value: p }))
+    const message = 'Select profile to edit or create a new one:'
     let answer = newProfile
     if (currentProfiles.length > 1) {
-      answer = await select({
-        message: 'Select profile to edit or create a new one:',
-        choices: xchoices,
-      })
+      answer = await select({ message, choices })
     }
     if (answer === newProfile) {
       answer = await input({
@@ -188,19 +183,18 @@ export default class ApolloConfig extends BaseCommand<typeof ApolloConfig> {
   }
 
   private async selectAccessType(address: string): Promise<string> {
-    const xchoices = [{ name: 'root', value: 'root' }]
-    const types: string[] = await this.getLoginTypes(address)
+    const choices = [{ name: 'root', value: 'root' }]
+    const types = await this.getLoginTypes(address)
     for (const type of types) {
-      xchoices.push({ name: type, value: type })
+      choices.push({ name: type.name, value: type.name })
     }
-    const answer = await select({
-      message: 'Select login type',
-      choices: xchoices,
-    })
+    const answer = await select({ message: 'Select login type', choices })
     return answer
   }
 
-  private async getLoginTypes(address: string): Promise<string[]> {
+  private async getLoginTypes(
+    address: string,
+  ): Promise<{ name: string; needsPopup: boolean; message: string }[]> {
     const response = await fetch(localhostToAddress(`${address}/auth/types`))
     if (!response.ok) {
       const errorMessage = await createFetchErrorMessage(

--- a/packages/apollo-cli/src/test/test.ts
+++ b/packages/apollo-cli/src/test/test.ts
@@ -113,6 +113,107 @@ void describe('Test CLI', () => {
     assert.strictEqual('', p.stdout.trim())
   })
 
+  void globalThis.itName(
+    'Interactive login type select shows names, not raw objects',
+    async () => {
+      // Regression test: /auth/types returns an array of
+      // {name, needsPopup, message} objects, but selectAccessType() in
+      // config.ts used to push those objects directly as a choice's `name`,
+      // so the interactive select rendered "[object Object]" instead of the
+      // login type name.
+      const serverScript = 'test_data/tmp_auth_types_server.mjs'
+      fs.writeFileSync(
+        serverScript,
+        `
+import http from 'node:http'
+const server = http.createServer((req, res) => {
+  if (req.url === '/auth/types') {
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify([{ name: 'guest', needsPopup: false, message: 'Continue as Guest' }]))
+    return
+  }
+  res.writeHead(404)
+  res.end()
+})
+server.listen(0, () => {
+  console.log(server.address().port)
+})
+`,
+      )
+      const authServer = spawnChildProcess('node', [serverScript])
+      const authPort: string = await new Promise((resolve) => {
+        authServer.stdout.once('data', (data: Buffer) => {
+          resolve(data.toString().trim())
+        })
+      })
+
+      const child = spawnChildProcess(`${apollo} config ${P}`, {
+        shell: '/bin/bash',
+      })
+      let stdout = ''
+      let stderr = ''
+      child.stdout.on('data', (data: Buffer) => {
+        stdout += data.toString()
+      })
+      child.stderr.on('data', (data: Buffer) => {
+        stderr += data.toString()
+      })
+
+      const waitFor = (pattern: string, timeoutMs = 15_000) =>
+        new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(() => {
+            clearInterval(interval)
+            reject(
+              new Error(
+                `Timed out waiting for "${pattern}". Stdout so far:\n${stdout}\nStderr so far:\n${stderr}`,
+              ),
+            )
+          }, timeoutMs)
+          const interval = setInterval(() => {
+            if (stdout.includes(pattern)) {
+              clearInterval(interval)
+              clearTimeout(timer)
+              resolve()
+            }
+          }, 50)
+        })
+
+      try {
+        await waitFor('Server address and port')
+        child.stdin.write(`http://localhost:${authPort}\r`)
+
+        await waitFor('Select login type')
+        // Move the selection down from the default "root" choice onto the
+        // mock server's "guest" login type, then confirm it.
+        child.stdin.write('\u001B[B')
+        await new Promise((resolve) => setTimeout(resolve, 500))
+        child.stdin.write('\r')
+
+        const exitCode: number | null = await new Promise((resolve) => {
+          child.on('exit', resolve)
+        })
+
+        assert.strictEqual(
+          exitCode,
+          0,
+          `Expected "apollo config" to exit cleanly. Stdout:\n${stdout}\nStderr:\n${stderr}`,
+        )
+        assert.ok(
+          !stdout.includes('[object Object]'),
+          `Select choices rendered a raw object instead of its name:\n${stdout}`,
+        )
+        assert.ok(stdout.includes('guest'))
+      } finally {
+        child.kill()
+        authServer.kill()
+        fs.unlinkSync(serverScript)
+      }
+
+      const p = new Shell(`${apollo} config ${P} accessType`)
+      assert.strictEqual(p.stdout.trim(), 'guest')
+    },
+  )
+
   void globalThis.itName('Apollo status', () => {
     let p = new Shell(`${apollo} status ${P}`)
     assert.strictEqual(p.stdout.trim(), 'testAdmin: Logged in')


### PR DESCRIPTION
The `apollo config` prompt to select an auth type was broken after #758. This fixes it and adds a test to make sure the interactive prompting works.